### PR TITLE
Switch from a bespoke format -> bincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,11 +469,15 @@ dependencies = [
 name = "hydroflow"
 version = "0.1.0"
 dependencies = [
+ "bincode",
+ "byteorder",
  "bytes",
  "criterion",
  "futures",
  "ref-cast",
  "sealed",
+ "serde",
+ "serde_json",
  "slotmap",
  "static_assertions",
  "tokio",

--- a/hydroflow/Cargo.toml
+++ b/hydroflow/Cargo.toml
@@ -18,6 +18,10 @@ static_assertions = "1.1.0"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.6.9", features = ["codec"] }
 tuple_list = "0.1"
+byteorder = "1.4.3"
+serde = "1"
+serde_json = "1"
+bincode = "1.3"
 
 [dev-dependencies]
 criterion = { version = "0.3", features = [ "async_tokio" ] }

--- a/hydroflow/tests/networked.rs
+++ b/hydroflow/tests/networked.rs
@@ -1,13 +1,20 @@
 use std::{collections::HashSet, sync::mpsc::channel};
 
-use hydroflow::{
-    lang::collections::Iter,
-    scheduled::{
-        ctx::RecvCtx, graph::Hydroflow, graph_demux::GraphDemux, graph_ext::GraphExt,
-        handoff::VecHandoff, net::Message,
-    },
+use hydroflow::scheduled::{
+    ctx::RecvCtx, graph::Hydroflow, graph_ext::GraphExt, handoff::VecHandoff,
 };
-use tokio::net::{TcpListener, TcpStream};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct EchoRequest {
+    return_addr: String,
+    payload: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct EchoResponse {
+    payload: String,
+}
 
 // This test sets up an echo server and runs a few connections to it.
 #[test]
@@ -28,14 +35,17 @@ fn test_echo_server() {
 
                 server_port_send.send(port).unwrap();
 
-                let (receiver_port, sender_port) = df.add_inout(move |_ctx, recv, send| {
-                    for msg in recv.take_inner() {
-                        let mut msg: Message = msg;
-                        let addr = format!("localhost:{}", msg.address);
-                        msg.address = port.try_into().unwrap();
-                        send.give(Some((addr, msg)));
-                    }
-                });
+                let (receiver_port, sender_port) =
+                    df.add_inout(move |_ctx, recv: &RecvCtx<VecHandoff<EchoRequest>>, send| {
+                        for msg in recv.take_inner() {
+                            send.give(Some((
+                                msg.return_addr,
+                                EchoResponse {
+                                    payload: msg.payload,
+                                },
+                            )));
+                        }
+                    });
                 df.add_edge(incoming_messages, receiver_port);
 
                 df.add_edge(sender_port, outbound_messages);
@@ -62,14 +72,10 @@ fn test_echo_server() {
                 df.add_edge(given_inputs, outbound_messages);
 
                 let receiver_port =
-                    df.add_sink(move |_ctx, recv: &RecvCtx<VecHandoff<Message>>| {
+                    df.add_sink(move |_ctx, recv: &RecvCtx<VecHandoff<EchoResponse>>| {
                         for v in recv.take_inner() {
                             log_message
-                                .send(format!(
-                                    "[CLIENT#{}] received back {:?}",
-                                    idx,
-                                    String::from_utf8(v.batch.to_vec()).unwrap()
-                                ))
+                                .send(format!("[CLIENT#{}] received back {:?}", idx, v.payload))
                                 .unwrap();
                         }
                     });
@@ -80,9 +86,9 @@ fn test_echo_server() {
 
                 input.give(Some((
                     server_addr.clone(),
-                    Message {
-                        address: port.into(),
-                        batch: format!("Hello world {}!", idx).into(),
+                    EchoRequest {
+                        return_addr: format!("localhost:{}", port),
+                        payload: format!("Hello world {}!", idx),
                     },
                 )));
 
@@ -105,75 +111,4 @@ fn test_echo_server() {
     }
 
     assert_eq!(expected_messages, actual_messages);
-}
-
-#[test]
-fn test_networked() {
-    let (port_sender, port_receiver) = channel();
-
-    std::thread::spawn(move || {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async move {
-            let mut df = Hydroflow::new();
-
-            let stream = TcpListener::bind("localhost:0").await.unwrap();
-            let addr = stream.local_addr().unwrap();
-
-            port_sender.send(addr.port()).unwrap();
-
-            let (stream, _) = stream.accept().await.unwrap();
-            let network_send = df.add_write_tcp_stream(stream);
-
-            let (input, out) = df.add_input();
-
-            input.give(Iter(
-                vec![Message {
-                    address: 0,
-                    batch: vec![1, 2, 3, 4].into(),
-                }]
-                .into_iter(),
-            ));
-
-            df.add_edge(out, network_send);
-
-            df.run_async().await.unwrap();
-        });
-    });
-
-    let (send, recv) = channel();
-
-    std::thread::spawn(move || {
-        let port = port_receiver.recv().unwrap();
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async move {
-            let mut df = Hydroflow::new();
-
-            let stream = TcpStream::connect(format!("localhost:{}", port))
-                .await
-                .unwrap();
-            let network_recv = df.add_read_tcp_stream(stream);
-
-            let input = df.add_sink(move |_ctx, recv: &RecvCtx<VecHandoff<_>>| {
-                for v in recv.take_inner() {
-                    send.send(v).unwrap();
-                }
-            });
-
-            let (demux, input_port) = df.add_demux::<_, _, _, VecHandoff<_>>(|_| ());
-
-            df.add_edge(network_recv, input_port);
-            df.add_demux_edge(&demux, (), input);
-
-            df.run_async().await.unwrap();
-        });
-    });
-
-    let val = recv.recv().unwrap();
-    assert_eq!(
-        val,
-        Message {
-            address: 0,
-            batch: vec![1, 2, 3, 4].into(),
-        }
-    );
 }


### PR DESCRIPTION
This commit tidies up the TCP stuff more. There's still more to be done in
terms of ergonomics but I want to wait for the API change to work on that. I
think the next steps are that, and also writing a benchmark against a
hand-coded server, since I think there's a lot of low-hanging fruit in terms of
stuff like buffer reuse.