### PR TITLE
Introduce an "Input" for ingressing data

### DIFF
--- a/hydroflow/src/scheduled/input.rs
+++ b/hydroflow/src/scheduled/input.rs
@@ -1,0 +1,31 @@
+use std::{cell::RefCell, rc::Rc};
+
+use super::{OpId, Reactor};
+
+pub struct Input<T> {
+    reactor: Reactor,
+    op_id: OpId,
+    data: Rc<RefCell<Vec<T>>>,
+}
+impl<T> Input<T> {
+    pub fn new(reactor: Reactor, op_id: OpId, data: Rc<RefCell<Vec<T>>>) -> Self {
+        Input {
+            reactor,
+            op_id,
+            data,
+        }
+    }
+
+    pub fn give(&self, t: T) {
+        (*self.data).borrow_mut().push(t);
+    }
+
+    pub fn flush(&self) {
+        self.reactor.trigger(self.op_id).unwrap(/* TODO(justin) */);
+    }
+
+    pub fn give_vec(&self, t: &mut Vec<T>) {
+        (*self.data).borrow_mut().extend(t.drain(..));
+        self.flush();
+    }
+}


### PR DESCRIPTION
This also does some minor optimization to make it less expensive to constantly
schedule the same operator. Only did a thread-local version for now, just to
try to get it working, I think it's easy to extend to a version that can be
cross-thread from here.