### PR TITLE
Add a basic implementation of relational algebra

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,6 +940,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "relalg"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "datadriven",
+ "hydroflow",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ members = [
     "benches",
     "covid_tracing",
     "covid_tracing_dist",
+    "relalg",
 ]

--- a/relalg/Cargo.toml
+++ b/relalg/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "relalg"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0"
+datadriven = "0.6.0"
+hydroflow = { path = "../hydroflow" }

--- a/relalg/src/lib.rs
+++ b/relalg/src/lib.rs
@@ -1,0 +1,180 @@
+#![allow(dead_code)]
+
+use anyhow::bail;
+use sexp::Sexp;
+
+mod runtime;
+mod sexp;
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone)]
+enum Datum {
+    Int(i64),
+    String(String),
+    Bool(bool),
+}
+
+impl Datum {
+    fn unwrap_int(self) -> i64 {
+        if let Datum::Int(i) = self {
+            i
+        } else {
+            panic!("was not int")
+        }
+    }
+}
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone)]
+enum ScalarExpr {
+    Literal(Datum),
+    ColRef(usize),
+    Eq(Box<ScalarExpr>, Box<ScalarExpr>),
+    Plus(Box<ScalarExpr>, Box<ScalarExpr>),
+}
+
+impl ScalarExpr {
+    fn eval(&self, data: &[Datum]) -> Datum {
+        match self {
+            ScalarExpr::Literal(d) => d.clone(),
+            ScalarExpr::ColRef(u) => data[*u].clone(),
+            ScalarExpr::Eq(a, b) => {
+                let a = a.eval(data);
+                let b = b.eval(data);
+                Datum::Bool(a == b)
+            }
+            ScalarExpr::Plus(a, b) => {
+                let a = a.eval(data).unwrap_int();
+                let b = b.eval(data).unwrap_int();
+                Datum::Int(a + b)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone)]
+enum RelExpr {
+    Values(Vec<Vec<ScalarExpr>>),
+    Filter(Vec<ScalarExpr>, Box<RelExpr>),
+    Project(Vec<ScalarExpr>, Box<RelExpr>),
+}
+
+fn parse_scalar(s: Sexp) -> anyhow::Result<ScalarExpr> {
+    match s {
+        Sexp::Atom(s) => {
+            if s.strip_prefix('@').is_some() {
+                Ok(ScalarExpr::ColRef(s[1..].parse::<usize>()?))
+            } else {
+                Ok(ScalarExpr::Literal(Datum::Int(s.parse::<i64>()?)))
+            }
+        }
+        Sexp::String(s) => Ok(ScalarExpr::Literal(Datum::String(s))),
+        Sexp::List(list, _) => {
+            if list.is_empty() {
+                bail!("empty list is not a relexpr");
+            }
+            match list[0].clone().expect_atom()?.as_str() {
+                "=" => {
+                    if list.len() < 3 {
+                        bail!("= requires two arguments");
+                    }
+                    Ok(ScalarExpr::Eq(
+                        Box::new(parse_scalar(list[1].clone())?),
+                        Box::new(parse_scalar(list[2].clone())?),
+                    ))
+                }
+                "+" => {
+                    if list.len() < 3 {
+                        bail!("+ requires two arguments");
+                    }
+                    Ok(ScalarExpr::Plus(
+                        Box::new(parse_scalar(list[1].clone())?),
+                        Box::new(parse_scalar(list[2].clone())?),
+                    ))
+                }
+                v => bail!("{} is not a scalar operator", v),
+            }
+        }
+    }
+}
+
+fn parse_relexpr(s: Sexp) -> anyhow::Result<RelExpr> {
+    let (list, _) = s.expect_list()?;
+    if list.is_empty() {
+        bail!("empty list is not a relexpr");
+    }
+    match list[0].clone().expect_atom()?.as_str() {
+        "values" => {
+            if list.len() < 2 {
+                bail!("values requires an argument");
+            }
+            let (values, _) = list[1].clone().expect_list()?;
+            let mut rows = Vec::new();
+            for r in values {
+                let (row, _) = r.expect_list()?;
+                let mut parsed_row = Vec::new();
+                for d in row {
+                    parsed_row.push(parse_scalar(d)?);
+                }
+                rows.push(parsed_row);
+            }
+            Ok(RelExpr::Values(rows))
+        }
+        "project" => {
+            if list.len() < 3 {
+                bail!("filter requires two arguments");
+            }
+            let (exprs_sexp, _) = list[1].clone().expect_list()?;
+            let exprs = exprs_sexp
+                .into_iter()
+                .map(parse_scalar)
+                .collect::<anyhow::Result<Vec<ScalarExpr>>>()?;
+
+            Ok(RelExpr::Project(
+                exprs,
+                Box::new(parse_relexpr(list[2].clone())?),
+            ))
+        }
+        "filter" => {
+            if list.len() < 3 {
+                bail!("filter requires two arguments");
+            }
+            let (filters_sexp, _) = list[1].clone().expect_list()?;
+            let filters = filters_sexp
+                .into_iter()
+                .map(parse_scalar)
+                .collect::<anyhow::Result<Vec<ScalarExpr>>>()?;
+
+            Ok(RelExpr::Filter(
+                filters,
+                Box::new(parse_relexpr(list[2].clone())?),
+            ))
+        }
+        v => bail!("{} is not a relational operator", v),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{parse_relexpr, runtime::run_dataflow, sexp::Sexp};
+
+    #[test]
+    fn datadriven_tests() {
+        datadriven::walk("testdata/", |t| {
+            t.run(|test_case| match test_case.directive.as_str() {
+                "build" => {
+                    let sexps = Sexp::parse(test_case.input.clone()).unwrap();
+                    let sexp = (&sexps[0]).clone();
+                    let rel_expr = parse_relexpr(sexp);
+                    format!("{:?}\n", rel_expr)
+                }
+                "run" => {
+                    let sexps = Sexp::parse(test_case.input.clone()).unwrap();
+                    let sexp = (&sexps[0]).clone();
+                    let rel_expr = parse_relexpr(sexp).unwrap();
+                    let output = run_dataflow(rel_expr);
+                    format!("{:?}\n", output)
+                }
+                _ => "unhandled directive\n".into(),
+            })
+        });
+    }
+}

--- a/relalg/src/runtime.rs
+++ b/relalg/src/runtime.rs
@@ -1,0 +1,73 @@
+#![allow(dead_code)]
+
+use std::{cell::RefCell, rc::Rc};
+
+use hydroflow::scheduled::{
+    collections::Iter,
+    ctx::{OutputPort, RecvCtx},
+    handoff::VecHandoff,
+    Hydroflow,
+};
+
+use crate::{Datum, RelExpr};
+
+pub(crate) fn run_dataflow(r: RelExpr) -> Vec<Vec<Datum>> {
+    let mut df = Hydroflow::new();
+
+    let output_port = render_relational(&mut df, r);
+
+    let output = Rc::new(RefCell::new(Vec::new()));
+    let inner = output.clone();
+    let sink = df.add_sink(move |_ctx, recv: &RecvCtx<VecHandoff<Vec<Datum>>>| {
+        for v in recv.take_inner() {
+            (*inner).borrow_mut().push(v);
+        }
+    });
+    df.add_edge(output_port, sink);
+
+    df.tick();
+
+    let v = (*output).borrow();
+    v.clone()
+}
+
+fn render_relational(df: &mut Hydroflow, r: RelExpr) -> OutputPort<VecHandoff<Vec<Datum>>> {
+    match r {
+        RelExpr::Values(mut v) => {
+            // TODO: drip-feed data?
+            let scope = Vec::new();
+            df.add_source(move |_ctx, send| {
+                send.give(Iter(
+                    v.drain(..)
+                        .map(|row| row.into_iter().map(|e| e.eval(&scope)).collect()),
+                ));
+            })
+        }
+        RelExpr::Filter(preds, v) => {
+            let input = render_relational(df, *v);
+            let (filter_in, filter_out) =
+                df.add_inout(move |_ctx, recv: &RecvCtx<VecHandoff<Vec<Datum>>>, send| {
+                    send.give(Iter(recv.take_inner().into_iter().filter(|row| {
+                        preds.iter().all(|p| p.eval(row) == Datum::Bool(true))
+                    })));
+                });
+            df.add_edge(input, filter_in);
+
+            filter_out
+        }
+        RelExpr::Project(exprs, v) => {
+            let input = render_relational(df, *v);
+            let (project_in, project_out) =
+                df.add_inout(move |_ctx, recv: &RecvCtx<VecHandoff<Vec<Datum>>>, send| {
+                    send.give(Iter(
+                        recv.take_inner()
+                            .into_iter()
+                            .map(|row| exprs.iter().map(|e| e.eval(&row)).collect()),
+                    ));
+                });
+            df.add_edge(input, project_in);
+
+            project_out
+        }
+    }
+}

--- a/relalg/src/sexp.rs
+++ b/relalg/src/sexp.rs
@@ -1,0 +1,291 @@
+use anyhow::bail;
+
+#[derive(Debug, Clone)]
+struct Parser {
+    input: Vec<char>,
+    idx: usize,
+}
+
+fn closer(ch: char) -> char {
+    match ch {
+        '(' => ')',
+        '[' => ']',
+        '{' => '}',
+        _ => panic!(""),
+    }
+}
+
+impl Parser {
+    fn atom_char(ch: char) -> bool {
+        ch != '{'
+            && ch != '}'
+            && ch != '['
+            && ch != ']'
+            && ch != '('
+            && ch != ')'
+            && !ch.is_whitespace()
+    }
+
+    fn new(input: String) -> Self {
+        Parser {
+            input: input.chars().collect(),
+            idx: 0,
+        }
+    }
+
+    fn munch(&mut self) {
+        while self.idx < self.input.len() && self.input[self.idx].is_whitespace() {
+            self.idx += 1;
+        }
+    }
+
+    pub fn parse_multiple(&mut self) -> Result<Vec<Sexp>, anyhow::Error> {
+        let mut out = Vec::new();
+        loop {
+            self.munch();
+            if self.idx >= self.input.len() {
+                break;
+            }
+            match self.input[self.idx] {
+                ')' | ']' | '}' => break,
+                _ => out.push(self.parse_one()?),
+            }
+        }
+
+        Ok(out)
+    }
+
+    fn parse_one(&mut self) -> Result<Sexp, anyhow::Error> {
+        self.munch();
+        match self.input[self.idx] {
+            ch @ '[' | ch @ '(' | ch @ '{' => {
+                self.idx += 1;
+                let contents = self.parse_multiple()?;
+                self.munch();
+                if self.idx >= self.input.len() || self.input[self.idx] != closer(ch) {
+                    bail!("unclosed {}", ch);
+                }
+                self.idx += 1;
+                Ok(Sexp::List(contents, ch))
+            }
+            '"' => {
+                self.idx += 1;
+                let mut out = String::new();
+                while self.idx < self.input.len() {
+                    match self.input[self.idx] {
+                        '"' => {
+                            self.idx += 1;
+                            return Ok(Sexp::String(out));
+                        }
+                        '\\' => {
+                            self.idx += 1;
+                            if self.idx >= self.input.len() {
+                                bail!("unexpected EOF after \\")
+                            }
+                            match self.input[self.idx] {
+                                'n' => out.push('\n'),
+                                't' => out.push('\t'),
+                                '"' => out.push('"'),
+                                '\\' => out.push('\\'),
+                                _ => bail!("unknown escape sequence"),
+                            }
+                            self.idx += 1;
+                        }
+                        ch => {
+                            out.push(ch);
+                        }
+                    }
+                    self.idx += 1;
+                }
+                bail!("unclosed '\"'");
+            }
+            ch if Self::atom_char(ch) => {
+                let mut s = String::new();
+                while self.idx < self.input.len() && Self::atom_char(self.input[self.idx]) {
+                    s.push(self.input[self.idx]);
+                    self.idx += 1;
+                }
+                Ok(Sexp::Atom(s))
+            }
+            _ => bail!("unhandled: {:?}", self.input[self.idx]),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Sexp {
+    Atom(String),
+    List(Vec<Sexp>, char),
+    String(String),
+}
+
+impl Sexp {
+    pub fn expect_atom(self) -> Result<String, anyhow::Error> {
+        match self {
+            Sexp::Atom(r) => Ok(r),
+            _ => bail!("expected atom"),
+        }
+    }
+
+    pub fn expect_list(self) -> Result<(Vec<Sexp>, char), anyhow::Error> {
+        match self {
+            Sexp::List(v, ch) => Ok((v, ch)),
+            _ => bail!("expected list"),
+        }
+    }
+
+    pub fn expect_string(self) -> Result<String, anyhow::Error> {
+        match self {
+            Sexp::String(r) => Ok(r),
+            _ => bail!("expected string"),
+        }
+    }
+
+    pub fn parse(s: String) -> Result<Vec<Sexp>, anyhow::Error> {
+        let mut p = Parser::new(s);
+        p.parse_multiple()
+    }
+
+    pub fn format(&self) -> String {
+        let mut out = String::new();
+        self.write(&mut out);
+        out
+    }
+
+    fn write(&self, s: &mut String) {
+        match self {
+            Sexp::String(st) => {
+                s.push('"');
+                for ch in st.chars() {
+                    match ch {
+                        '\n' => s.push_str("\\n"),
+                        '"' => s.push_str("\\\""),
+                        '\t' => s.push_str("\\t"),
+                        '\\' => s.push_str("\\\\"),
+                        ch => s.push(ch),
+                    }
+                }
+                s.push('"');
+            }
+            Sexp::Atom(atom) => s.push_str(atom),
+            Sexp::List(v, ch) => {
+                s.push(*ch);
+                let mut space = "";
+                for sexp in v {
+                    s.push_str(space);
+                    space = " ";
+                    Self::write(sexp, s);
+                }
+                s.push(closer(*ch));
+            }
+        }
+    }
+}
+
+pub trait FromSexp: Sized {
+    fn from_sexp(s: Sexp) -> Result<Self, anyhow::Error>;
+}
+
+impl FromSexp for Sexp {
+    fn from_sexp(s: Sexp) -> Result<Self, anyhow::Error> {
+        Ok(s)
+    }
+}
+
+impl ToSexp for Sexp {
+    fn to_sexp(&self) -> Sexp {
+        self.clone()
+    }
+}
+
+pub trait ToSexp {
+    fn to_sexp(&self) -> Sexp;
+}
+
+impl<I: FromSexp> FromSexp for Vec<I> {
+    fn from_sexp(s: Sexp) -> Result<Self, anyhow::Error> {
+        let (v, _) = s.expect_list()?;
+        v.into_iter()
+            .map(|s| I::from_sexp(s))
+            .collect::<Result<Self, _>>()
+    }
+}
+
+impl<I: ToSexp> ToSexp for Vec<I> {
+    fn to_sexp(&self) -> Sexp {
+        Sexp::List(self.iter().map(|i| i.to_sexp()).collect(), '[')
+    }
+}
+
+impl<A: FromSexp, B: FromSexp> FromSexp for (A, B) {
+    fn from_sexp(s: Sexp) -> Result<Self, anyhow::Error> {
+        let (v, _) = s.expect_list()?;
+        if v.len() != 2 {
+            bail!("expected pair");
+        }
+        // TODO: remove clone
+        Ok((A::from_sexp(v[0].clone())?, B::from_sexp(v[1].clone())?))
+    }
+}
+
+impl<A: ToSexp, B: ToSexp> ToSexp for (A, B) {
+    fn to_sexp(&self) -> Sexp {
+        Sexp::List(vec![self.0.to_sexp(), self.1.to_sexp()], '(')
+    }
+}
+
+macro_rules! impl_from_fromstr {
+    ($name:ident) => {
+        impl FromSexp for $name {
+            fn from_sexp(s: Sexp) -> Result<Self, anyhow::Error> {
+                Ok(s.expect_atom()?.parse::<$name>()?)
+            }
+        }
+
+        impl ToSexp for $name {
+            fn to_sexp(&self) -> Sexp {
+                Sexp::Atom(format!("{}", self))
+            }
+        }
+    };
+}
+
+impl_from_fromstr!(i64);
+impl_from_fromstr!(usize);
+impl_from_fromstr!(String);
+
+#[derive(Debug, Clone)]
+struct LitString(String);
+
+impl FromSexp for LitString {
+    fn from_sexp(s: Sexp) -> Result<Self, anyhow::Error> {
+        Ok(LitString(s.expect_string()?.parse::<String>()?))
+    }
+}
+
+impl ToSexp for LitString {
+    fn to_sexp(&self) -> Sexp {
+        Sexp::String(self.0.to_string())
+    }
+}
+
+impl ToSexp for () {
+    fn to_sexp(&self) -> Sexp {
+        Sexp::List(Vec::new(), '(')
+    }
+}
+
+#[test]
+fn test_parse() {
+    for s in ["1", "(1)", "(plus (one two))", "(+ 1 2)", "\"foo\""] {
+        assert_eq!(
+            s,
+            Sexp::parse(s.into())
+                .unwrap()
+                .into_iter()
+                .map(|s| s.format())
+                .collect::<Vec<String>>()
+                .join(" ")
+        );
+    }
+}

--- a/relalg/testdata/build/rel
+++ b/relalg/testdata/build/rel
@@ -1,0 +1,37 @@
+build
+(values [[1 2 3]])
+----
+Ok(Values([[Literal(Int(1)), Literal(Int(2)), Literal(Int(3))]]))
+
+build
+(values [[1 2 3] [4 5 6]])
+----
+Ok(Values([[Literal(Int(1)), Literal(Int(2)), Literal(Int(3))], [Literal(Int(4)), Literal(Int(5)), Literal(Int(6))]]))
+
+build
+(values [[-1 2 -3] [4 -5 6]])
+----
+Ok(Values([[Literal(Int(-1)), Literal(Int(2)), Literal(Int(-3))], [Literal(Int(4)), Literal(Int(-5)), Literal(Int(6))]]))
+
+build
+(values [[(= 1 2) (= 2 3)]])
+----
+Ok(Values([[Eq(Literal(Int(1)), Literal(Int(2))), Eq(Literal(Int(2)), Literal(Int(3)))]]))
+
+build
+(filter [(= 1 2)]
+    (values []))
+----
+Ok(Filter([Eq(Literal(Int(1)), Literal(Int(2)))], Values([])))
+
+build
+(filter [(= @0 2)]
+    (values [[2 1] [1 2]]))
+----
+Ok(Filter([Eq(ColRef(0), Literal(Int(2)))], Values([[Literal(Int(2)), Literal(Int(1))], [Literal(Int(1)), Literal(Int(2))]])))
+
+build
+(project [@0 @1]
+    (values [[2 1] [1 2]]))
+----
+Ok(Project([ColRef(0), ColRef(1)], Values([[Literal(Int(2)), Literal(Int(1))], [Literal(Int(1)), Literal(Int(2))]])))

--- a/relalg/testdata/run/run
+++ b/relalg/testdata/run/run
@@ -1,0 +1,22 @@
+run
+(values [[1 2 3]])
+----
+[[Int(1), Int(2), Int(3)]]
+
+run
+(filter [(= @0 1)]
+    (values [[1 2 3] [2 3 4] [1 1 1]]))
+----
+[[Int(1), Int(2), Int(3)], [Int(1), Int(1), Int(1)]]
+
+run
+(project [(= @0 1) @2]
+    (values [[1 2 3] [2 3 4] [1 1 1]]))
+----
+[[Bool(true), Int(3)], [Bool(false), Int(4)], [Bool(true), Int(1)]]
+
+run
+(project [(+ @0 1) @2 (+ @0 @1)]
+    (values [[1 2 3] [2 3 4] [1 1 1]]))
+----
+[[Int(2), Int(3), Int(3)], [Int(3), Int(4), Int(5)], [Int(2), Int(1), Int(2)]]


### PR DESCRIPTION
This is a WIP implementation of relational algebra that runs in Hydroflow.

Right now it only uses scheduled components and is only at runtime, no codegen,
just for simplicity. It's also not how I would design a non-proof-of-concept IR
but I think for our purposes for now it will be fine.

The sexp parser is one I had from another unpublished project that I just copy-pasted in here. I didn't love any of the libraries I tried and I already had this one written, so I just vendored it.