### PR TITLE
Add a simple codegen path for relational algebra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
+          components: rustfmt
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,6 +946,8 @@ dependencies = [
  "anyhow",
  "datadriven",
  "hydroflow",
+ "quote",
+ "xshell",
 ]
 
 [[package]]
@@ -1435,3 +1437,18 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "xshell"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaad2035244c56da05573d4d7fda5f903c60a5f35b9110e157a14a1df45a9f14"
+dependencies = [
+ "xshell-macros",
+]
+
+[[package]]
+name = "xshell-macros"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4916a4a3cad759e499a3620523bf9545cc162d7a06163727dde97ce9aaa4cf39"

--- a/relalg/Cargo.toml
+++ b/relalg/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 anyhow = "1.0"
 datadriven = "0.6.0"
 hydroflow = { path = "../hydroflow" }
+quote = "1.0"
+xshell = "0.1"

--- a/relalg/src/codegen.rs
+++ b/relalg/src/codegen.rs
@@ -1,0 +1,123 @@
+use quote::{
+    __private::{Ident, TokenStream},
+    format_ident, quote, ToTokens,
+};
+use xshell::cmd;
+
+use crate::{Datum, RelExpr, ScalarExpr};
+
+pub(crate) fn generate_dataflow(r: RelExpr) -> String {
+    let mut builder = SubgraphBuilder::new();
+    let id = builder.compile_op(&r);
+    let code = builder.code;
+    run_rustfmt(format!(
+        "{}",
+        quote! {
+            fn main() {
+                #(#code)*
+
+                for row in #id {
+                    println!("{:?}", row);
+                }
+            }
+        }
+    ))
+    .unwrap()
+}
+
+// TODO(justin): How do we make this portable/run on CI?
+fn run_rustfmt(s: String) -> anyhow::Result<String> {
+    Ok(cmd!("rustfmt").stdin(s).read()?)
+}
+
+struct SubgraphBuilder {
+    sym_id: usize,
+    code: Vec<TokenStream>,
+}
+
+// TODO(justin): we can manually inline all this to just get raw rust code, but should check
+// to see how much of that the rust compiler will do for us first.
+impl ToTokens for ScalarExpr {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.extend(match self {
+            ScalarExpr::Literal(Datum::Int(x)) => quote! { ScalarExpr::Literal(Datum::Int(#x)) },
+            ScalarExpr::ColRef(x) => quote! { ScalarExpr::ColRef(#x) },
+            ScalarExpr::Eq(a, b) => quote! {
+                ScalarExpr::Eq(Box::new(#a), Box::new(#b))
+            },
+            ScalarExpr::Plus(a, b) => quote! {
+                ScalarExpr::Plus(Box::new(#a), Box::new(#b))
+            },
+            _ => panic!("unhandled"),
+        })
+    }
+}
+
+impl SubgraphBuilder {
+    fn gensym(&mut self, prefix: &str) -> Ident {
+        self.sym_id += 1;
+        format_ident!("__{}_{}", prefix, self.sym_id)
+    }
+
+    fn new() -> Self {
+        SubgraphBuilder {
+            sym_id: 0,
+            code: Vec::new(),
+        }
+    }
+
+    fn compile_op(&mut self, r: &RelExpr) -> Ident {
+        match r {
+            RelExpr::Values(v) => {
+                let op_name = self.gensym("values");
+                let mut payload = TokenStream::default();
+                let iter = v.iter().map(|row| {
+                    quote! {
+                        vec![ #(#row.eval(&Vec::new())),* ]
+                    }
+                });
+                payload.extend(quote! {
+                    vec![
+                        #(
+                            #iter
+                        ),*
+                    ]
+                });
+
+                self.code.push(quote! {
+                    let #op_name = #payload.into_iter();
+                });
+
+                op_name
+            }
+            RelExpr::Filter(preds, input) => {
+                let op_name = self.gensym("filter");
+                let input_name = self.compile_op(&*input);
+
+                let pred = quote! {
+                    #(#preds.eval(row).is_true())&&*
+                };
+
+                self.code.push(quote! {
+                    let #op_name = #input_name.filter(|row| #pred);
+                });
+
+                op_name
+            }
+            RelExpr::Project(exprs, input) => {
+                let op_name = self.gensym("project");
+                let input_name = self.compile_op(&*input);
+
+                let pred = quote! {
+                    vec![ #(#exprs.eval(&row)),* ]
+                };
+
+                self.code.push(quote! {
+                    let #op_name = #input_name.map(|row| #pred);
+                });
+
+                op_name
+            }
+        }
+    }
+}

--- a/relalg/src/main.rs
+++ b/relalg/src/main.rs
@@ -1,0 +1,39 @@
+use relalg::{Datum, ScalarExpr};
+
+// Can copy-paste the examples from the tests in here to actually run them.
+
+fn main() {
+    let __values_2 = vec![
+        vec![
+            ScalarExpr::Literal(Datum::Int(1i64)).eval(&Vec::new()),
+            ScalarExpr::Literal(Datum::Int(2i64)).eval(&Vec::new()),
+            ScalarExpr::Literal(Datum::Int(3i64)).eval(&Vec::new()),
+        ],
+        vec![
+            ScalarExpr::Literal(Datum::Int(4i64)).eval(&Vec::new()),
+            ScalarExpr::Literal(Datum::Int(5i64)).eval(&Vec::new()),
+            ScalarExpr::Literal(Datum::Int(6i64)).eval(&Vec::new()),
+        ],
+    ]
+    .into_iter();
+    let __project_1 = __values_2.map(|row| {
+        vec![
+            ScalarExpr::Plus(
+                Box::new(ScalarExpr::ColRef(0usize)),
+                Box::new(ScalarExpr::Literal(Datum::Int(1i64))),
+            )
+            .eval(&row),
+            ScalarExpr::Plus(
+                Box::new(ScalarExpr::Literal(Datum::Int(5i64))),
+                Box::new(ScalarExpr::Plus(
+                    Box::new(ScalarExpr::ColRef(1usize)),
+                    Box::new(ScalarExpr::ColRef(2usize)),
+                )),
+            )
+            .eval(&row),
+        ]
+    });
+    for row in __project_1 {
+        println!("{:?}", row);
+    }
+}

--- a/relalg/testdata/compile/compile
+++ b/relalg/testdata/compile/compile
@@ -1,0 +1,118 @@
+compile
+(values [[1 2 3]])
+----
+fn main() {
+    let __values_1 = vec![vec![
+        ScalarExpr::Literal(Datum::Int(1i64)).eval(&Vec::new()),
+        ScalarExpr::Literal(Datum::Int(2i64)).eval(&Vec::new()),
+        ScalarExpr::Literal(Datum::Int(3i64)).eval(&Vec::new()),
+    ]]
+    .into_iter();
+    for row in __values_1 {
+        println!("{:?}", row);
+    }
+}
+
+compile
+(filter [(= @0 1)]
+    (values [[1 2 3]]))
+----
+fn main() {
+    let __values_2 = vec![vec![
+        ScalarExpr::Literal(Datum::Int(1i64)).eval(&Vec::new()),
+        ScalarExpr::Literal(Datum::Int(2i64)).eval(&Vec::new()),
+        ScalarExpr::Literal(Datum::Int(3i64)).eval(&Vec::new()),
+    ]]
+    .into_iter();
+    let __filter_1 = __values_2.filter(|row| {
+        ScalarExpr::Eq(
+            Box::new(ScalarExpr::ColRef(0usize)),
+            Box::new(ScalarExpr::Literal(Datum::Int(1i64))),
+        )
+        .eval(row)
+        .is_true()
+    });
+    for row in __filter_1 {
+        println!("{:?}", row);
+    }
+}
+
+compile
+(filter [(= @0 1) (= 5 (+ @1 @2))]
+    (values [[1 2 3] [4 5 6]]))
+----
+fn main() {
+    let __values_2 = vec![
+        vec![
+            ScalarExpr::Literal(Datum::Int(1i64)).eval(&Vec::new()),
+            ScalarExpr::Literal(Datum::Int(2i64)).eval(&Vec::new()),
+            ScalarExpr::Literal(Datum::Int(3i64)).eval(&Vec::new()),
+        ],
+        vec![
+            ScalarExpr::Literal(Datum::Int(4i64)).eval(&Vec::new()),
+            ScalarExpr::Literal(Datum::Int(5i64)).eval(&Vec::new()),
+            ScalarExpr::Literal(Datum::Int(6i64)).eval(&Vec::new()),
+        ],
+    ]
+    .into_iter();
+    let __filter_1 = __values_2.filter(|row| {
+        ScalarExpr::Eq(
+            Box::new(ScalarExpr::ColRef(0usize)),
+            Box::new(ScalarExpr::Literal(Datum::Int(1i64))),
+        )
+        .eval(row)
+        .is_true()
+            && ScalarExpr::Eq(
+                Box::new(ScalarExpr::Literal(Datum::Int(5i64))),
+                Box::new(ScalarExpr::Plus(
+                    Box::new(ScalarExpr::ColRef(1usize)),
+                    Box::new(ScalarExpr::ColRef(2usize)),
+                )),
+            )
+            .eval(row)
+            .is_true()
+    });
+    for row in __filter_1 {
+        println!("{:?}", row);
+    }
+}
+
+compile
+(project [(+ @0 1) (+ 5 (+ @1 @2))]
+    (values [[1 2 3] [4 5 6]]))
+----
+fn main() {
+    let __values_2 = vec![
+        vec![
+            ScalarExpr::Literal(Datum::Int(1i64)).eval(&Vec::new()),
+            ScalarExpr::Literal(Datum::Int(2i64)).eval(&Vec::new()),
+            ScalarExpr::Literal(Datum::Int(3i64)).eval(&Vec::new()),
+        ],
+        vec![
+            ScalarExpr::Literal(Datum::Int(4i64)).eval(&Vec::new()),
+            ScalarExpr::Literal(Datum::Int(5i64)).eval(&Vec::new()),
+            ScalarExpr::Literal(Datum::Int(6i64)).eval(&Vec::new()),
+        ],
+    ]
+    .into_iter();
+    let __project_1 = __values_2.map(|row| {
+        vec![
+            ScalarExpr::Plus(
+                Box::new(ScalarExpr::ColRef(0usize)),
+                Box::new(ScalarExpr::Literal(Datum::Int(1i64))),
+            )
+            .eval(&row),
+            ScalarExpr::Plus(
+                Box::new(ScalarExpr::Literal(Datum::Int(5i64))),
+                Box::new(ScalarExpr::Plus(
+                    Box::new(ScalarExpr::ColRef(1usize)),
+                    Box::new(ScalarExpr::ColRef(2usize)),
+                )),
+            )
+            .eval(&row),
+        ]
+    });
+    for row in __project_1 {
+        println!("{:?}", row);
+    }
+}


### PR DESCRIPTION
This currently only handles some very simple patterns, and doesn't invoke
scheduled components at all, but this is the general pattern I was thinking for
now. Comments on the overall design welcome, you can see examples of the
generated code in testdata/compile/compile.

What's more, I think this PR will probably fail on CI since it shells out to
rustfmt to format the generated code. Suggestions welcome for how to fix, I
might just make it skip running the test (probably with a warning) if rustfmt
does not just work.

Next step is to introduce a let binding layer to the language, to force the
codegen to use scheduled components/invoke Hydroflow.

I'll add some docs for this, but if you want to regenerate the output for the tests you can run
```
env REWRITE=1 cargo test -p relalg
```
to repopulate them.