### PR TITLE
The Surface API

### DIFF
--- a/hydroflow/src/builder/build/mod.rs
+++ b/hydroflow/src/builder/build/mod.rs
@@ -1,0 +1,46 @@
+//! Internal "subgraph builders" to implement the Surface API. For more info see [super].
+
+pub mod pull_chain;
+pub mod pull_filter;
+pub mod pull_flat_map;
+pub mod pull_handoff;
+pub mod pull_join;
+pub mod pull_map;
+
+pub mod push_filter;
+pub mod push_flat_map;
+pub mod push_for_each;
+pub mod push_handoff;
+pub mod push_map;
+pub mod push_tee;
+
+use crate::compiled::Pusherator;
+use crate::scheduled::handoff::HandoffList;
+
+pub trait PullBuildBase {
+    type ItemOut;
+    type Build<'slf, 'inp>: Iterator<Item = Self::ItemOut>;
+}
+pub trait PullBuild: PullBuildBase {
+    type InputHandoffs: HandoffList;
+
+    /// Builds the iterator for a single run of the subgraph.
+    fn build<'slf, 'hof>(
+        &'slf mut self,
+        handoffs: <Self::InputHandoffs as HandoffList>::RecvCtx<'hof>,
+    ) -> Self::Build<'slf, 'hof>;
+}
+
+pub trait PushBuildBase {
+    type ItemIn;
+    type Build<'slf, 'hof>: Pusherator<Item = Self::ItemIn>;
+}
+pub trait PushBuild: PushBuildBase {
+    type OutputHandoffs: HandoffList;
+
+    /// Builds the pusherator for a single run of the subgraph.
+    fn build<'slf, 'hof>(
+        &'slf mut self,
+        handoffs: <Self::OutputHandoffs as HandoffList>::SendCtx<'hof>,
+    ) -> Self::Build<'slf, 'hof>;
+}

--- a/hydroflow/src/builder/build/pull_chain.rs
+++ b/hydroflow/src/builder/build/pull_chain.rs
@@ -1,0 +1,54 @@
+use super::{PullBuild, PullBuildBase};
+
+use crate::scheduled::handoff::{HandoffList, HandoffListSplit};
+use crate::scheduled::type_list::Extend;
+
+pub struct ChainPullBuild<PrevA, PrevB>
+where
+    PrevA: PullBuild,
+    PrevB: PullBuild<ItemOut = PrevA::ItemOut>,
+{
+    prev_a: PrevA,
+    prev_b: PrevB,
+}
+
+impl<PrevA, PrevB> ChainPullBuild<PrevA, PrevB>
+where
+    PrevA: PullBuild,
+    PrevB: PullBuild<ItemOut = PrevA::ItemOut>,
+{
+    pub fn new(prev_a: PrevA, prev_b: PrevB) -> Self {
+        Self { prev_a, prev_b }
+    }
+}
+
+impl<PrevA, PrevB> PullBuildBase for ChainPullBuild<PrevA, PrevB>
+where
+    PrevA: PullBuild,
+    PrevB: PullBuild<ItemOut = PrevA::ItemOut>,
+{
+    type ItemOut = PrevA::ItemOut;
+    type Build<'slf, 'hof> = std::iter::Chain<PrevA::Build<'slf, 'hof>, PrevB::Build<'slf, 'hof>>;
+}
+
+impl<PrevA, PrevB> PullBuild for ChainPullBuild<PrevA, PrevB>
+where
+    PrevA: PullBuild,
+    PrevB: PullBuild<ItemOut = PrevA::ItemOut>,
+    PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        HandoffList + HandoffListSplit<PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
+{
+    type InputHandoffs = <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended;
+
+    fn build<'slf, 'hof>(
+        &'slf mut self,
+        input: <Self::InputHandoffs as HandoffList>::RecvCtx<'hof>,
+    ) -> Self::Build<'slf, 'hof> {
+        let (input_a, input_b) =
+            <Self::InputHandoffs as HandoffListSplit<_>>::split_recv_ctx(input);
+        let iter_a = self.prev_a.build(input_a);
+        let iter_b = self.prev_b.build(input_b);
+        iter_a.chain(iter_b)
+    }
+}

--- a/hydroflow/src/builder/build/pull_filter.rs
+++ b/hydroflow/src/builder/build/pull_filter.rs
@@ -23,7 +23,7 @@ where
 type PullBuildImpl<'slf, 'hof, Prev, Func>
 where
     Prev: PullBuild,
-= std::iter::Filter<Prev::Build<'slf, 'hof>, impl 'slf + FnMut(&Prev::ItemOut) -> bool>;
+= std::iter::Filter<Prev::Build<'slf, 'hof>, impl FnMut(&Prev::ItemOut) -> bool>;
 
 impl<Prev, Func> PullBuildBase for FilterPullBuild<Prev, Func>
 where

--- a/hydroflow/src/builder/build/pull_filter.rs
+++ b/hydroflow/src/builder/build/pull_filter.rs
@@ -1,0 +1,50 @@
+use super::{PullBuild, PullBuildBase};
+
+use crate::scheduled::handoff::HandoffList;
+
+pub struct FilterPullBuild<Prev, Func>
+where
+    Prev: PullBuild,
+{
+    prev: Prev,
+    func: Func,
+}
+impl<Prev, Func> FilterPullBuild<Prev, Func>
+where
+    Prev: PullBuild,
+    Func: FnMut(&Prev::ItemOut) -> bool,
+{
+    pub fn new(prev: Prev, func: Func) -> Self {
+        Self { prev, func }
+    }
+}
+
+#[allow(type_alias_bounds)]
+type PullBuildImpl<'slf, 'hof, Prev, Func>
+where
+    Prev: PullBuild,
+= std::iter::Filter<Prev::Build<'slf, 'hof>, impl 'slf + FnMut(&Prev::ItemOut) -> bool>;
+
+impl<Prev, Func> PullBuildBase for FilterPullBuild<Prev, Func>
+where
+    Prev: PullBuild,
+    Func: FnMut(&Prev::ItemOut) -> bool,
+{
+    type ItemOut = Prev::ItemOut;
+    type Build<'slf, 'hof> = PullBuildImpl<'slf, 'hof, Prev, Func>;
+}
+
+impl<Prev, Func> PullBuild for FilterPullBuild<Prev, Func>
+where
+    Prev: PullBuild,
+    Func: FnMut(&Prev::ItemOut) -> bool,
+{
+    type InputHandoffs = Prev::InputHandoffs;
+
+    fn build<'slf, 'hof>(
+        &'slf mut self,
+        handoffs: <Self::InputHandoffs as HandoffList>::RecvCtx<'hof>,
+    ) -> Self::Build<'slf, 'hof> {
+        self.prev.build(handoffs).filter(|x| (self.func)(x))
+    }
+}

--- a/hydroflow/src/builder/build/pull_flat_map.rs
+++ b/hydroflow/src/builder/build/pull_flat_map.rs
@@ -24,7 +24,7 @@ where
 type PullBuildImpl<'slf, 'hof, Prev, Func, Out>
 where
     Prev: PullBuild,
-= std::iter::FlatMap<Prev::Build<'slf, 'hof>, Out, impl 'slf + FnMut(Prev::ItemOut) -> Out>;
+= std::iter::FlatMap<Prev::Build<'slf, 'hof>, Out, impl FnMut(Prev::ItemOut) -> Out>;
 
 impl<Prev, Func, Out> PullBuildBase for FlatMapPullBuild<Prev, Func>
 where

--- a/hydroflow/src/builder/build/pull_flat_map.rs
+++ b/hydroflow/src/builder/build/pull_flat_map.rs
@@ -1,0 +1,53 @@
+use super::{PullBuild, PullBuildBase};
+
+use crate::scheduled::handoff::HandoffList;
+
+pub struct FlatMapPullBuild<Prev, Func>
+where
+    Prev: PullBuild,
+{
+    prev: Prev,
+    func: Func,
+}
+impl<Prev, Func, Out> FlatMapPullBuild<Prev, Func>
+where
+    Prev: PullBuild,
+    Func: FnMut(Prev::ItemOut) -> Out,
+    Out: IntoIterator,
+{
+    pub fn new(prev: Prev, func: Func) -> Self {
+        Self { prev, func }
+    }
+}
+
+#[allow(type_alias_bounds)]
+type PullBuildImpl<'slf, 'hof, Prev, Func, Out>
+where
+    Prev: PullBuild,
+= std::iter::FlatMap<Prev::Build<'slf, 'hof>, Out, impl 'slf + FnMut(Prev::ItemOut) -> Out>;
+
+impl<Prev, Func, Out> PullBuildBase for FlatMapPullBuild<Prev, Func>
+where
+    Prev: PullBuild,
+    Func: FnMut(Prev::ItemOut) -> Out,
+    Out: IntoIterator,
+{
+    type ItemOut = Out::Item;
+    type Build<'slf, 'hof> = PullBuildImpl<'slf, 'hof, Prev, Func, Out>;
+}
+
+impl<Prev, Func, Out> PullBuild for FlatMapPullBuild<Prev, Func>
+where
+    Prev: PullBuild,
+    Func: FnMut(Prev::ItemOut) -> Out,
+    Out: IntoIterator,
+{
+    type InputHandoffs = Prev::InputHandoffs;
+
+    fn build<'slf, 'hof>(
+        &'slf mut self,
+        handoffs: <Self::InputHandoffs as HandoffList>::RecvCtx<'hof>,
+    ) -> Self::Build<'slf, 'hof> {
+        self.prev.build(handoffs).flat_map(|x| (self.func)(x))
+    }
+}

--- a/hydroflow/src/builder/build/pull_handoff.rs
+++ b/hydroflow/src/builder/build/pull_handoff.rs
@@ -1,0 +1,56 @@
+use super::{PullBuild, PullBuildBase};
+
+use std::marker::PhantomData;
+
+use crate::scheduled::handoff::{Handoff, HandoffList};
+use crate::{tl, tt};
+
+pub struct HandoffPullBuild<Hof>
+where
+    Hof: Handoff,
+{
+    _phantom: PhantomData<fn(Hof)>,
+}
+
+impl<Hof> Default for HandoffPullBuild<Hof>
+where
+    Hof: Handoff,
+{
+    fn default() -> Self {
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<Hof> HandoffPullBuild<Hof>
+where
+    Hof: Handoff,
+{
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+impl<Hof> PullBuildBase for HandoffPullBuild<Hof>
+where
+    Hof: Handoff,
+{
+    type ItemOut = Hof::Inner;
+    type Build<'slf, 'hof> = std::array::IntoIter<Hof::Inner, 1>;
+}
+
+impl<Hof> PullBuild for HandoffPullBuild<Hof>
+where
+    Hof: Handoff,
+{
+    type InputHandoffs = tt!(Hof);
+
+    fn build<'slf, 'hof>(
+        &'slf mut self,
+        handoffs: <Self::InputHandoffs as HandoffList>::RecvCtx<'hof>,
+    ) -> Self::Build<'slf, 'hof> {
+        let tl!(handoff) = handoffs;
+        [handoff.take_inner()].into_iter()
+    }
+}

--- a/hydroflow/src/builder/build/pull_join.rs
+++ b/hydroflow/src/builder/build/pull_join.rs
@@ -1,0 +1,81 @@
+use super::{PullBuild, PullBuildBase};
+
+use std::hash::Hash;
+
+use crate::compiled::pull::{JoinState, SymmetricHashJoin};
+use crate::scheduled::handoff::{HandoffList, HandoffListSplit};
+use crate::scheduled::type_list::Extend;
+
+pub struct JoinPullBuild<PrevA, PrevB, Key, ValA, ValB>
+where
+    PrevA: PullBuild<ItemOut = (Key, ValA)>,
+    PrevB: PullBuild<ItemOut = (Key, ValB)>,
+    Key: 'static + Eq + Hash + Clone,
+    ValA: 'static + Eq + Clone,
+    ValB: 'static + Eq + Clone,
+{
+    prev_a: PrevA,
+    prev_b: PrevB,
+    state: JoinState<Key, ValA, ValB>,
+}
+impl<PrevA, PrevB, Key, ValA, ValB> JoinPullBuild<PrevA, PrevB, Key, ValA, ValB>
+where
+    PrevA: PullBuild<ItemOut = (Key, ValA)>,
+    PrevB: PullBuild<ItemOut = (Key, ValB)>,
+    Key: 'static + Eq + Hash + Clone,
+    ValA: 'static + Eq + Clone,
+    ValB: 'static + Eq + Clone,
+{
+    pub fn new(prev_a: PrevA, prev_b: PrevB) -> Self {
+        Self {
+            prev_a,
+            prev_b,
+            state: Default::default(),
+        }
+    }
+}
+
+impl<PrevA, PrevB, Key, ValA, ValB> PullBuildBase for JoinPullBuild<PrevA, PrevB, Key, ValA, ValB>
+where
+    PrevA: PullBuild<ItemOut = (Key, ValA)>,
+    PrevB: PullBuild<ItemOut = (Key, ValB)>,
+    Key: 'static + Eq + Hash + Clone,
+    ValA: 'static + Eq + Clone,
+    ValB: 'static + Eq + Clone,
+{
+    type ItemOut = (Key, ValA, ValB);
+    type Build<'slf, 'hof> = SymmetricHashJoin<
+        'slf,
+        Key,
+        PrevA::Build<'slf, 'hof>,
+        ValA,
+        PrevB::Build<'slf, 'hof>,
+        ValB,
+    >;
+}
+
+impl<PrevA, PrevB, Key, ValA, ValB> PullBuild for JoinPullBuild<PrevA, PrevB, Key, ValA, ValB>
+where
+    PrevA: PullBuild<ItemOut = (Key, ValA)>,
+    PrevB: PullBuild<ItemOut = (Key, ValB)>,
+    Key: 'static + Eq + Hash + Clone,
+    ValA: 'static + Eq + Clone,
+    ValB: 'static + Eq + Clone,
+
+    PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        HandoffList + HandoffListSplit<PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
+{
+    type InputHandoffs = <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended;
+
+    fn build<'slf, 'hof>(
+        &'slf mut self,
+        input: <Self::InputHandoffs as HandoffList>::RecvCtx<'hof>,
+    ) -> Self::Build<'slf, 'hof> {
+        let (input_a, input_b) =
+            <Self::InputHandoffs as HandoffListSplit<_>>::split_recv_ctx(input);
+        let iter_a = self.prev_a.build(input_a);
+        let iter_b = self.prev_b.build(input_b);
+        SymmetricHashJoin::new(iter_a, iter_b, &mut self.state)
+    }
+}

--- a/hydroflow/src/builder/build/pull_map.rs
+++ b/hydroflow/src/builder/build/pull_map.rs
@@ -1,0 +1,50 @@
+use super::{PullBuild, PullBuildBase};
+
+use crate::scheduled::handoff::HandoffList;
+
+pub struct MapPullBuild<Prev, Func>
+where
+    Prev: PullBuild,
+{
+    prev: Prev,
+    func: Func,
+}
+impl<Prev, Func, Out> MapPullBuild<Prev, Func>
+where
+    Prev: PullBuild,
+    Func: FnMut(Prev::ItemOut) -> Out,
+{
+    pub fn new(prev: Prev, func: Func) -> Self {
+        Self { prev, func }
+    }
+}
+
+#[allow(type_alias_bounds)]
+type PullBuildImpl<'slf, 'hof, Prev, Func, Out>
+where
+    Prev: PullBuild,
+= std::iter::Map<Prev::Build<'slf, 'hof>, impl 'slf + FnMut(Prev::ItemOut) -> Out>;
+
+impl<Prev, Func, Out> PullBuildBase for MapPullBuild<Prev, Func>
+where
+    Prev: PullBuild,
+    Func: FnMut(Prev::ItemOut) -> Out,
+{
+    type ItemOut = Out;
+    type Build<'slf, 'hof> = PullBuildImpl<'slf, 'hof, Prev, Func, Out>;
+}
+
+impl<Prev, Func, Out> PullBuild for MapPullBuild<Prev, Func>
+where
+    Prev: PullBuild,
+    Func: FnMut(Prev::ItemOut) -> Out,
+{
+    type InputHandoffs = Prev::InputHandoffs;
+
+    fn build<'slf, 'hof>(
+        &'slf mut self,
+        handoffs: <Self::InputHandoffs as HandoffList>::RecvCtx<'hof>,
+    ) -> Self::Build<'slf, 'hof> {
+        self.prev.build(handoffs).map(|x| (self.func)(x))
+    }
+}

--- a/hydroflow/src/builder/build/pull_map.rs
+++ b/hydroflow/src/builder/build/pull_map.rs
@@ -23,7 +23,7 @@ where
 type PullBuildImpl<'slf, 'hof, Prev, Func, Out>
 where
     Prev: PullBuild,
-= std::iter::Map<Prev::Build<'slf, 'hof>, impl 'slf + FnMut(Prev::ItemOut) -> Out>;
+= std::iter::Map<Prev::Build<'slf, 'hof>, impl FnMut(Prev::ItemOut) -> Out>;
 
 impl<Prev, Func, Out> PullBuildBase for MapPullBuild<Prev, Func>
 where

--- a/hydroflow/src/builder/build/push_filter.rs
+++ b/hydroflow/src/builder/build/push_filter.rs
@@ -1,0 +1,52 @@
+use super::{PushBuild, PushBuildBase};
+
+use crate::compiled::filter::Filter;
+use crate::scheduled::handoff::HandoffList;
+
+pub struct FilterPushBuild<Next, Func>
+where
+    Next: PushBuild,
+    Func: FnMut(&Next::ItemIn) -> bool,
+{
+    next: Next,
+    func: Func,
+}
+impl<Next, Func> FilterPushBuild<Next, Func>
+where
+    Next: PushBuild,
+    Func: FnMut(&Next::ItemIn) -> bool,
+{
+    pub fn new(next: Next, func: Func) -> Self {
+        Self { next, func }
+    }
+}
+
+#[allow(type_alias_bounds)]
+type PushBuildImpl<'slf, 'hof, Next, Func>
+where
+    Next: PushBuild,
+= Filter<Next::ItemIn, impl 'slf + FnMut(&Next::ItemIn) -> bool, Next::Build<'slf, 'hof>>;
+
+impl<Next, Func> PushBuildBase for FilterPushBuild<Next, Func>
+where
+    Next: PushBuild,
+    Func: FnMut(&Next::ItemIn) -> bool,
+{
+    type ItemIn = Next::ItemIn;
+    type Build<'slf, 'hof> = PushBuildImpl<'slf, 'hof, Next, Func>;
+}
+
+impl<Next, Func> PushBuild for FilterPushBuild<Next, Func>
+where
+    Next: PushBuild,
+    Func: FnMut(&Next::ItemIn) -> bool,
+{
+    type OutputHandoffs = Next::OutputHandoffs;
+
+    fn build<'slf, 'hof>(
+        &'slf mut self,
+        handoffs: <Self::OutputHandoffs as HandoffList>::SendCtx<'hof>,
+    ) -> Self::Build<'slf, 'hof> {
+        Filter::new(|x| (self.func)(x), self.next.build(handoffs))
+    }
+}

--- a/hydroflow/src/builder/build/push_filter.rs
+++ b/hydroflow/src/builder/build/push_filter.rs
@@ -25,7 +25,7 @@ where
 type PushBuildImpl<'slf, 'hof, Next, Func>
 where
     Next: PushBuild,
-= Filter<Next::ItemIn, impl 'slf + FnMut(&Next::ItemIn) -> bool, Next::Build<'slf, 'hof>>;
+= Filter<Next::ItemIn, impl FnMut(&Next::ItemIn) -> bool, Next::Build<'slf, 'hof>>;
 
 impl<Next, Func> PushBuildBase for FilterPushBuild<Next, Func>
 where

--- a/hydroflow/src/builder/build/push_flat_map.rs
+++ b/hydroflow/src/builder/build/push_flat_map.rs
@@ -32,7 +32,7 @@ where
 type PushBuildImpl<'slf, 'hof, Next, Func, In, Out>
 where
     Next: PushBuild,
-= FlatMap<In, Out, impl 'slf + FnMut(In) -> Out, Next::Build<'slf, 'hof>>;
+= FlatMap<In, Out, impl FnMut(In) -> Out, Next::Build<'slf, 'hof>>;
 
 impl<Next, Func, In, Out> PushBuildBase for FlatMapPushBuild<Next, Func, In>
 where

--- a/hydroflow/src/builder/build/push_flat_map.rs
+++ b/hydroflow/src/builder/build/push_flat_map.rs
@@ -1,0 +1,61 @@
+use super::{PushBuild, PushBuildBase};
+
+use std::marker::PhantomData;
+
+use crate::compiled::flat_map::FlatMap;
+use crate::scheduled::handoff::HandoffList;
+
+pub struct FlatMapPushBuild<Next, Func, In>
+where
+    Next: PushBuild,
+{
+    next: Next,
+    func: Func,
+    _phantom: PhantomData<fn(In)>,
+}
+impl<Next, Func, In, Out> FlatMapPushBuild<Next, Func, In>
+where
+    Next: PushBuild,
+    Func: FnMut(In) -> Out,
+    Out: IntoIterator<Item = Next::ItemIn>,
+{
+    pub fn new(next: Next, func: Func) -> Self {
+        Self {
+            next,
+            func,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+#[allow(type_alias_bounds)]
+type PushBuildImpl<'slf, 'hof, Next, Func, In, Out>
+where
+    Next: PushBuild,
+= FlatMap<In, Out, impl 'slf + FnMut(In) -> Out, Next::Build<'slf, 'hof>>;
+
+impl<Next, Func, In, Out> PushBuildBase for FlatMapPushBuild<Next, Func, In>
+where
+    Next: PushBuild,
+    Func: FnMut(In) -> Out,
+    Out: IntoIterator<Item = Next::ItemIn>,
+{
+    type ItemIn = In;
+    type Build<'slf, 'hof> = PushBuildImpl<'slf, 'hof, Next, Func, In, Out>;
+}
+
+impl<Next, Func, In, Out> PushBuild for FlatMapPushBuild<Next, Func, In>
+where
+    Next: PushBuild,
+    Func: FnMut(In) -> Out,
+    Out: IntoIterator<Item = Next::ItemIn>,
+{
+    type OutputHandoffs = Next::OutputHandoffs;
+
+    fn build<'slf, 'hof>(
+        &'slf mut self,
+        handoffs: <Self::OutputHandoffs as HandoffList>::SendCtx<'hof>,
+    ) -> Self::Build<'slf, 'hof> {
+        FlatMap::new(|x| (self.func)(x), self.next.build(handoffs))
+    }
+}

--- a/hydroflow/src/builder/build/push_for_each.rs
+++ b/hydroflow/src/builder/build/push_for_each.rs
@@ -1,0 +1,51 @@
+use super::{PushBuild, PushBuildBase};
+
+use std::marker::PhantomData;
+
+use crate::compiled::for_each::ForEach;
+use crate::scheduled::handoff::HandoffList;
+use crate::tt;
+
+pub struct ForEachPushBuild<Func, In>
+where
+    Func: FnMut(In),
+{
+    func: Func,
+    _phantom: PhantomData<fn(In)>,
+}
+impl<Func, In> ForEachPushBuild<Func, In>
+where
+    Func: FnMut(In),
+{
+    pub fn new(func: Func) -> Self {
+        Self {
+            func,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+#[allow(type_alias_bounds)]
+type PushBuildImpl<'slf, 'hof, Func, In> = ForEach<In, impl FnMut(In)>;
+
+impl<Func, In> PushBuildBase for ForEachPushBuild<Func, In>
+where
+    Func: FnMut(In),
+{
+    type ItemIn = In;
+    type Build<'slf, 'hof> = PushBuildImpl<'slf, 'hof, Func, In>;
+}
+
+impl<Func, In> PushBuild for ForEachPushBuild<Func, In>
+where
+    Func: FnMut(In),
+{
+    type OutputHandoffs = tt!();
+
+    fn build<'slf, 'hof>(
+        &'slf mut self,
+        (): <Self::OutputHandoffs as HandoffList>::SendCtx<'hof>,
+    ) -> Self::Build<'slf, 'hof> {
+        ForEach::new(|x| (self.func)(x))
+    }
+}

--- a/hydroflow/src/builder/build/push_handoff.rs
+++ b/hydroflow/src/builder/build/push_handoff.rs
@@ -1,0 +1,57 @@
+use super::{PushBuild, PushBuildBase};
+
+use std::marker::PhantomData;
+
+use crate::compiled::push_handoff::PushHandoff;
+use crate::scheduled::handoff::{CanReceive, Handoff, HandoffList};
+use crate::{tl, tt};
+
+pub struct HandoffPushBuild<Hof, In>
+where
+    Hof: Handoff + CanReceive<In>,
+{
+    _phantom: PhantomData<fn(Hof, In)>,
+}
+
+impl<Hof, In> Default for HandoffPushBuild<Hof, In>
+where
+    Hof: Handoff + CanReceive<In>,
+{
+    fn default() -> Self {
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<Hof, In> HandoffPushBuild<Hof, In>
+where
+    Hof: Handoff + CanReceive<In>,
+{
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+impl<Hof, In> PushBuildBase for HandoffPushBuild<Hof, In>
+where
+    Hof: Handoff + CanReceive<In>,
+{
+    type ItemIn = In;
+    type Build<'slf, 'hof> = PushHandoff<'hof, Hof, In>;
+}
+
+impl<Hof, In> PushBuild for HandoffPushBuild<Hof, In>
+where
+    Hof: Handoff + CanReceive<In>,
+{
+    type OutputHandoffs = tt!(Hof);
+
+    fn build<'slf, 'hof>(
+        &'slf mut self,
+        handoffs: <Self::OutputHandoffs as HandoffList>::SendCtx<'hof>,
+    ) -> Self::Build<'slf, 'hof> {
+        let tl!(handoff) = handoffs;
+        PushHandoff::new(handoff)
+    }
+}

--- a/hydroflow/src/builder/build/push_map.rs
+++ b/hydroflow/src/builder/build/push_map.rs
@@ -1,0 +1,59 @@
+use super::{PushBuild, PushBuildBase};
+
+use std::marker::PhantomData;
+
+use crate::compiled::map::Map;
+use crate::scheduled::handoff::HandoffList;
+
+pub struct MapPushBuild<Next, Func, In>
+where
+    Next: PushBuild,
+    Func: FnMut(In) -> Next::ItemIn,
+{
+    next: Next,
+    func: Func,
+    _phantom: PhantomData<fn(In)>,
+}
+impl<Next, Func, In> MapPushBuild<Next, Func, In>
+where
+    Next: PushBuild,
+    Func: FnMut(In) -> Next::ItemIn,
+{
+    pub fn new(next: Next, func: Func) -> Self {
+        Self {
+            next,
+            func,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+#[allow(type_alias_bounds)]
+type PushBuildImpl<'slf, 'hof, Next, Func, In>
+where
+    Next: PushBuild,
+= Map<In, Next::ItemIn, impl 'slf + FnMut(In) -> Next::ItemIn, Next::Build<'slf, 'hof>>;
+
+impl<Next, Func, In> PushBuildBase for MapPushBuild<Next, Func, In>
+where
+    Next: PushBuild,
+    Func: FnMut(In) -> Next::ItemIn,
+{
+    type ItemIn = In;
+    type Build<'slf, 'hof> = PushBuildImpl<'slf, 'hof, Next, Func, In>;
+}
+
+impl<Next, Func, In> PushBuild for MapPushBuild<Next, Func, In>
+where
+    Next: PushBuild,
+    Func: FnMut(In) -> Next::ItemIn,
+{
+    type OutputHandoffs = Next::OutputHandoffs;
+
+    fn build<'slf, 'hof>(
+        &'slf mut self,
+        handoffs: <Self::OutputHandoffs as HandoffList>::SendCtx<'hof>,
+    ) -> Self::Build<'slf, 'hof> {
+        Map::new(|x| (self.func)(x), self.next.build(handoffs))
+    }
+}

--- a/hydroflow/src/builder/build/push_map.rs
+++ b/hydroflow/src/builder/build/push_map.rs
@@ -32,7 +32,7 @@ where
 type PushBuildImpl<'slf, 'hof, Next, Func, In>
 where
     Next: PushBuild,
-= Map<In, Next::ItemIn, impl 'slf + FnMut(In) -> Next::ItemIn, Next::Build<'slf, 'hof>>;
+= Map<In, Next::ItemIn, impl FnMut(In) -> Next::ItemIn, Next::Build<'slf, 'hof>>;
 
 impl<Next, Func, In> PushBuildBase for MapPushBuild<Next, Func, In>
 where

--- a/hydroflow/src/builder/build/push_tee.rs
+++ b/hydroflow/src/builder/build/push_tee.rs
@@ -1,0 +1,58 @@
+use super::{PushBuild, PushBuildBase};
+
+use crate::compiled::tee::Tee;
+use crate::scheduled::handoff::{HandoffList, HandoffListSplit};
+use crate::scheduled::type_list::Extend;
+
+pub struct TeePushBuild<NextA, NextB>
+where
+    NextA: PushBuild,
+    NextB: PushBuild<ItemIn = NextA::ItemIn>,
+    NextA::ItemIn: Clone,
+{
+    next_a: NextA,
+    next_b: NextB,
+}
+impl<NextA, NextB> TeePushBuild<NextA, NextB>
+where
+    NextA: PushBuild,
+    NextB: PushBuild<ItemIn = NextA::ItemIn>,
+    NextA::ItemIn: Clone,
+{
+    pub fn new(next_a: NextA, next_b: NextB) -> Self {
+        Self { next_a, next_b }
+    }
+}
+
+impl<NextA, NextB> PushBuildBase for TeePushBuild<NextA, NextB>
+where
+    NextA: PushBuild,
+    NextB: PushBuild<ItemIn = NextA::ItemIn>,
+    NextA::ItemIn: Clone,
+{
+    type ItemIn = NextA::ItemIn;
+    type Build<'slf, 'hof> = Tee<Self::ItemIn, NextA::Build<'slf, 'hof>, NextB::Build<'slf, 'hof>>;
+}
+
+impl<NextA, NextB> PushBuild for TeePushBuild<NextA, NextB>
+where
+    NextA: PushBuild,
+    NextB: PushBuild<ItemIn = NextA::ItemIn>,
+    NextA::ItemIn: Clone,
+    NextA::OutputHandoffs: Extend<NextB::OutputHandoffs>,
+    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended:
+        HandoffList + HandoffListSplit<NextA::OutputHandoffs, Suffix = NextB::OutputHandoffs>,
+{
+    type OutputHandoffs = <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended;
+
+    fn build<'slf, 'hof>(
+        &'slf mut self,
+        input: <Self::OutputHandoffs as HandoffList>::SendCtx<'hof>,
+    ) -> Self::Build<'slf, 'hof> {
+        let (input_a, input_b) =
+            <Self::OutputHandoffs as HandoffListSplit<_>>::split_send_ctx(input);
+        let build_a = self.next_a.build(input_a);
+        let build_b = self.next_b.build(input_b);
+        Tee::new(build_a, build_b)
+    }
+}

--- a/hydroflow/src/builder/connect/mod.rs
+++ b/hydroflow/src/builder/connect/mod.rs
@@ -1,0 +1,25 @@
+//! Internal "connects" which connect input/output ports to implement the Surface API. For more info see [super].
+
+mod pull_binary;
+mod pull_handoff;
+mod push_binary;
+mod push_handoff;
+mod push_null;
+
+pub use pull_binary::BinaryPullConnect;
+pub use pull_handoff::HandoffPullConnect;
+pub use push_binary::BinaryPushConnect;
+pub use push_handoff::HandoffPushConnect;
+pub use push_null::NullPushConnect;
+
+use crate::scheduled::handoff::HandoffList;
+
+pub trait PullConnect {
+    type InputHandoffs: HandoffList;
+    fn connect(self, ports: <Self::InputHandoffs as HandoffList>::InputPort);
+}
+
+pub trait PushConnect {
+    type OutputHandoffs: HandoffList;
+    fn connect(self, ports: <Self::OutputHandoffs as HandoffList>::OutputPort);
+}

--- a/hydroflow/src/builder/connect/pull_binary.rs
+++ b/hydroflow/src/builder/connect/pull_binary.rs
@@ -1,0 +1,40 @@
+use super::PullConnect;
+
+use crate::scheduled::handoff::{HandoffList, HandoffListSplit};
+use crate::scheduled::type_list::Extend;
+
+pub struct BinaryPullConnect<PrevA, PrevB>
+where
+    PrevA: PullConnect,
+    PrevB: PullConnect,
+{
+    prev_a: PrevA,
+    prev_b: PrevB,
+}
+
+impl<PrevA, PrevB> BinaryPullConnect<PrevA, PrevB>
+where
+    PrevA: PullConnect,
+    PrevB: PullConnect,
+{
+    pub fn new(prev_a: PrevA, prev_b: PrevB) -> Self {
+        Self { prev_a, prev_b }
+    }
+}
+
+impl<PrevA, PrevB> PullConnect for BinaryPullConnect<PrevA, PrevB>
+where
+    PrevA: PullConnect,
+    PrevB: PullConnect,
+    PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        HandoffList + HandoffListSplit<PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
+{
+    type InputHandoffs = <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended;
+    fn connect(self, ports: <Self::InputHandoffs as HandoffList>::InputPort) {
+        let (ports_a, ports_b) =
+            <Self::InputHandoffs as HandoffListSplit<_>>::split_input_port(ports);
+        self.prev_a.connect(ports_a);
+        self.prev_b.connect(ports_b);
+    }
+}

--- a/hydroflow/src/builder/connect/pull_handoff.rs
+++ b/hydroflow/src/builder/connect/pull_handoff.rs
@@ -1,0 +1,36 @@
+use super::PullConnect;
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use crate::scheduled::ctx::InputPort;
+use crate::scheduled::handoff::{Handoff, HandoffList};
+use crate::{tl, tt};
+
+pub struct HandoffPullConnect<Hof>
+where
+    Hof: Handoff,
+{
+    port: Rc<Cell<Option<InputPort<Hof>>>>,
+}
+
+impl<Hof> HandoffPullConnect<Hof>
+where
+    Hof: Handoff,
+{
+    pub fn new(port: Rc<Cell<Option<InputPort<Hof>>>>) -> Self {
+        Self { port }
+    }
+}
+
+impl<Hof> PullConnect for HandoffPullConnect<Hof>
+where
+    Hof: Handoff,
+{
+    type InputHandoffs = tt!(Hof);
+    fn connect(self, ports: <Self::InputHandoffs as HandoffList>::InputPort) {
+        let tl!(port) = ports;
+        let old_port = self.port.replace(Some(port));
+        assert!(old_port.is_none());
+    }
+}

--- a/hydroflow/src/builder/connect/push_binary.rs
+++ b/hydroflow/src/builder/connect/push_binary.rs
@@ -1,0 +1,40 @@
+use super::PushConnect;
+
+use crate::scheduled::handoff::{HandoffList, HandoffListSplit};
+use crate::scheduled::type_list::Extend;
+
+pub struct BinaryPushConnect<PrevA, PrevB>
+where
+    PrevA: PushConnect,
+    PrevB: PushConnect,
+{
+    prev_a: PrevA,
+    prev_b: PrevB,
+}
+
+impl<PrevA, PrevB> BinaryPushConnect<PrevA, PrevB>
+where
+    PrevA: PushConnect,
+    PrevB: PushConnect,
+{
+    pub fn new(prev_a: PrevA, prev_b: PrevB) -> Self {
+        Self { prev_a, prev_b }
+    }
+}
+
+impl<PrevA, PrevB> PushConnect for BinaryPushConnect<PrevA, PrevB>
+where
+    PrevA: PushConnect,
+    PrevB: PushConnect,
+    PrevA::OutputHandoffs: Extend<PrevB::OutputHandoffs>,
+    <PrevA::OutputHandoffs as Extend<PrevB::OutputHandoffs>>::Extended:
+        HandoffList + HandoffListSplit<PrevA::OutputHandoffs, Suffix = PrevB::OutputHandoffs>,
+{
+    type OutputHandoffs = <PrevA::OutputHandoffs as Extend<PrevB::OutputHandoffs>>::Extended;
+    fn connect(self, ports: <Self::OutputHandoffs as HandoffList>::OutputPort) {
+        let (ports_a, ports_b) =
+            <Self::OutputHandoffs as HandoffListSplit<_>>::split_output_port(ports);
+        self.prev_a.connect(ports_a);
+        self.prev_b.connect(ports_b);
+    }
+}

--- a/hydroflow/src/builder/connect/push_handoff.rs
+++ b/hydroflow/src/builder/connect/push_handoff.rs
@@ -1,0 +1,41 @@
+use super::PushConnect;
+
+use std::cell::Cell;
+use std::marker::PhantomData;
+use std::rc::Rc;
+
+use crate::scheduled::ctx::OutputPort;
+use crate::scheduled::handoff::{Handoff, HandoffList};
+use crate::{tl, tt};
+
+pub struct HandoffPushConnect<Hof>
+where
+    Hof: Handoff,
+{
+    port: Rc<Cell<Option<OutputPort<Hof>>>>,
+    _phantom: PhantomData<fn(Hof)>,
+}
+
+impl<Hof> HandoffPushConnect<Hof>
+where
+    Hof: Handoff,
+{
+    pub fn new(port: Rc<Cell<Option<OutputPort<Hof>>>>) -> Self {
+        Self {
+            port,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<Hof> PushConnect for HandoffPushConnect<Hof>
+where
+    Hof: Handoff,
+{
+    type OutputHandoffs = tt!(Hof);
+    fn connect(self, ports: <Self::OutputHandoffs as HandoffList>::OutputPort) {
+        let tl!(port) = ports;
+        let old_port = self.port.replace(Some(port));
+        assert!(old_port.is_none());
+    }
+}

--- a/hydroflow/src/builder/connect/push_null.rs
+++ b/hydroflow/src/builder/connect/push_null.rs
@@ -1,0 +1,18 @@
+use super::PushConnect;
+
+use crate::scheduled::handoff::HandoffList;
+use crate::tt;
+
+#[derive(Default)]
+pub struct NullPushConnect;
+
+impl NullPushConnect {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+impl PushConnect for NullPushConnect {
+    type OutputHandoffs = tt!();
+    fn connect(self, (): <Self::OutputHandoffs as HandoffList>::OutputPort) {}
+}

--- a/hydroflow/src/builder/hydroflow_builder.rs
+++ b/hydroflow/src/builder/hydroflow_builder.rs
@@ -1,0 +1,122 @@
+use super::build::{PullBuild, PushBuild};
+use super::connect::{PullConnect, PushConnect};
+use super::surface::pivot::PivotSurface;
+
+use std::rc::Rc;
+use std::sync::mpsc::SyncSender;
+
+use crate::compiled::pivot::Pivot;
+use crate::scheduled::graph::Hydroflow;
+use crate::scheduled::graph_ext::GraphExt;
+use crate::scheduled::handoff::{CanReceive, Handoff};
+use crate::scheduled::input::Input;
+
+use super::surface::pull_handoff::HandoffPullSurface;
+use super::surface::push_handoff::HandoffPushSurfaceReversed;
+use super::surface::push_start::StartPushSurface;
+use super::surface::{PullSurface, PushSurfaceReversed};
+
+/// The user-facing entry point for the Surface API.
+#[derive(Default)]
+pub struct HydroflowBuilder {
+    hydroflow: Hydroflow,
+    // TODO(mingwei): use a dedicated trait instead of FnOnce?
+    handoff_connectors: Vec<Box<dyn FnOnce(&mut Hydroflow)>>,
+}
+impl HydroflowBuilder {
+    /// Creates a handoff, returning push and pull ends which can be chained
+    /// using the Surface API.
+    pub fn make_handoff<H, T>(
+        &mut self,
+    ) -> (HandoffPushSurfaceReversed<H, T>, HandoffPullSurface<H>)
+    where
+        H: Handoff + CanReceive<T>,
+    {
+        let push_port = Default::default();
+        let push = HandoffPushSurfaceReversed::new(Rc::clone(&push_port));
+
+        let pull_port = Default::default();
+        let pull = HandoffPullSurface::new(Rc::clone(&pull_port));
+
+        self.handoff_connectors.push(Box::new(move |hydroflow| {
+            if let (Some(output_port), Some(input_port)) = (push_port.take(), pull_port.take()) {
+                hydroflow.add_edge(output_port, input_port);
+            } else {
+                panic!("Handoff was never connected!!"); // TODO(mingwei): more informative error messages.
+            }
+        }));
+        (push, pull)
+    }
+
+    /// Adds a `pivot` created via the Surface API.
+    pub fn add_subgraph<Pull, Push>(&mut self, pivot: PivotSurface<Pull, Push>)
+    where
+        Pull: 'static + PullSurface,
+        Push: 'static + PushSurfaceReversed<ItemIn = Pull::ItemOut>,
+    {
+        let ((pull_connect, push_connect), (mut pull_build, mut push_build)) = pivot.into_parts();
+
+        let (input_ports, output_ports) = self
+            .hydroflow
+            .add_subgraph::<_, Pull::InputHandoffs, Push::OutputHandoffs>(
+                move |_ctx, recv_ctx, send_ctx| {
+                    let pull = pull_build.build(recv_ctx);
+                    let push = push_build.build(send_ctx);
+                    let pivot = Pivot::new(pull, push);
+                    pivot.run();
+                },
+            );
+
+        pull_connect.connect(input_ports);
+        push_connect.connect(output_ports);
+    }
+
+    /// Creates a new external channel input.
+    pub fn add_channel_input<T, W>(&mut self) -> (Input<T, SyncSender<T>>, HandoffPullSurface<W>)
+    where
+        T: 'static,
+        W: 'static + Handoff + CanReceive<T>,
+    {
+        let (input, output_port) = self.hydroflow.add_channel_input();
+
+        let pull_port = Default::default();
+        let pull = HandoffPullSurface::new(Rc::clone(&pull_port));
+
+        self.handoff_connectors.push(Box::new(move |hydroflow| {
+            if let Some(input_port) = pull_port.take() {
+                hydroflow.add_edge(output_port, input_port);
+            } else {
+                panic!("Channel input was never connected!!"); // TODO(mingwei): more informative error messages.
+            }
+        }));
+
+        (input, pull)
+    }
+
+    pub fn build(mut self) -> Hydroflow {
+        for handoff_connector in self.handoff_connectors {
+            // TODO(mingwei): be more principled with this.
+            (handoff_connector)(&mut self.hydroflow);
+        }
+        self.hydroflow
+    }
+
+    /// Start a new branch for teeing.
+    ///
+    /// For example:
+    /// ```ignore
+    /// my_ints
+    ///     .tee(
+    ///         builder
+    ///             .start_tee()
+    ///             .filter(|&x| 0 == x % 2)
+    ///             .for_each(|x| println!("Even: {}", x)),
+    ///         builder
+    ///             .start_tee()
+    ///             .filter(|&x| 1 == x % 2)
+    ///             .for_each(|x| println!("Odd: {}", x)));
+    /// ```
+    pub fn start_tee<T>(&self) -> StartPushSurface<T> {
+        StartPushSurface::new()
+    }
+}

--- a/hydroflow/src/builder/mod.rs
+++ b/hydroflow/src/builder/mod.rs
@@ -1,0 +1,244 @@
+//! Hydroflow's Surface API.
+//!
+//! ## Internal Documentation
+//!
+//! Due to the limitations of type-level programming in Rust, this code is
+//! "baklava" code containing lot of layers. Each layer does one thing, then
+//! constructs the next layer(s) down. This table describes what each layer
+//! does and is named. Layers are listed starting from the highest
+//! (user-facing API) layer and ending with the lowest (code-running) layer.
+//!
+//! ### Layer Structure
+//! ```text
+//!               (A) Surface API
+//!         (B) (Push Surface Reversed*)
+//!                  /            \
+//!                 /              \
+//!        (C) Connector   (D) Subgraph Builder
+//!                                  |
+//!                       (E) Iterator/Pusherator
+//! ```
+//! <sup>*Only used with `Push` to reverse the ownership direction.</sup>
+//!
+//! ### Layer Descriptions
+//! <table>
+//! <tr>
+//!     <th rowspan="2">Layer</th>
+//!     <th rowspan="2">Purpose</th>
+//!     <th colspan="2">Naming</th>
+//! </tr>
+//! <tr>
+//!    <th>Pull</th>
+//!    <th>Push</th>
+//! </tr>
+//! <tr>
+//!     <td>(A) The Surface API</td>
+//!     <td rowspan="2">
+//!         &bull; Presents a clean functional-chaining API for users.<br>
+//!         &bull; Consumed to simultaneously create a (C) connector and (D) builder.<br>
+//!         &bull; <strong>Push Only</strong>: Extra layer needed to reverse ownership order.
+//!     </td>
+//!     <td><code>PullSurface</code></td>
+//!     <td><code>PushSurface</code></td>
+//! </tr>
+//! <tr>
+//!     <td>(B) Push Surface Reversed</td>
+//!     <td>N/A</td>
+//!     <td><code>PushSurfaceReversed</code></td>
+//! </tr>
+//! <tr>
+//!     <td>(C) Connectors</td>
+//!     <td>
+//!         &bull; Connects <code>OutputPort</code>s and <code>InputPort</code>s, splits type lists in order to do so.<br>
+//!         &bull; Does not go to any lower layers.<br>
+//!         &bull; Uses the input/output <code>HandoffList</code> variadic type.
+//!     </td>
+//!     <td><code>PullConnect</code></td>
+//!     <td><code>PushConnect</code></td>
+//! </tr>
+//! <tr>
+//!     <td>(D) Subgraph Builders</td>
+//!     <td>
+//!         &bull; On each subgraph invocation, constructs the (E) iterators and pivot which will be run.<br>
+//!         &bull; Is owned by the subgraph task, lends closures to (E) iterators.<br>
+//!         &bull; Uses the input/output <code>HandoffList</code> variadic type.
+//!     </td>
+//!     <td><code>PullBuild</code></td>
+//!     <td><code>PushBuild</code></td>
+//! </tr>
+//! <tr>
+//!     <td>(E) Iterators</td>
+//!     <td>
+//!         &bull; Runs code on individual dataflow elements, in the case of dataflow.<br>
+//!         &bull; In the future, will correspond to semilattice morphisms alternatively.
+//!     </td>
+//!     <td><code>std::iter::Iterator</code></td>
+//!     <td><code>crate::compiled::Pusherator</code></td>
+//! </tr>
+//! </table>
+//!
+//! ### How the code actually runs
+//!
+//! The layers are used in [HydroflowBuilder::add_subgraph]. The method
+//! receives a pivot with `PullSurface` and `PushSurfaceReversed` halves. Then
+//! `into_parts()` splits them into the build half and the connector half.
+//! The build half is used to create the subgraph which gives back
+//! input/output ports. Then the connector half is used to connect up those
+//! ports.
+
+pub mod build;
+pub mod connect;
+pub mod surface;
+
+mod hydroflow_builder;
+pub use hydroflow_builder::HydroflowBuilder;
+
+/// Prelude to quick-import items needed for using the Surface API.
+///
+/// Usage:
+/// ```rust
+/// use hydroflow::builder::prelude::*;
+/// ```
+pub mod prelude {
+    pub use super::surface::{BaseSurface, PullSurface, PushSurface};
+    pub use super::HydroflowBuilder;
+}
+
+#[test]
+fn test_teeing() {
+    use crate::scheduled::handoff::VecHandoff;
+    use prelude::*;
+
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    let mut builder = HydroflowBuilder::default();
+    let (ingress_send, ingress) = builder.add_channel_input::<Option<usize>, VecHandoff<_>>();
+
+    let output_evn: Rc<RefCell<Vec<usize>>> = Default::default();
+    let output_odd: Rc<RefCell<Vec<usize>>> = Default::default();
+
+    let output_evn_take = Rc::clone(&output_evn);
+    let output_odd_take = Rc::clone(&output_odd);
+
+    let sg = ingress
+        .flat_map(std::convert::identity)
+        .flat_map(|x| [11 * x, x])
+        .pivot()
+        .tee(
+            builder
+                .start_tee()
+                .filter(|&x| 0 == x % 2)
+                .for_each(move |x| output_evn_take.borrow_mut().push(x)),
+            builder
+                .start_tee()
+                .filter(|&x| 1 == x % 2)
+                .for_each(move |x| output_odd_take.borrow_mut().push(x)),
+        );
+    builder.add_subgraph(sg);
+
+    let mut hydroflow = builder.build();
+    {
+        for x in 1..9 {
+            ingress_send.give(Some(x));
+        }
+        ingress_send.flush();
+
+        hydroflow.tick();
+
+        assert_eq!(&[22, 2, 44, 4, 66, 6, 88, 8], &**output_evn.borrow());
+        assert_eq!(&[11, 1, 33, 3, 55, 5, 77, 7], &**output_odd.borrow());
+    }
+}
+
+#[test]
+fn test_covid() {
+    use crate::scheduled::handoff::VecHandoff;
+    use prelude::*;
+
+    type Pid = usize;
+    type Name = &'static str;
+    type Phone = &'static str;
+    type DateTime = usize;
+
+    const TRANSMISSIBLE_DURATION: usize = 14;
+
+    let mut builder = HydroflowBuilder::default();
+
+    let (loop_send, loop_recv) = builder.make_handoff::<VecHandoff<(Pid, DateTime)>, _>();
+    let (notifs_send, notifs_recv) = builder.make_handoff::<VecHandoff<(Pid, DateTime)>, _>();
+
+    let (diagnosed_send, diagnosed) =
+        builder.add_channel_input::<Option<(Pid, (DateTime, DateTime))>, VecHandoff<_>>();
+    let (contacts_send, contacts) =
+        builder.add_channel_input::<Option<(Pid, Pid, DateTime)>, VecHandoff<_>>();
+    let (peoples_send, peoples) =
+        builder.add_channel_input::<Option<(Pid, (Name, Phone))>, VecHandoff<_>>();
+
+    let exposed = loop_recv
+        .flat_map(std::convert::identity)
+        .map(|(pid, t)| (pid, (t, t + TRANSMISSIBLE_DURATION)))
+        .chain(diagnosed.flat_map(std::convert::identity));
+
+    builder.add_subgraph(
+        contacts
+            .flat_map(std::convert::identity)
+            .flat_map(|(pid_a, pid_b, t)| [(pid_a, (pid_b, t)), (pid_b, (pid_a, t))])
+            .join(exposed)
+            .filter(|(_pid_a, (_pid_b, t_contact), (t_from, t_to))| {
+                (t_from..=t_to).contains(&t_contact)
+            })
+            .map(|(_pid_a, pid_b_t_contact, _t_from_to)| pid_b_t_contact)
+            .pivot()
+            .map(Some) // For handoff CanReceive.
+            .tee(notifs_send, loop_send),
+    );
+
+    builder.add_subgraph(
+        notifs_recv
+            .flat_map(std::convert::identity)
+            .join(peoples.flat_map(std::convert::identity))
+            .pivot()
+            .for_each(|(_pid, exposure_time, (name, phone))| {
+                println!(
+                    "[{}] To {}: Possible Exposure at t = {}",
+                    name, phone, exposure_time
+                );
+            }),
+    );
+
+    let mut hydroflow = builder.build();
+    {
+        peoples_send.give(Some((101, ("Mingwei S", "+1 650 555 7283"))));
+        peoples_send.give(Some((102, ("Justin J", "+1 519 555 3458"))));
+        peoples_send.give(Some((103, ("Mae M", "+1 912 555 9129"))));
+        peoples_send.flush();
+
+        contacts_send.give(Some((101, 102, 1031))); // Mingwei + Justin
+        contacts_send.give(Some((101, 201, 1027))); // Mingwei + Joe
+        contacts_send.flush();
+
+        let mae_diag_datetime = 1022;
+
+        diagnosed_send.give(Some((
+            103, // Mae
+            (
+                mae_diag_datetime,
+                mae_diag_datetime + TRANSMISSIBLE_DURATION,
+            ),
+        )));
+        diagnosed_send.flush();
+
+        hydroflow.tick();
+
+        contacts_send.give(Some((101, 103, mae_diag_datetime + 6))); // Mingwei + Mae
+        contacts_send.flush();
+
+        hydroflow.tick();
+
+        peoples_send.give(Some((103, ("Joe H", "+1 510 555 9999"))));
+        peoples_send.flush();
+
+        hydroflow.tick();
+    }
+}

--- a/hydroflow/src/builder/surface/filter.rs
+++ b/hydroflow/src/builder/surface/filter.rs
@@ -1,0 +1,101 @@
+use super::{BaseSurface, PullSurface, PushSurface, PushSurfaceReversed};
+
+use crate::builder::build::pull_filter::FilterPullBuild;
+use crate::builder::build::push_filter::FilterPushBuild;
+
+pub struct FilterSurface<Prev, Func>
+where
+    Prev: BaseSurface,
+{
+    prev: Prev,
+    func: Func,
+}
+impl<Prev, Func> FilterSurface<Prev, Func>
+where
+    Prev: BaseSurface,
+    Func: FnMut(&Prev::ItemOut) -> bool,
+{
+    pub fn new(prev: Prev, func: Func) -> Self {
+        Self { prev, func }
+    }
+}
+
+impl<Prev, Func> BaseSurface for FilterSurface<Prev, Func>
+where
+    Prev: BaseSurface,
+    Func: FnMut(&Prev::ItemOut) -> bool,
+{
+    type ItemOut = Prev::ItemOut;
+}
+
+impl<Prev, Func> PullSurface for FilterSurface<Prev, Func>
+where
+    Prev: PullSurface,
+    Func: FnMut(&Prev::ItemOut) -> bool,
+{
+    type InputHandoffs = Prev::InputHandoffs;
+
+    type Connect = Prev::Connect;
+    type Build = FilterPullBuild<Prev::Build, Func>;
+
+    fn into_parts(self) -> (Self::Connect, Self::Build) {
+        let (connect, build) = self.prev.into_parts();
+        let build = FilterPullBuild::new(build, self.func);
+        (connect, build)
+    }
+}
+
+impl<Prev, Func> PushSurface for FilterSurface<Prev, Func>
+where
+    Prev: PushSurface,
+    Func: FnMut(&Prev::ItemOut) -> bool,
+{
+    type Output<Next>
+    where
+        Next: PushSurfaceReversed<ItemIn = Self::ItemOut>,
+    = Prev::Output<FilterPushSurfaceReversed<Next, Func>>;
+
+    fn reverse<Next>(self, next: Next) -> Self::Output<Next>
+    where
+        Next: PushSurfaceReversed<ItemIn = Self::ItemOut>,
+    {
+        self.prev
+            .reverse(FilterPushSurfaceReversed::new(next, self.func))
+    }
+}
+
+pub struct FilterPushSurfaceReversed<Next, Func>
+where
+    Next: PushSurfaceReversed,
+{
+    next: Next,
+    func: Func,
+}
+impl<Next, Func> FilterPushSurfaceReversed<Next, Func>
+where
+    Next: PushSurfaceReversed,
+    Func: FnMut(&Next::ItemIn) -> bool,
+{
+    pub fn new(next: Next, func: Func) -> Self {
+        Self { next, func }
+    }
+}
+
+impl<Next, Func> PushSurfaceReversed for FilterPushSurfaceReversed<Next, Func>
+where
+    Next: PushSurfaceReversed,
+    Func: FnMut(&Next::ItemIn) -> bool,
+{
+    type OutputHandoffs = Next::OutputHandoffs;
+
+    type ItemIn = Next::ItemIn;
+
+    type Connect = Next::Connect;
+    type Build = FilterPushBuild<Next::Build, Func>;
+
+    fn into_parts(self) -> (Self::Connect, Self::Build) {
+        let (connect, build) = self.next.into_parts();
+        let build = FilterPushBuild::new(build, self.func);
+        (connect, build)
+    }
+}

--- a/hydroflow/src/builder/surface/flat_map.rs
+++ b/hydroflow/src/builder/surface/flat_map.rs
@@ -1,0 +1,114 @@
+use super::{BaseSurface, PullSurface, PushSurface, PushSurfaceReversed};
+
+use std::marker::PhantomData;
+
+use crate::builder::build::pull_flat_map::FlatMapPullBuild;
+use crate::builder::build::push_flat_map::FlatMapPushBuild;
+
+pub struct FlatMapSurface<Prev, Func>
+where
+    Prev: BaseSurface,
+{
+    prev: Prev,
+    func: Func,
+}
+impl<Prev, Func, Out> FlatMapSurface<Prev, Func>
+where
+    Prev: BaseSurface,
+    Func: FnMut(Prev::ItemOut) -> Out,
+    Out: IntoIterator,
+{
+    pub fn new(prev: Prev, func: Func) -> Self {
+        Self { prev, func }
+    }
+}
+
+impl<Prev, Func, Out> BaseSurface for FlatMapSurface<Prev, Func>
+where
+    Prev: BaseSurface,
+    Func: FnMut(Prev::ItemOut) -> Out,
+    Out: IntoIterator,
+{
+    type ItemOut = Out::Item;
+}
+
+impl<Prev, Func, Out> PullSurface for FlatMapSurface<Prev, Func>
+where
+    Prev: PullSurface,
+    Func: FnMut(Prev::ItemOut) -> Out,
+    Out: IntoIterator,
+{
+    type InputHandoffs = Prev::InputHandoffs;
+
+    type Connect = Prev::Connect;
+    type Build = FlatMapPullBuild<Prev::Build, Func>;
+
+    fn into_parts(self) -> (Self::Connect, Self::Build) {
+        let (connect, build) = self.prev.into_parts();
+        let build = FlatMapPullBuild::new(build, self.func);
+        (connect, build)
+    }
+}
+
+impl<Prev, Func, Out> PushSurface for FlatMapSurface<Prev, Func>
+where
+    Prev: PushSurface,
+    Func: FnMut(Prev::ItemOut) -> Out,
+    Out: IntoIterator,
+{
+    type Output<Next>
+    where
+        Next: PushSurfaceReversed<ItemIn = Self::ItemOut>,
+    = Prev::Output<FlatMapPushSurfaceReversed<Next, Func, Prev::ItemOut>>;
+
+    fn reverse<Next>(self, next: Next) -> Self::Output<Next>
+    where
+        Next: PushSurfaceReversed<ItemIn = Self::ItemOut>,
+    {
+        self.prev
+            .reverse(FlatMapPushSurfaceReversed::new(next, self.func))
+    }
+}
+
+pub struct FlatMapPushSurfaceReversed<Next, Func, In>
+where
+    Next: PushSurfaceReversed,
+{
+    next: Next,
+    func: Func,
+    _phantom: PhantomData<fn(In)>,
+}
+impl<Next, Func, In, Out> FlatMapPushSurfaceReversed<Next, Func, In>
+where
+    Next: PushSurfaceReversed,
+    Func: FnMut(In) -> Out,
+    Out: IntoIterator<Item = Next::ItemIn>,
+{
+    pub fn new(next: Next, func: Func) -> Self {
+        Self {
+            next,
+            func,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<Next, Func, In, Out> PushSurfaceReversed for FlatMapPushSurfaceReversed<Next, Func, In>
+where
+    Next: PushSurfaceReversed,
+    Func: FnMut(In) -> Out,
+    Out: IntoIterator<Item = Next::ItemIn>,
+{
+    type OutputHandoffs = Next::OutputHandoffs;
+
+    type ItemIn = In;
+
+    type Connect = Next::Connect;
+    type Build = FlatMapPushBuild<Next::Build, Func, In>;
+
+    fn into_parts(self) -> (Self::Connect, Self::Build) {
+        let (connect, build) = self.next.into_parts();
+        let build = FlatMapPushBuild::new(build, self.func);
+        (connect, build)
+    }
+}

--- a/hydroflow/src/builder/surface/map.rs
+++ b/hydroflow/src/builder/surface/map.rs
@@ -1,0 +1,108 @@
+use super::{BaseSurface, PullSurface, PushSurface, PushSurfaceReversed};
+
+use std::marker::PhantomData;
+
+use crate::builder::build::pull_map::MapPullBuild;
+use crate::builder::build::push_map::MapPushBuild;
+
+pub struct MapSurface<Prev, Func>
+where
+    Prev: BaseSurface,
+{
+    prev: Prev,
+    func: Func,
+}
+impl<Prev, Func, Out> MapSurface<Prev, Func>
+where
+    Prev: BaseSurface,
+    Func: FnMut(Prev::ItemOut) -> Out,
+{
+    pub fn new(prev: Prev, func: Func) -> Self {
+        Self { prev, func }
+    }
+}
+
+impl<Prev, Func, Out> BaseSurface for MapSurface<Prev, Func>
+where
+    Prev: BaseSurface,
+    Func: FnMut(Prev::ItemOut) -> Out,
+{
+    type ItemOut = Out;
+}
+
+impl<Prev, Func, Out> PullSurface for MapSurface<Prev, Func>
+where
+    Prev: PullSurface,
+    Func: FnMut(Prev::ItemOut) -> Out,
+{
+    type InputHandoffs = Prev::InputHandoffs;
+
+    type Connect = Prev::Connect;
+    type Build = MapPullBuild<Prev::Build, Func>;
+
+    fn into_parts(self) -> (Self::Connect, Self::Build) {
+        let (connect, build) = self.prev.into_parts();
+        let build = MapPullBuild::new(build, self.func);
+        (connect, build)
+    }
+}
+
+impl<Prev, Func, Out> PushSurface for MapSurface<Prev, Func>
+where
+    Prev: PushSurface,
+    Func: FnMut(Prev::ItemOut) -> Out,
+{
+    type Output<Next>
+    where
+        Next: PushSurfaceReversed<ItemIn = Self::ItemOut>,
+    = Prev::Output<MapPushSurfaceReversed<Next, Func, Prev::ItemOut>>;
+
+    fn reverse<Next>(self, next: Next) -> Self::Output<Next>
+    where
+        Next: PushSurfaceReversed<ItemIn = Self::ItemOut>,
+    {
+        self.prev
+            .reverse(MapPushSurfaceReversed::new(next, self.func))
+    }
+}
+
+pub struct MapPushSurfaceReversed<Next, Func, In>
+where
+    Next: PushSurfaceReversed,
+{
+    next: Next,
+    func: Func,
+    _phantom: PhantomData<fn(In)>,
+}
+impl<Next, Func, In> MapPushSurfaceReversed<Next, Func, In>
+where
+    Next: PushSurfaceReversed,
+    Func: FnMut(In) -> Next::ItemIn,
+{
+    pub fn new(next: Next, func: Func) -> Self {
+        Self {
+            next,
+            func,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<Next, Func, In> PushSurfaceReversed for MapPushSurfaceReversed<Next, Func, In>
+where
+    Next: PushSurfaceReversed,
+    Func: FnMut(In) -> Next::ItemIn,
+{
+    type OutputHandoffs = Next::OutputHandoffs;
+
+    type ItemIn = In;
+
+    type Connect = Next::Connect;
+    type Build = MapPushBuild<Next::Build, Func, In>;
+
+    fn into_parts(self) -> (Self::Connect, Self::Build) {
+        let (connect, build) = self.next.into_parts();
+        let build = MapPushBuild::new(build, self.func);
+        (connect, build)
+    }
+}

--- a/hydroflow/src/builder/surface/mod.rs
+++ b/hydroflow/src/builder/surface/mod.rs
@@ -1,0 +1,169 @@
+//! Structs used to create the user-facing Surface API.
+//!
+//! Main user-facing traits are [`BaseSurface`], [`PullSurface`], and
+//! [`PushSurface`], which provide an iterator-like API with easy method
+//! chaining. The traits need to be imported when using the Surface API.
+//! You can use the prelude to do this easily:
+//! ```ignore
+//! use hydroflow::build::prelude::*;
+//! ```
+//!
+//! * [`BaseSurface`] provides linear chaining methods like [`BaseSurface::map`], [`BaseSurface::filter`], etc..
+//! * [`PullSurface`] provides methods to combine multiple input streams: [`PullSurface::chain`], [`PullSurface::join`].
+//!     * To switch to push, call [`PullSurface::pivot`].
+//! * [`PushSurface`] provides sink chaining methods and methods to split into multiple output streams: [`PushSurface::tee`], [`PushSurface::for_each`].
+//!
+//! For implementation info see [super].
+
+use super::build::{PullBuild, PushBuild};
+use super::connect::{PullConnect, PushConnect};
+
+pub mod filter;
+pub mod flat_map;
+pub mod map;
+pub mod pivot;
+
+pub mod pull_chain;
+pub mod pull_handoff;
+pub mod pull_join;
+
+pub mod push_for_each;
+pub mod push_handoff;
+pub mod push_pivot;
+pub mod push_start;
+pub mod push_tee;
+
+use std::hash::Hash;
+
+use crate::scheduled::handoff::{HandoffList, HandoffListSplit};
+use crate::scheduled::type_list::Extend;
+
+/// Common trait shared between push and pull surface APIs.
+///
+/// Provides non-push/pull-specific chaining methods.
+pub trait BaseSurface {
+    type ItemOut;
+
+    fn map<Func, Out>(self, func: Func) -> map::MapSurface<Self, Func>
+    where
+        Self: Sized,
+        Func: FnMut(Self::ItemOut) -> Out,
+    {
+        map::MapSurface::new(self, func)
+    }
+
+    fn flat_map<Func, Out>(self, func: Func) -> flat_map::FlatMapSurface<Self, Func>
+    where
+        Self: Sized,
+        Func: FnMut(Self::ItemOut) -> Out,
+        Out: IntoIterator,
+    {
+        flat_map::FlatMapSurface::new(self, func)
+    }
+
+    fn filter<Func>(self, func: Func) -> filter::FilterSurface<Self, Func>
+    where
+        Self: Sized,
+        Func: FnMut(&Self::ItemOut) -> bool,
+    {
+        filter::FilterSurface::new(self, func)
+    }
+}
+
+pub trait PullSurface: BaseSurface {
+    type InputHandoffs: HandoffList;
+
+    type Connect: PullConnect<InputHandoffs = Self::InputHandoffs>;
+    type Build: PullBuild<InputHandoffs = Self::InputHandoffs, ItemOut = Self::ItemOut>;
+
+    fn into_parts(self) -> (Self::Connect, Self::Build);
+
+    fn chain<Other>(self, other: Other) -> pull_chain::ChainPullSurface<Self, Other>
+    where
+        Self: Sized,
+        Other: PullSurface<ItemOut = Self::ItemOut>,
+    {
+        pull_chain::ChainPullSurface::new(self, other)
+    }
+
+    fn join<Other, Key, ValSelf, ValOther>(
+        self,
+        other: Other,
+    ) -> pull_join::JoinPullSurface<Self, Other>
+    where
+        Self: Sized + PullSurface<ItemOut = (Key, ValSelf)>,
+        Other: PullSurface<ItemOut = (Key, ValOther)>,
+        Key: 'static + Eq + Hash + Clone,
+        ValSelf: 'static + Eq + Clone,
+        ValOther: 'static + Eq + Clone,
+    {
+        pull_join::JoinPullSurface::new(self, other)
+    }
+
+    fn pivot(self) -> push_pivot::PivotPushSurface<Self>
+    where
+        Self: Sized,
+    {
+        push_pivot::PivotPushSurface::new(self)
+    }
+}
+
+pub trait PushSurface: BaseSurface {
+    /// This should usually be a type which impls [PushSurfaceReversed], but it is not enforced since we also need to return a Pivot in the end.
+    type Output<Next>
+    where
+        Next: PushSurfaceReversed<ItemIn = Self::ItemOut>;
+
+    fn reverse<Next>(self, next: Next) -> Self::Output<Next>
+    where
+        Next: PushSurfaceReversed<ItemIn = Self::ItemOut>;
+
+    /// To create a output tee, use [`HydroflowBuilder::start_tee()`](crate::builder::HydroflowBuilder::start_tee).
+    fn tee<NextA, NextB>(
+        self,
+        next_a: NextA,
+        next_b: NextB,
+    ) -> Self::Output<push_tee::TeePushSurfaceReversed<NextA, NextB>>
+    where
+        Self: Sized,
+        Self::ItemOut: Clone,
+        NextA: PushSurfaceReversed<ItemIn = Self::ItemOut>,
+        NextB: PushSurfaceReversed<ItemIn = Self::ItemOut>,
+
+        NextA::OutputHandoffs: Extend<NextB::OutputHandoffs>,
+        <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended:
+            HandoffList + HandoffListSplit<NextA::OutputHandoffs, Suffix = NextB::OutputHandoffs>,
+    {
+        let next = push_tee::TeePushSurfaceReversed::new(next_a, next_b);
+        self.reverse(next)
+    }
+
+    fn for_each<Func>(
+        self,
+        func: Func,
+    ) -> Self::Output<push_for_each::ForEachPushSurfaceReversed<Func, Self::ItemOut>>
+    where
+        Self: Sized,
+        Func: FnMut(Self::ItemOut),
+    {
+        let next = push_for_each::ForEachPushSurfaceReversed::new(func);
+        self.reverse(next)
+    }
+}
+
+/// This extra layer is needed due to the ownership order. In the functional
+/// chaining syntax each operator owns the previous (can only go in order
+/// things are called/defined), but in the end we need each pusherator to own
+/// the _next_ pusherator which it's pushing to.
+///
+/// This is the already-reversed, [PushSurface] does the actual reversing.
+pub trait PushSurfaceReversed {
+    type OutputHandoffs: HandoffList;
+
+    type ItemIn;
+
+    type Connect: PushConnect<OutputHandoffs = Self::OutputHandoffs>;
+    type Build: PushBuild<OutputHandoffs = Self::OutputHandoffs, ItemIn = Self::ItemIn>;
+
+    fn into_parts(self) -> (Self::Connect, Self::Build);
+}

--- a/hydroflow/src/builder/surface/pivot.rs
+++ b/hydroflow/src/builder/surface/pivot.rs
@@ -1,0 +1,33 @@
+use super::{PullSurface, PushSurfaceReversed};
+
+#[allow(type_alias_bounds)]
+type Parts<Pull, Push>
+where
+    Pull: PullSurface,
+    Push: PushSurfaceReversed<ItemIn = Pull::ItemOut>,
+= ((Pull::Connect, Push::Connect), (Pull::Build, Push::Build));
+
+/// The combination of both Pull and Push surface halves.
+pub struct PivotSurface<Pull, Push>
+where
+    Pull: PullSurface,
+    Push: PushSurfaceReversed<ItemIn = Pull::ItemOut>,
+{
+    pull: Pull,
+    push: Push,
+}
+impl<Pull, Push> PivotSurface<Pull, Push>
+where
+    Pull: PullSurface,
+    Push: PushSurfaceReversed<ItemIn = Pull::ItemOut>,
+{
+    pub fn new(pull: Pull, push: Push) -> Self {
+        Self { pull, push }
+    }
+
+    pub fn into_parts(self) -> Parts<Pull, Push> {
+        let (pull_connect, pull_build) = self.pull.into_parts();
+        let (push_connect, push_build) = self.push.into_parts();
+        ((pull_connect, push_connect), (pull_build, push_build))
+    }
+}

--- a/hydroflow/src/builder/surface/pull_chain.rs
+++ b/hydroflow/src/builder/surface/pull_chain.rs
@@ -1,0 +1,54 @@
+use super::{BaseSurface, PullSurface};
+
+use crate::builder::build::pull_chain::ChainPullBuild;
+use crate::builder::connect::BinaryPullConnect;
+use crate::scheduled::handoff::{HandoffList, HandoffListSplit};
+use crate::scheduled::type_list::Extend;
+
+pub struct ChainPullSurface<PrevA, PrevB>
+where
+    PrevA: PullSurface,
+    PrevB: PullSurface<ItemOut = PrevA::ItemOut>,
+{
+    prev_a: PrevA,
+    prev_b: PrevB,
+}
+impl<PrevA, PrevB> ChainPullSurface<PrevA, PrevB>
+where
+    PrevA: PullSurface,
+    PrevB: PullSurface<ItemOut = PrevA::ItemOut>,
+{
+    pub fn new(prev_a: PrevA, prev_b: PrevB) -> Self {
+        Self { prev_a, prev_b }
+    }
+}
+
+impl<PrevA, PrevB> BaseSurface for ChainPullSurface<PrevA, PrevB>
+where
+    PrevA: PullSurface,
+    PrevB: PullSurface<ItemOut = PrevA::ItemOut>,
+{
+    type ItemOut = PrevA::ItemOut;
+}
+
+impl<PrevA, PrevB> PullSurface for ChainPullSurface<PrevA, PrevB>
+where
+    PrevA: PullSurface,
+    PrevB: PullSurface<ItemOut = PrevA::ItemOut>,
+    PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        HandoffList + HandoffListSplit<PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
+{
+    type InputHandoffs = <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended;
+
+    type Connect = BinaryPullConnect<PrevA::Connect, PrevB::Connect>;
+    type Build = ChainPullBuild<PrevA::Build, PrevB::Build>;
+
+    fn into_parts(self) -> (Self::Connect, Self::Build) {
+        let (connect_a, build_a) = self.prev_a.into_parts();
+        let (connect_b, build_b) = self.prev_b.into_parts();
+        let connect = BinaryPullConnect::new(connect_a, connect_b);
+        let build = ChainPullBuild::new(build_a, build_b);
+        (connect, build)
+    }
+}

--- a/hydroflow/src/builder/surface/pull_handoff.rs
+++ b/hydroflow/src/builder/surface/pull_handoff.rs
@@ -1,0 +1,49 @@
+use super::{BaseSurface, PullSurface};
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use crate::builder::build::pull_handoff::HandoffPullBuild;
+use crate::builder::connect::HandoffPullConnect;
+use crate::scheduled::ctx::InputPort;
+use crate::scheduled::handoff::Handoff;
+use crate::tt;
+
+pub struct HandoffPullSurface<Hof>
+where
+    Hof: Handoff,
+{
+    port: Rc<Cell<Option<InputPort<Hof>>>>,
+}
+
+impl<Hof> HandoffPullSurface<Hof>
+where
+    Hof: Handoff,
+{
+    pub fn new(port: Rc<Cell<Option<InputPort<Hof>>>>) -> Self {
+        Self { port }
+    }
+}
+
+impl<Hof> BaseSurface for HandoffPullSurface<Hof>
+where
+    Hof: Handoff,
+{
+    type ItemOut = Hof::Inner;
+}
+
+impl<Hof> PullSurface for HandoffPullSurface<Hof>
+where
+    Hof: Handoff,
+{
+    type InputHandoffs = tt!(Hof);
+
+    type Connect = HandoffPullConnect<Hof>;
+    type Build = HandoffPullBuild<Hof>;
+
+    fn into_parts(self) -> (Self::Connect, Self::Build) {
+        let connect = HandoffPullConnect::new(self.port);
+        let build = HandoffPullBuild::new();
+        (connect, build)
+    }
+}

--- a/hydroflow/src/builder/surface/pull_join.rs
+++ b/hydroflow/src/builder/surface/pull_join.rs
@@ -1,0 +1,65 @@
+use super::{BaseSurface, PullSurface};
+
+use std::hash::Hash;
+
+use crate::builder::build::pull_join::JoinPullBuild;
+use crate::builder::connect::BinaryPullConnect;
+use crate::scheduled::handoff::{HandoffList, HandoffListSplit};
+use crate::scheduled::type_list::Extend;
+
+pub struct JoinPullSurface<PrevA, PrevB>
+where
+    PrevA: PullSurface,
+    PrevB: PullSurface,
+{
+    prev_a: PrevA,
+    prev_b: PrevB,
+}
+impl<PrevA, PrevB, Key, ValA, ValB> JoinPullSurface<PrevA, PrevB>
+where
+    PrevA: PullSurface<ItemOut = (Key, ValA)>,
+    PrevB: PullSurface<ItemOut = (Key, ValB)>,
+    Key: 'static + Eq + Hash + Clone,
+    ValA: 'static + Eq + Clone,
+    ValB: 'static + Eq + Clone,
+{
+    pub fn new(prev_a: PrevA, prev_b: PrevB) -> Self {
+        Self { prev_a, prev_b }
+    }
+}
+
+impl<PrevA, PrevB, Key, ValA, ValB> BaseSurface for JoinPullSurface<PrevA, PrevB>
+where
+    PrevA: PullSurface<ItemOut = (Key, ValA)>,
+    PrevB: PullSurface<ItemOut = (Key, ValB)>,
+    Key: 'static + Eq + Hash + Clone,
+    ValA: 'static + Eq + Clone,
+    ValB: 'static + Eq + Clone,
+{
+    type ItemOut = (Key, ValA, ValB);
+}
+
+impl<PrevA, PrevB, Key, ValA, ValB> PullSurface for JoinPullSurface<PrevA, PrevB>
+where
+    PrevA: PullSurface<ItemOut = (Key, ValA)>,
+    PrevB: PullSurface<ItemOut = (Key, ValB)>,
+    Key: 'static + Eq + Hash + Clone,
+    ValA: 'static + Eq + Clone,
+    ValB: 'static + Eq + Clone,
+    PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        HandoffList + HandoffListSplit<PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
+{
+    type InputHandoffs = <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended;
+
+    type Connect = BinaryPullConnect<PrevA::Connect, PrevB::Connect>;
+    type Build = JoinPullBuild<PrevA::Build, PrevB::Build, Key, ValA, ValB>;
+
+    fn into_parts(self) -> (Self::Connect, Self::Build) {
+        let (connect_a, build_a) = self.prev_a.into_parts();
+        let (connect_b, build_b) = self.prev_b.into_parts();
+        let connect = BinaryPullConnect::new(connect_a, connect_b);
+        let build = JoinPullBuild::new(build_a, build_b);
+        (connect, build)
+    }
+}

--- a/hydroflow/src/builder/surface/push_for_each.rs
+++ b/hydroflow/src/builder/surface/push_for_each.rs
@@ -1,0 +1,44 @@
+use super::PushSurfaceReversed;
+
+use std::marker::PhantomData;
+
+use crate::builder::build::push_for_each::ForEachPushBuild;
+use crate::builder::connect::NullPushConnect;
+use crate::tt;
+
+pub struct ForEachPushSurfaceReversed<Func, In>
+where
+    Func: FnMut(In),
+{
+    func: Func,
+    _phantom: PhantomData<fn(In)>,
+}
+impl<Func, In> ForEachPushSurfaceReversed<Func, In>
+where
+    Func: FnMut(In),
+{
+    pub fn new(func: Func) -> Self {
+        Self {
+            func,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<Func, In> PushSurfaceReversed for ForEachPushSurfaceReversed<Func, In>
+where
+    Func: FnMut(In),
+{
+    type OutputHandoffs = tt!();
+
+    type ItemIn = In;
+
+    type Connect = NullPushConnect;
+    type Build = ForEachPushBuild<Func, In>;
+
+    fn into_parts(self) -> (Self::Connect, Self::Build) {
+        let connect = NullPushConnect::new();
+        let build = ForEachPushBuild::new(self.func);
+        (connect, build)
+    }
+}

--- a/hydroflow/src/builder/surface/push_handoff.rs
+++ b/hydroflow/src/builder/surface/push_handoff.rs
@@ -1,0 +1,49 @@
+use super::PushSurfaceReversed;
+
+use std::cell::Cell;
+use std::marker::PhantomData;
+use std::rc::Rc;
+
+use crate::builder::build::push_handoff::HandoffPushBuild;
+use crate::builder::connect::HandoffPushConnect;
+use crate::scheduled::ctx::OutputPort;
+use crate::scheduled::handoff::{CanReceive, Handoff};
+use crate::tt;
+
+pub struct HandoffPushSurfaceReversed<Hof, In>
+where
+    Hof: Handoff + CanReceive<In>,
+{
+    port: Rc<Cell<Option<OutputPort<Hof>>>>,
+    _phantom: PhantomData<fn(In)>,
+}
+
+impl<Hof, In> HandoffPushSurfaceReversed<Hof, In>
+where
+    Hof: Handoff + CanReceive<In>,
+{
+    pub fn new(port: Rc<Cell<Option<OutputPort<Hof>>>>) -> Self {
+        Self {
+            port,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<Hof, In> PushSurfaceReversed for HandoffPushSurfaceReversed<Hof, In>
+where
+    Hof: Handoff + CanReceive<In>,
+{
+    type OutputHandoffs = tt!(Hof);
+
+    type ItemIn = In;
+
+    type Connect = HandoffPushConnect<Hof>;
+    type Build = HandoffPushBuild<Hof, In>;
+
+    fn into_parts(self) -> (Self::Connect, Self::Build) {
+        let connect = HandoffPushConnect::new(self.port);
+        let build = HandoffPushBuild::new();
+        (connect, build)
+    }
+}

--- a/hydroflow/src/builder/surface/push_pivot.rs
+++ b/hydroflow/src/builder/surface/push_pivot.rs
@@ -1,0 +1,43 @@
+use super::{BaseSurface, PullSurface, PushSurface, PushSurfaceReversed};
+
+use super::pivot::PivotSurface;
+
+pub struct PivotPushSurface<Pull>
+where
+    Pull: PullSurface,
+{
+    pull: Pull,
+}
+
+impl<Pull> PivotPushSurface<Pull>
+where
+    Pull: PullSurface,
+{
+    pub fn new(pull: Pull) -> Self {
+        Self { pull }
+    }
+}
+
+impl<Pull> BaseSurface for PivotPushSurface<Pull>
+where
+    Pull: PullSurface,
+{
+    type ItemOut = Pull::ItemOut;
+}
+
+impl<Pull> PushSurface for PivotPushSurface<Pull>
+where
+    Pull: PullSurface,
+{
+    type Output<Next>
+    where
+        Next: PushSurfaceReversed<ItemIn = Self::ItemOut>,
+    = PivotSurface<Pull, Next>;
+
+    fn reverse<Next>(self, next: Next) -> Self::Output<Next>
+    where
+        Next: PushSurfaceReversed<ItemIn = Self::ItemOut>,
+    {
+        PivotSurface::new(self.pull, next)
+    }
+}

--- a/hydroflow/src/builder/surface/push_start.rs
+++ b/hydroflow/src/builder/surface/push_start.rs
@@ -1,0 +1,39 @@
+use super::{BaseSurface, PushSurface, PushSurfaceReversed};
+
+use std::marker::PhantomData;
+
+pub struct StartPushSurface<Out> {
+    _phantom: PhantomData<fn(Out)>,
+}
+
+impl<Out> Default for StartPushSurface<Out> {
+    fn default() -> Self {
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<Out> StartPushSurface<Out> {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+impl<Out> BaseSurface for StartPushSurface<Out> {
+    type ItemOut = Out;
+}
+
+impl<Out> PushSurface for StartPushSurface<Out> {
+    type Output<Next>
+    where
+        Next: PushSurfaceReversed<ItemIn = Self::ItemOut>,
+    = Next;
+
+    fn reverse<Next>(self, next: Next) -> Self::Output<Next>
+    where
+        Next: PushSurfaceReversed<ItemIn = Self::ItemOut>,
+    {
+        next
+    }
+}

--- a/hydroflow/src/builder/surface/push_tee.rs
+++ b/hydroflow/src/builder/surface/push_tee.rs
@@ -1,0 +1,51 @@
+use super::PushSurfaceReversed;
+
+use crate::builder::build::push_tee::TeePushBuild;
+use crate::builder::connect::BinaryPushConnect;
+use crate::scheduled::handoff::{HandoffList, HandoffListSplit};
+use crate::scheduled::type_list::Extend;
+
+pub struct TeePushSurfaceReversed<NextA, NextB>
+where
+    NextA: PushSurfaceReversed,
+    NextB: PushSurfaceReversed<ItemIn = NextA::ItemIn>,
+    NextA::ItemIn: Clone,
+{
+    next_a: NextA,
+    next_b: NextB,
+}
+impl<NextA, NextB> TeePushSurfaceReversed<NextA, NextB>
+where
+    NextA: PushSurfaceReversed,
+    NextB: PushSurfaceReversed<ItemIn = NextA::ItemIn>,
+    NextA::ItemIn: Clone,
+{
+    pub fn new(next_a: NextA, next_b: NextB) -> Self {
+        Self { next_a, next_b }
+    }
+}
+
+impl<NextA, NextB> PushSurfaceReversed for TeePushSurfaceReversed<NextA, NextB>
+where
+    NextA: PushSurfaceReversed,
+    NextB: PushSurfaceReversed<ItemIn = NextA::ItemIn>,
+    NextA::ItemIn: Clone,
+    NextA::OutputHandoffs: Extend<NextB::OutputHandoffs>,
+    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended:
+        HandoffList + HandoffListSplit<NextA::OutputHandoffs, Suffix = NextB::OutputHandoffs>,
+{
+    type OutputHandoffs = <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended;
+
+    type ItemIn = NextA::ItemIn;
+
+    type Connect = BinaryPushConnect<NextA::Connect, NextB::Connect>;
+    type Build = TeePushBuild<NextA::Build, NextB::Build>;
+
+    fn into_parts(self) -> (Self::Connect, Self::Build) {
+        let (connect_a, build_a) = self.next_a.into_parts();
+        let (connect_b, build_b) = self.next_b.into_parts();
+        let connect = BinaryPushConnect::new(connect_a, connect_b);
+        let build = TeePushBuild::new(build_a, build_b);
+        (connect, build)
+    }
+}

--- a/hydroflow/src/compiled/flat_map.rs
+++ b/hydroflow/src/compiled/flat_map.rs
@@ -1,0 +1,82 @@
+use super::{Pusherator, PusheratorBuild};
+
+use std::marker::PhantomData;
+
+pub struct FlatMap<T, U, F, O>
+where
+    F: FnMut(T) -> U,
+    U: IntoIterator,
+    O: Pusherator<Item = U::Item>,
+{
+    out: O,
+    f: F,
+    _marker: PhantomData<T>,
+}
+impl<T, U, F, O> Pusherator for FlatMap<T, U, F, O>
+where
+    F: FnMut(T) -> U,
+    U: IntoIterator,
+    O: Pusherator<Item = U::Item>,
+{
+    type Item = T;
+    fn give(&mut self, item: Self::Item) {
+        for x in (self.f)(item) {
+            self.out.give(x);
+        }
+    }
+}
+impl<T, U, F, O> FlatMap<T, U, F, O>
+where
+    F: FnMut(T) -> U,
+    U: IntoIterator,
+    O: Pusherator<Item = U::Item>,
+{
+    pub fn new(f: F, out: O) -> Self {
+        Self {
+            out,
+            f,
+            _marker: PhantomData,
+        }
+    }
+}
+
+pub struct FlatMapBuild<T, U, F, P>
+where
+    F: FnMut(T) -> U,
+    U: IntoIterator,
+    P: PusheratorBuild<Item = T>,
+{
+    prev: P,
+    f: F,
+    _marker: PhantomData<T>,
+}
+impl<T, U, F, P> FlatMapBuild<T, U, F, P>
+where
+    F: FnMut(T) -> U,
+    U: IntoIterator,
+    P: PusheratorBuild<Item = T>,
+{
+    pub fn new(prev: P, f: F) -> Self {
+        Self {
+            prev,
+            f,
+            _marker: PhantomData,
+        }
+    }
+}
+impl<T, U, F, P> PusheratorBuild for FlatMapBuild<T, U, F, P>
+where
+    F: FnMut(T) -> U,
+    U: IntoIterator,
+    P: PusheratorBuild<Item = T>,
+{
+    type Item = U::Item;
+
+    type Output<O: Pusherator<Item = Self::Item>> = P::Output<FlatMap<T, U, F, O>>;
+    fn build<O>(self, input: O) -> Self::Output<O>
+    where
+        O: Pusherator<Item = Self::Item>,
+    {
+        self.prev.build(FlatMap::new(self.f, input))
+    }
+}

--- a/hydroflow/src/compiled/mod.rs
+++ b/hydroflow/src/compiled/mod.rs
@@ -6,6 +6,7 @@ pub mod map;
 pub mod partition;
 pub mod pivot;
 pub mod pull;
+pub mod push_handoff;
 pub mod tee;
 
 use std::marker::PhantomData;
@@ -64,6 +65,17 @@ pub trait PusheratorBuild {
         F: FnMut(Self::Item),
     {
         self.build(for_each::ForEach::new(f))
+    }
+
+    fn handoff<H>(
+        self,
+        handoff: &mut crate::scheduled::ctx::SendCtx<H>,
+    ) -> Self::Output<push_handoff::PushHandoff<'_, H, Self::Item>>
+    where
+        Self: Sized,
+        H: crate::scheduled::handoff::Handoff + crate::scheduled::handoff::CanReceive<Self::Item>,
+    {
+        self.build(push_handoff::PushHandoff::new(handoff))
     }
 }
 

--- a/hydroflow/src/compiled/mod.rs
+++ b/hydroflow/src/compiled/mod.rs
@@ -1,4 +1,5 @@
 pub mod filter;
+pub mod flat_map;
 pub mod for_each;
 pub mod group_by;
 pub mod map;

--- a/hydroflow/src/compiled/push_handoff.rs
+++ b/hydroflow/src/compiled/push_handoff.rs
@@ -1,0 +1,34 @@
+use super::Pusherator;
+
+use std::marker::PhantomData;
+
+use crate::scheduled::ctx::SendCtx;
+use crate::scheduled::handoff::{CanReceive, Handoff};
+
+pub struct PushHandoff<'a, H, T>
+where
+    H: Handoff + CanReceive<T>,
+{
+    send_ctx: &'a SendCtx<H>,
+    _phantom: PhantomData<fn(T)>,
+}
+impl<'a, H, T> PushHandoff<'a, H, T>
+where
+    H: Handoff + CanReceive<T>,
+{
+    pub fn new(send_ctx: &'a SendCtx<H>) -> Self {
+        Self {
+            send_ctx,
+            _phantom: PhantomData,
+        }
+    }
+}
+impl<'a, H, T> Pusherator for PushHandoff<'a, H, T>
+where
+    H: Handoff + CanReceive<T>,
+{
+    type Item = T;
+    fn give(&mut self, item: Self::Item) {
+        self.send_ctx.give(item);
+    }
+}

--- a/hydroflow/src/lib.rs
+++ b/hydroflow/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(feature = "variadic_generics", feature(generic_associated_types))]
 #![allow(clippy::let_and_return)]
 
+pub mod builder;
 pub mod compiled;
 pub mod lang;
 pub mod scheduled;

--- a/hydroflow/src/scheduled/handoff/handoff_list.rs
+++ b/hydroflow/src/scheduled/handoff/handoff_list.rs
@@ -7,6 +7,7 @@ use sealed::sealed;
 
 use crate::scheduled::ctx::{InputPort, OutputPort, RecvCtx, SendCtx};
 use crate::scheduled::graph::HandoffData;
+use crate::scheduled::type_list::TypeList;
 use crate::scheduled::{HandoffId, SubgraphId};
 
 use super::Handoff;
@@ -22,17 +23,17 @@ use super::Handoff;
 /// type MyHandoffList = tl!(VecHandoff<usize>, VecHandoff<String>, TeeingHandoff<u32>);
 /// ```
 #[sealed]
-pub trait HandoffList {
-    type InputHid;
-    type InputPort;
-    type RecvCtx<'a>;
+pub trait HandoffList: TypeList {
+    type InputHid: TypeList;
+    type InputPort: TypeList;
+    type RecvCtx<'a>: TypeList;
     fn make_input(sg_id: SubgraphId) -> (Self::InputHid, Self::InputPort);
     fn make_recv<'a>(handoffs: &'a [HandoffData], input_hids: &Self::InputHid)
         -> Self::RecvCtx<'a>;
 
-    type OutputHid;
-    type OutputPort;
-    type SendCtx<'a>;
+    type OutputHid: TypeList;
+    type OutputPort: TypeList;
+    type SendCtx<'a>: TypeList;
     fn make_output(sg_id: SubgraphId) -> (Self::OutputHid, Self::OutputPort);
     fn make_send<'a>(
         handoffs: &'a [HandoffData],
@@ -137,5 +138,117 @@ impl HandoffList for () {
         _handoffs: &'a [HandoffData],
         _output_hids: &Self::OutputHid,
     ) -> Self::SendCtx<'a> {
+    }
+}
+
+pub trait HandoffListSplit<A>: HandoffList
+where
+    A: HandoffList,
+{
+    type Suffix: HandoffList;
+
+    fn split_input_port(
+        input_port: Self::InputPort,
+    ) -> (A::InputPort, <Self::Suffix as HandoffList>::InputPort);
+
+    #[allow(clippy::needless_lifetimes)] // clippy false positive
+    fn split_recv_ctx<'a>(
+        recv_ctx: Self::RecvCtx<'a>,
+    ) -> (A::RecvCtx<'a>, <Self::Suffix as HandoffList>::RecvCtx<'a>);
+
+    fn split_output_port(
+        output_port: Self::OutputPort,
+    ) -> (A::OutputPort, <Self::Suffix as HandoffList>::OutputPort);
+
+    #[allow(clippy::needless_lifetimes)] // clippy false positive
+    fn split_send_ctx<'a>(
+        recv_ctx: Self::SendCtx<'a>,
+    ) -> (A::SendCtx<'a>, <Self::Suffix as HandoffList>::SendCtx<'a>);
+}
+
+impl<X, T, U> HandoffListSplit<(X, U)> for (X, T)
+where
+    X: Handoff,
+    T: HandoffListSplit<U>,
+    U: HandoffList,
+{
+    type Suffix = T::Suffix;
+
+    fn split_input_port(
+        input_port: Self::InputPort,
+    ) -> (
+        <(X, U) as HandoffList>::InputPort,
+        <Self::Suffix as HandoffList>::InputPort,
+    ) {
+        let (x, t) = input_port;
+        let (u, v) = <T as HandoffListSplit<U>>::split_input_port(t);
+        ((x, u), v)
+    }
+
+    #[allow(clippy::needless_lifetimes)]
+    fn split_recv_ctx<'a>(
+        recv_ctx: Self::RecvCtx<'a>,
+    ) -> (
+        <(X, U) as HandoffList>::RecvCtx<'a>,
+        <Self::Suffix as HandoffList>::RecvCtx<'a>,
+    ) {
+        let (x, t) = recv_ctx;
+        let (u, v) = <T as HandoffListSplit<U>>::split_recv_ctx(t);
+        ((x, u), v)
+    }
+
+    fn split_output_port(
+        output_port: Self::OutputPort,
+    ) -> (
+        <(X, U) as HandoffList>::OutputPort,
+        <Self::Suffix as HandoffList>::OutputPort,
+    ) {
+        let (x, t) = output_port;
+        let (u, v) = <T as HandoffListSplit<U>>::split_output_port(t);
+        ((x, u), v)
+    }
+
+    #[allow(clippy::needless_lifetimes)]
+    fn split_send_ctx<'a>(
+        send_ctx: Self::SendCtx<'a>,
+    ) -> (
+        <(X, U) as HandoffList>::SendCtx<'a>,
+        <Self::Suffix as HandoffList>::SendCtx<'a>,
+    ) {
+        let (x, t) = send_ctx;
+        let (u, v) = <T as HandoffListSplit<U>>::split_send_ctx(t);
+        ((x, u), v)
+    }
+}
+impl<T> HandoffListSplit<()> for T
+where
+    T: HandoffList,
+{
+    type Suffix = T;
+
+    fn split_input_port(
+        input_port: Self::InputPort,
+    ) -> (<() as HandoffList>::InputPort, T::InputPort) {
+        ((), input_port)
+    }
+
+    #[allow(clippy::needless_lifetimes)]
+    fn split_recv_ctx<'a>(
+        recv_ctx: Self::RecvCtx<'a>,
+    ) -> (<() as HandoffList>::RecvCtx<'a>, T::RecvCtx<'a>) {
+        ((), recv_ctx)
+    }
+
+    fn split_output_port(
+        output_port: Self::OutputPort,
+    ) -> (<() as HandoffList>::OutputPort, T::OutputPort) {
+        ((), output_port)
+    }
+
+    #[allow(clippy::needless_lifetimes)]
+    fn split_send_ctx<'a>(
+        send_ctx: Self::SendCtx<'a>,
+    ) -> (<() as HandoffList>::SendCtx<'a>, T::SendCtx<'a>) {
+        ((), send_ctx)
     }
 }

--- a/hydroflow/src/scheduled/handoff/mod.rs
+++ b/hydroflow/src/scheduled/handoff/mod.rs
@@ -2,7 +2,7 @@ mod handoff_list;
 mod tee;
 mod vector;
 
-pub use handoff_list::HandoffList;
+pub use handoff_list::{HandoffList, HandoffListSplit};
 pub use tee::TeeingHandoff;
 pub use vector::VecHandoff;
 

--- a/hydroflow/src/scheduled/mod.rs
+++ b/hydroflow/src/scheduled/mod.rs
@@ -12,6 +12,7 @@ pub mod reactor;
 pub mod state;
 pub(crate) mod subgraph;
 pub mod util;
+pub mod type_list;
 
 pub type SubgraphId = usize;
 pub type HandoffId = usize;

--- a/hydroflow/src/scheduled/mod.rs
+++ b/hydroflow/src/scheduled/mod.rs
@@ -11,8 +11,8 @@ pub mod query;
 pub mod reactor;
 pub mod state;
 pub(crate) mod subgraph;
-pub mod util;
 pub mod type_list;
+pub mod util;
 
 pub type SubgraphId = usize;
 pub type HandoffId = usize;

--- a/hydroflow/src/scheduled/type_list.rs
+++ b/hydroflow/src/scheduled/type_list.rs
@@ -1,0 +1,76 @@
+pub trait TypeList {}
+
+impl TypeList for () {}
+impl<X, T> TypeList for (X, T) where T: TypeList {}
+
+pub trait Extend<U>: TypeList
+where
+    U: TypeList,
+{
+    type Extended: TypeList;
+    fn extend(self, input: U) -> Self::Extended;
+}
+
+impl<X, T, U> Extend<U> for (X, T)
+where
+    T: TypeList + Extend<U>,
+    U: TypeList,
+{
+    type Extended = (X, <T as Extend<U>>::Extended);
+    fn extend(self, input: U) -> Self::Extended {
+        let (x, t) = self;
+        (x, t.extend(input))
+    }
+}
+impl<U> Extend<U> for ()
+where
+    U: TypeList,
+{
+    type Extended = U;
+    fn extend(self, input: U) -> Self::Extended {
+        input
+    }
+}
+
+pub trait SplitPrefix<U>: TypeList
+where
+    U: TypeList,
+{
+    type Suffix: TypeList;
+    fn split(self) -> (U, Self::Suffix);
+}
+impl<X, T, U> SplitPrefix<(X, U)> for (X, T)
+where
+    U: TypeList,
+    T: SplitPrefix<U>
+{
+    type Suffix = <T as SplitPrefix<U>>::Suffix;
+    fn split(self) -> ((X, U), Self::Suffix) {
+        let (x, t) = self;
+        let (t, u) = t.split();
+        ((x, t), u)
+    }
+}
+impl<T> SplitPrefix<()> for T
+where
+    T: TypeList,
+{
+    type Suffix = T;
+    fn split(self) -> ((), Self::Suffix) {
+        ((), self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{tt, tl};
+
+    use super::*;
+
+    type MyList = tt!(u8, u16, u32, u64);
+    type MyPrefix = tt!(u8, u16);
+
+    type MySuffix = <MyList as SplitPrefix<MyPrefix>>::Suffix;
+
+    const _: MySuffix = tl!(0_u32, 0_u64);
+}

--- a/hydroflow/src/scheduled/type_list.rs
+++ b/hydroflow/src/scheduled/type_list.rs
@@ -42,7 +42,7 @@ where
 impl<X, T, U> SplitPrefix<(X, U)> for (X, T)
 where
     U: TypeList,
-    T: SplitPrefix<U>
+    T: SplitPrefix<U>,
 {
     type Suffix = <T as SplitPrefix<U>>::Suffix;
     fn split(self) -> ((X, U), Self::Suffix) {
@@ -61,9 +61,37 @@ where
     }
 }
 
+pub trait Split<U, V>: TypeList
+where
+    U: TypeList,
+    V: TypeList,
+{
+    fn split(self) -> (U, V);
+}
+impl<X, T, U, V> Split<(X, U), V> for (X, T)
+where
+    T: Split<U, V>,
+    U: TypeList,
+    V: TypeList,
+{
+    fn split(self) -> ((X, U), V) {
+        let (x, t) = self;
+        let (u, v) = t.split();
+        ((x, u), v)
+    }
+}
+impl<T> Split<(), T> for T
+where
+    T: TypeList,
+{
+    fn split(self) -> ((), T) {
+        ((), self)
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use crate::{tt, tl};
+    use crate::{tl, tt};
 
     use super::*;
 
@@ -72,5 +100,6 @@ mod test {
 
     type MySuffix = <MyList as SplitPrefix<MyPrefix>>::Suffix;
 
+    #[allow(dead_code)]
     const _: MySuffix = tl!(0_u32, 0_u64);
 }


### PR DESCRIPTION
This adds quite a few files and new code, but a lot is relatively simple boiler-plate-esque code for different chaining operators (map, flat_map, filter, etc.).

Start at `hydroflow/src/builder/mod.rs`. Traits for each layer in `hydroflow/src/builder/surface/mod.rs`, `hydroflow/src/builder/connect/mod.rs`, ``hydroflow/src/builder/build/mod.rs`.

Example/test code is at the bottom of `hydroflow/src/builder/mod.rs` (probably should be moved somewhere more suitable later)

The other files for specific operators in each layer (e.g. `hydroflow/src/builder/build/pull_flat_map.rs`) are not so important.

Operators which have multiple inputs/outputs use the fancy `Extend` and `HandoffListSplit<Prefix>` traits for dealing with tuple type lists, allowing us to combine/split the handoff lists.