### PR TITLE
Extend Covid tracing demo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,7 @@ name = "covid_tracing"
 version = "0.1.0"
 dependencies = [
  "hydroflow",
+ "rand",
  "time",
 ]
 

--- a/covid_tracing/Cargo.toml
+++ b/covid_tracing/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 hydroflow = { path = "../hydroflow" }
 time = "0.3"
+rand = "0.8.4"

--- a/covid_tracing/src/people.rs
+++ b/covid_tracing/src/people.rs
@@ -1,0 +1,404 @@
+pub fn get_people() -> Vec<(&'static str, (&'static str, &'static str))> {
+    vec![
+        (
+            "fea3ca46-1ed1-4f13-8880-f95f5d00faf6",
+            ("Rodi Bullant", "149-597-9574"),
+        ),
+        (
+            "d651dcb4-8dbb-42d8-aed0-4337625f04c4",
+            ("Ronald Nodes", "675-922-4944"),
+        ),
+        (
+            "3e117920-b34b-476e-b87c-13334cbdf301",
+            ("Ban Mathon", "216-824-3797"),
+        ),
+        (
+            "9ecee93f-f712-4563-b77c-193bbbb05c1e",
+            ("Cosme Berceros", "577-354-6448"),
+        ),
+        (
+            "f4a783e9-eb4f-499b-a9bc-5326f74137f8",
+            ("Marney Yakubovich", "424-157-5147"),
+        ),
+        (
+            "38d77463-e4d6-40fd-b8f4-df3c21526d73",
+            ("Hayward Rees", "731-672-8082"),
+        ),
+        (
+            "3a5202ef-3d63-4246-b3bc-13fdef20d81b",
+            ("Perl Shimony", "186-955-7461"),
+        ),
+        (
+            "32fbed50-218c-4575-b85c-d4a28a40523f",
+            ("Gunilla Broz", "771-990-8049"),
+        ),
+        (
+            "35093f95-ffd0-483d-93ec-d0f3e0a53fd7",
+            ("Vivianna Beton", "414-197-4575"),
+        ),
+        (
+            "4819d38d-298d-4c37-905c-791c3e55043c",
+            ("Cathryn Breslauer", "814-155-2555"),
+        ),
+        (
+            "fee51463-02f8-4563-9458-922a73f0f356",
+            ("Bel Birmingham", "728-242-3872"),
+        ),
+        (
+            "7e632735-afed-4cc4-8052-24d4bd6b221b",
+            ("Wenonah Buckam", "368-557-2819"),
+        ),
+        (
+            "96260c3d-3184-46db-95ff-0643a029a8bf",
+            ("Sydney Kuzma", "622-799-8342"),
+        ),
+        (
+            "ed921fd4-c564-4394-b26e-e890cf5b099e",
+            ("Brigitte Symones", "130-986-3854"),
+        ),
+        (
+            "05da05d3-6ac7-4811-b9a8-75f48788688f",
+            ("Jeremie Chalfont", "174-234-4827"),
+        ),
+        (
+            "e27c7313-7428-4fe1-8ee0-64ba85207120",
+            ("Bernadina MacCarlich", "605-652-0586"),
+        ),
+        (
+            "179b61b2-a8f1-4584-8025-a1cbdfb9c1dd",
+            ("Roselle Pinnock", "495-464-7967"),
+        ),
+        (
+            "12fca00f-75ff-40e6-a0a2-13e7652ee430",
+            ("Beatriz Bartens", "448-852-5670"),
+        ),
+        (
+            "80a2b340-6b75-4e31-954f-b5c426b4ae2d",
+            ("Edee Hardes", "173-691-2283"),
+        ),
+        (
+            "5d6eccf9-1bb3-4d99-b5cf-2a6ad619c31b",
+            ("Panchito Sawbridge", "667-634-2095"),
+        ),
+        (
+            "3e68fcca-425a-4937-810f-b33df4f7c75c",
+            ("Orelee Battaille", "219-791-0530"),
+        ),
+        (
+            "f867cc56-c0cc-44ad-86b4-e414ff04f540",
+            ("Norry Seargeant", "647-342-9576"),
+        ),
+        (
+            "6c987f0e-8c78-4712-858d-79d3ed050b8b",
+            ("Melitta Rosenhaupt", "524-567-5314"),
+        ),
+        (
+            "f8cbe86a-c8a9-42ba-9725-27618eeefd1b",
+            ("Ariana Siggery", "137-434-2001"),
+        ),
+        (
+            "3b6cf7ba-0359-41b0-a808-34f98a7e643c",
+            ("Pieter Gladwish", "456-973-2475"),
+        ),
+        (
+            "16c387d8-b36b-4579-882a-092920de4ccb",
+            ("Andee Wynne", "162-495-0623"),
+        ),
+        (
+            "ac7a2a35-3897-4a5b-b751-4f1f93d2c0c5",
+            ("Moyna Stretton", "918-201-0719"),
+        ),
+        (
+            "26f9bdc1-221f-4a9b-a9df-f2e82a3c9a49",
+            ("Carrol Hallward", "589-716-3393"),
+        ),
+        (
+            "0ab48b93-2374-48ef-9d62-a4767e12380d",
+            ("Daisy Olyff", "331-552-7871"),
+        ),
+        (
+            "a3904464-c563-4167-802f-4ff2747b41ee",
+            ("Lottie Caws", "394-486-9093"),
+        ),
+        (
+            "ab4ba171-1c87-415e-8631-54d1adab369e",
+            ("Adrian Gisbourn", "826-908-7064"),
+        ),
+        (
+            "7f3c3baa-314f-4be4-b637-983fe8b6ae56",
+            ("Wolf Beckers", "451-407-4127"),
+        ),
+        (
+            "a7b0dd02-54ef-4d2f-99a4-44752b12c468",
+            ("Salomone Nieass", "129-357-6179"),
+        ),
+        (
+            "196c509a-b0ea-4443-8b0b-fc70458b8131",
+            ("Simonette Yarwood", "116-771-9575"),
+        ),
+        (
+            "71eef037-ef98-4b75-a42e-4b077d20041e",
+            ("Fielding Tapton", "529-705-3206"),
+        ),
+        (
+            "4d8136df-48d7-41dc-a2ae-928c7e9e35c6",
+            ("Kirsteni Wise", "590-858-8045"),
+        ),
+        (
+            "1b572f33-0f3f-467a-9126-3046518aaf07",
+            ("Farrell Layne", "381-707-1048"),
+        ),
+        (
+            "f63a6788-3ea6-4a0a-92dc-328da9c998e9",
+            ("Winny Cakebread", "772-363-8325"),
+        ),
+        (
+            "0fbe0df4-23a4-497c-82ff-72160b05aa23",
+            ("Yuma Feltoe", "424-674-1730"),
+        ),
+        (
+            "45f01d58-fab1-4e70-bdc7-7eb8fc874b9f",
+            ("Filippa Lenormand", "912-382-6359"),
+        ),
+        (
+            "2a9021b4-eadd-422a-899d-c178601b7c9e",
+            ("Allis Nicholson", "413-970-7710"),
+        ),
+        (
+            "0ec5315d-0604-4d38-b04e-83779cd96fff",
+            ("Blythe Roncelli", "786-120-2069"),
+        ),
+        (
+            "5175a9fa-f619-4c3b-a00b-175007b5a242",
+            ("Asia Yanuk", "274-711-1347"),
+        ),
+        (
+            "9395d32d-b23c-4eab-91c0-c02796061d22",
+            ("Florance Karpf", "651-275-6315"),
+        ),
+        (
+            "3e357d8a-dbc7-4ded-869f-ef70b6849ee3",
+            ("Jodie Tweed", "537-911-9645"),
+        ),
+        (
+            "5edbe8b8-3f1a-42cd-b58a-5c100d72fbc1",
+            ("Kara Brissard", "288-317-6718"),
+        ),
+        (
+            "244ee714-bea2-4022-9f55-761e29540627",
+            ("Duane Holtom", "883-796-0361"),
+        ),
+        (
+            "a4b43b40-10cd-42fc-8475-1e5ac80a0c65",
+            ("Free Bailey", "360-436-3647"),
+        ),
+        (
+            "93580a7b-da67-4775-8865-5435cd2d39a2",
+            ("Kristoffer Lovick", "386-946-5917"),
+        ),
+        (
+            "bbdbb94c-f3c9-4014-9f75-4d13eae92623",
+            ("Suzanna Lovick", "222-187-4109"),
+        ),
+        (
+            "aeb11c9f-d1d6-46ae-896d-727f35d47064",
+            ("Kelsey Wolsey", "906-193-0798"),
+        ),
+        (
+            "312a3f37-ee5f-456b-a929-23bd09d7d8b6",
+            ("Bernhard Verna", "315-831-1203"),
+        ),
+        (
+            "23d905c7-7d55-439e-acb7-076b09ee3cf3",
+            ("Daryl Fountain", "530-698-9806"),
+        ),
+        (
+            "6d75a6c3-f635-4a6a-907c-8f83cb9c8108",
+            ("Jess Farnon", "645-400-4365"),
+        ),
+        (
+            "d25e788a-ee0c-42c3-b29a-bd6b8d26fe3d",
+            ("Auguste Wooster", "248-289-7238"),
+        ),
+        (
+            "bde92ceb-d1ae-45a1-99b9-16b9bdf1e1fe",
+            ("Evered Lindores", "279-376-1264"),
+        ),
+        (
+            "e6bb81b8-feb7-40c4-a2f5-6d68abe6c5e5",
+            ("Klement Notti", "643-775-1032"),
+        ),
+        (
+            "5eb7ebfd-598e-4351-8194-fb28e08d1393",
+            ("Reynard Chasteau", "445-107-6387"),
+        ),
+        (
+            "da65d8d3-963d-466c-9c53-85611a9ba82f",
+            ("Mariya Streeter", "941-142-7640"),
+        ),
+        (
+            "6af7d9bd-34e9-435e-868a-a9f7fe9e1008",
+            ("Aida Drohan", "310-113-0876"),
+        ),
+        (
+            "12e41f26-921b-4b6f-83f9-8c7b66168801",
+            ("Bar Klain", "729-719-9739"),
+        ),
+        (
+            "d2b5321a-1a1c-4dab-a8df-bfb9fe53fb31",
+            ("Keely Stovell", "917-519-8723"),
+        ),
+        (
+            "2914da55-b468-401d-8259-b7f2e600ff7f",
+            ("Noble Scruton", "418-371-4117"),
+        ),
+        (
+            "19e7ef64-0017-42c2-9248-06b1aa97e9f6",
+            ("Cyndia Yell", "906-495-8478"),
+        ),
+        (
+            "2fcdcb92-a180-4304-acc6-5bbdb260dcaf",
+            ("Evangeline Lismer", "671-605-0021"),
+        ),
+        (
+            "0f50fbf0-b228-4de2-b2fe-bc7f64b295ab",
+            ("Selma Thomassin", "319-898-9797"),
+        ),
+        (
+            "1e50c5fd-947a-4cb6-809f-82848cded85c",
+            ("Ardeen Allicock", "872-259-7177"),
+        ),
+        (
+            "6a04a869-8d41-4871-8c65-8725791d8ce8",
+            ("Demetris MacAlaster", "951-921-7559"),
+        ),
+        (
+            "7296a714-244c-45de-b92d-1c740e08992e",
+            ("Stormi Primett", "917-740-6883"),
+        ),
+        (
+            "99d86f59-bed2-438a-8e4c-07fc058b93d9",
+            ("Beitris Chilley", "325-393-3236"),
+        ),
+        (
+            "cfc1b88b-f6f7-4bdb-8b37-5daf8c11b603",
+            ("Stu Baldetti", "777-729-0845"),
+        ),
+        (
+            "7f9f3bd1-853b-42a6-97a4-ca2dd846d6bf",
+            ("Melinda Comolli", "594-507-7448"),
+        ),
+        (
+            "7e32d4bc-f6a0-46d7-85d8-7134e7f7f7a7",
+            ("Geneva Culbert", "550-798-4155"),
+        ),
+        (
+            "66eb9111-1517-4c9f-a462-b7f33c626819",
+            ("Livvyy Edler", "826-107-7633"),
+        ),
+        (
+            "f65d0553-9f53-4512-8a90-451bd33879cb",
+            ("Nehemiah Fibbitts", "852-605-0858"),
+        ),
+        (
+            "d14d329c-6449-400d-99b3-034c79b3a0f8",
+            ("Adela Stare", "275-869-3393"),
+        ),
+        (
+            "e944487c-5076-4893-82fa-d89c20988cdd",
+            ("Leanna Wilbraham", "343-855-2454"),
+        ),
+        (
+            "3a981fbe-c432-4185-8843-7eb4dccb71fb",
+            ("Lorie Godsal", "914-432-9079"),
+        ),
+        (
+            "c49911c7-b9d0-449c-90bd-2512ccd8fd33",
+            ("Darlleen Whitlaw", "442-441-5807"),
+        ),
+        (
+            "7ff068f2-dfc2-4be0-bd9b-21105f2d03c7",
+            ("Tallie Creane", "119-340-0837"),
+        ),
+        (
+            "de2e6895-7962-4398-929f-2d1c84f35ba6",
+            ("Jules Perulli", "270-599-3494"),
+        ),
+        (
+            "42488e5c-d1f9-4f0a-ab1c-e6a56f3d020e",
+            ("Marnia Buret", "887-830-1757"),
+        ),
+        (
+            "d629b49d-c7bb-4b65-acbb-6c091f3a8ba4",
+            ("Fan Pottle", "995-672-1133"),
+        ),
+        (
+            "8297b20f-329f-45e7-81af-9bce3852419b",
+            ("Riley Rowlstone", "309-131-0137"),
+        ),
+        (
+            "b25ade19-101e-478b-b061-2ac115c59aa8",
+            ("Ricky Betun", "169-570-8846"),
+        ),
+        (
+            "342a00dd-af00-4f93-9606-f845dfc908e7",
+            ("Noell Spores", "251-773-8137"),
+        ),
+        (
+            "9d65c8bb-0d34-420c-91a7-faa97402f741",
+            ("Ira Lethlay", "668-470-2638"),
+        ),
+        (
+            "e0fbd6ee-c734-4cf5-a085-9cd6b0cef122",
+            ("Juditha Mowsley", "475-184-2995"),
+        ),
+        (
+            "aecb9ed5-0dd3-48bc-b460-43f24f9525cb",
+            ("Fayette Landes", "371-245-0180"),
+        ),
+        (
+            "ecb171a4-1b8f-49ff-a39b-6ac22752734e",
+            ("Alexis Winship", "312-655-4337"),
+        ),
+        (
+            "2b976930-2924-4fb9-975a-c1aad8b3610f",
+            ("Brice Clear", "140-896-9154"),
+        ),
+        (
+            "3e4da5b9-5333-40dc-bead-682a703d6b47",
+            ("Jeromy Hammel", "248-969-7509"),
+        ),
+        (
+            "a819b6a3-cf2c-4448-90ca-3d1a92f22669",
+            ("Torrey Greste", "395-905-3649"),
+        ),
+        (
+            "54e7d2fc-b483-43a4-a8aa-f0b9c42ddc2d",
+            ("Aili Carlet", "393-685-9855"),
+        ),
+        (
+            "b8d648a5-4bde-43fb-be72-d6a75be46b70",
+            ("Vivyanne McFall", "152-434-7479"),
+        ),
+        (
+            "ca665199-dfb7-420a-995c-f592492b8f78",
+            ("Adrian Gammett", "228-595-3116"),
+        ),
+        (
+            "4c6b93e4-5352-4d9c-8d11-21ebd4f39746",
+            ("Graeme Rosenshine", "183-561-8920"),
+        ),
+        (
+            "734b6e03-0392-4a72-8832-1c5cceb5e415",
+            ("Gustavo Greenhead", "576-522-1965"),
+        ),
+        (
+            "b70071fa-8d09-4e8f-8f94-d0aa93102708",
+            ("Cherise Fawlkes", "567-339-5082"),
+        ),
+        (
+            "43701be8-8412-42f0-ab1e-291c53238299",
+            ("Shanie Rannald", "966-648-9027"),
+        ),
+    ]
+}


### PR DESCRIPTION
This commit extends the Covid tracing demo to run in real-time. Includes a
bunch of randomly generated data to give it some texture.