### PR TITLE
Replace concrete Subgraph types with FnMut()

### DIFF
--- a/hydroflow/src/scheduled/query.rs
+++ b/hydroflow/src/scheduled/query.rs
@@ -33,7 +33,7 @@ impl Query {
         let (inputs, output) = (*self.df).borrow_mut().add_n_in_m_out(
             ops.len(),
             1,
-            |ins: &mut [RecvCtx<VecHandoff<T>>], out| {
+            |ins: &[RecvCtx<VecHandoff<T>>], out| {
                 for input in ins {
                     out[0].give(Iter(input.take_inner().into_iter()));
                 }
@@ -146,11 +146,11 @@ impl<T: Clone> Operator<T> {
         let (inputs, outputs) = (*self.df).borrow_mut().add_n_in_m_out(
             1,
             n,
-            move |recvs: &mut [RecvCtx<VecHandoff<T>>], sends| {
+            move |recvs: &[RecvCtx<VecHandoff<T>>], sends| {
                 // TODO(justin): optimize this (extra clone, etc.).
                 #[allow(clippy::into_iter_on_ref)]
                 for v in recvs.into_iter().next().unwrap().take_inner() {
-                    for s in &mut *sends {
+                    for s in sends {
                         s.give(Some(v.clone()));
                     }
                 }

--- a/hydroflow/src/scheduled/subgraph.rs
+++ b/hydroflow/src/scheduled/subgraph.rs
@@ -1,6 +1,3 @@
-use crate::scheduled::ctx::{RecvCtx, SendCtx};
-use crate::scheduled::handoff::{Handoff, HandoffList};
-
 /**
  * Represents a compiled subgraph. Used internally by [Dataflow] to erase the input/output [Handoff] types.
  */
@@ -8,67 +5,11 @@ pub(crate) trait Subgraph {
     // TODO: pass in some scheduling info?
     fn run(&mut self);
 }
-/**
- * Closure-based [OpSubtree] implementation.
- */
-pub(crate) struct VariadicClosureSubgraph<F, R, W>
+impl<F> Subgraph for F
 where
-    F: FnMut(&R::RecvCtx, &W::SendCtx),
-    R: HandoffList,
-    W: HandoffList,
-{
-    f: F,
-    recv: R::RecvCtx,
-    send: W::SendCtx,
-}
-impl<F, R, W> VariadicClosureSubgraph<F, R, W>
-where
-    F: FnMut(&R::RecvCtx, &W::SendCtx),
-    R: HandoffList,
-    W: HandoffList,
-{
-    pub fn new(f: F, recv: R::RecvCtx, send: W::SendCtx) -> Self {
-        Self { f, recv, send }
-    }
-}
-impl<F, R, W> Subgraph for VariadicClosureSubgraph<F, R, W>
-where
-    F: FnMut(&R::RecvCtx, &W::SendCtx),
-    R: HandoffList,
-    W: HandoffList,
+    F: FnMut(),
 {
     fn run(&mut self) {
-        (self.f)(&mut self.recv, &mut self.send)
-    }
-}
-
-pub(crate) struct NtoMClosureSubgraph<F, R, W>
-where
-    F: FnMut(&mut [RecvCtx<R>], &mut [SendCtx<W>]),
-    R: Handoff,
-    W: Handoff,
-{
-    f: F,
-    recvs: Vec<RecvCtx<R>>,
-    sends: Vec<SendCtx<W>>,
-}
-impl<F, R, W> NtoMClosureSubgraph<F, R, W>
-where
-    F: FnMut(&mut [RecvCtx<R>], &mut [SendCtx<W>]),
-    R: Handoff,
-    W: Handoff,
-{
-    pub fn new(f: F, recvs: Vec<RecvCtx<R>>, sends: Vec<SendCtx<W>>) -> Self {
-        Self { f, recvs, sends }
-    }
-}
-impl<F, R, W> Subgraph for NtoMClosureSubgraph<F, R, W>
-where
-    F: FnMut(&mut [RecvCtx<R>], &mut [SendCtx<W>]),
-    R: Handoff,
-    W: Handoff,
-{
-    fn run(&mut self) {
-        (self.f)(&mut self.recvs, &mut self.sends)
+        (self)();
     }
 }


### PR DESCRIPTION
Also removes a few more unneccesary `&mut`s

less code is better code