### PR TITLE
Rewrite echo server using the surface API

### DIFF
--- a/hydroflow/src/scheduled/net/network_vertex.rs
+++ b/hydroflow/src/scheduled/net/network_vertex.rs
@@ -78,8 +78,10 @@ impl Hydroflow {
         tokio::spawn(async move {
             while let Some(addr) = connection_reqs_recv.next().await {
                 let addr: Address = addr;
-                let stream = TcpStream::connect(addr.clone()).await.unwrap();
-                connections_send.send((addr, stream)).await.unwrap();
+                connections_send
+                    .send((addr.clone(), TcpStream::connect(addr.clone()).await))
+                    .await
+                    .unwrap();
             }
         });
 
@@ -128,30 +130,45 @@ impl Hydroflow {
                     },
 
                     Some((addr, conn)) = connections_recv.next() => {
-                        match connections.get_mut(&addr) {
-                            Some(ConnStatus::Pending(msgs)) => {
-                                let mut conn = FramedWrite::new(conn, LengthDelimitedCodec::new());
-                                for msg in msgs.drain(..) {
-                                    // TODO(justin): move the actual sending here
-                                    // into a different task so we don't have to
-                                    // wait for the send.
-                                    let msg = bincode::serialize(&msg).unwrap();
-                                    conn.send(msg.into()).await.unwrap();
+                        match conn {
+                            Ok(conn) => {
+                                match connections.get_mut(&addr) {
+                                    Some(ConnStatus::Pending(msgs)) => {
+                                        let mut conn = FramedWrite::new(conn, LengthDelimitedCodec::new());
+                                        for msg in msgs.drain(..) {
+                                            // TODO(justin): move the actual sending here
+                                            // into a different task so we don't have to
+                                            // wait for the send.
+                                            let msg = bincode::serialize(&msg).unwrap();
+                                            conn.send(msg.into()).await.unwrap();
+                                        }
+                                        connections.insert(addr, ConnStatus::Connected(conn));
+                                    }
+                                    None => {
+                                        // This means nobody ever requested this
+                                        // connection, so we shouldn't have initiated it
+                                        // in the first place.
+                                        unreachable!()
+                                    }
+                                    Some(ConnStatus::Connected(_tcp)) => {
+                                        // This means we were already connected, so we
+                                        // shouldn't have connected again. If the
+                                        // connection cache becomes shared this could
+                                        // become reachable.
+                                        unreachable!()
+                                    }
                                 }
-                                connections.insert(addr, ConnStatus::Connected(conn));
                             }
-                            None => {
-                                // This means nobody ever requested this
-                                // connection, so we shouldn't have initiated it
-                                // in the first place.
-                                unreachable!()
-                            }
-                            Some(ConnStatus::Connected(_tcp)) => {
-                                // This means we were already connected, so we
-                                // shouldn't have connected again. If the
-                                // connection cache becomes shared this could
-                                // become reachable.
-                                unreachable!()
+                            Err(e) => {
+                                // We couldn't connect to the address for some
+                                // reason.
+                                // TODO(justin): once we have a clearer picture
+                                // of error handling, we could do something like
+                                // send this error along a pipe to be handled by
+                                // someone else. For now, just log it and drop
+                                // any pending messages.
+                                eprintln!("couldn't connect to {}: {}", addr, e);
+                                connections.remove(&addr);
                             }
                         }
                     },

--- a/hydroflow/tests/networked.rs
+++ b/hydroflow/tests/networked.rs
@@ -1,132 +1,33 @@
 use std::{collections::HashSet, sync::mpsc::channel};
 
+use futures::{SinkExt, StreamExt};
 use hydroflow::{
     builder::{
         prelude::{BaseSurface, PullSurface, PushSurface},
         surface::pull_handoff::HandoffPullSurface,
         HydroflowBuilder,
     },
-    scheduled::{
-        ctx::{OutputPort, RecvCtx},
-        graph::Hydroflow,
-        graph_ext::GraphExt,
-        handoff::VecHandoff,
-    },
+    scheduled::{ctx::OutputPort, graph_ext::GraphExt, handoff::VecHandoff},
 };
 use serde::{Deserialize, Serialize};
+use tokio::{
+    net::{TcpListener, TcpStream},
+    sync::mpsc::{Receiver, Sender},
+};
+use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 struct EchoRequest {
     return_addr: String,
     payload: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 struct EchoResponse {
     payload: String,
 }
 
-// This test sets up an echo server and runs a few connections to it.
-#[test]
-fn test_echo_server() {
-    let (log_message, all_received_messages) = channel();
-
-    let (server_port_send, server_port_recv) = std::sync::mpsc::channel();
-
-    // First, spin up the server.
-    {
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(async move {
-                let mut df = Hydroflow::new();
-
-                let (port, incoming_messages) = df.inbound_tcp_vertex().await;
-                let outbound_messages = df.outbound_tcp_vertex().await;
-
-                server_port_send.send(port).unwrap();
-
-                let (receiver_port, sender_port) =
-                    df.add_inout(move |_ctx, recv: &RecvCtx<VecHandoff<EchoRequest>>, send| {
-                        for msg in recv.take_inner() {
-                            send.give(Some((
-                                msg.return_addr,
-                                EchoResponse {
-                                    payload: msg.payload,
-                                },
-                            )));
-                        }
-                    });
-                df.add_edge(incoming_messages, receiver_port);
-
-                df.add_edge(sender_port, outbound_messages);
-                df.run_async().await.unwrap();
-            });
-        });
-    }
-
-    let server_port = server_port_recv.recv().unwrap();
-
-    // Connect to it some number of times.
-    for idx in 0..3 {
-        let log_message = log_message.clone();
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(async move {
-                let mut df = Hydroflow::new();
-
-                let (port, incoming_messages) = df.inbound_tcp_vertex().await;
-                let outbound_messages = df.outbound_tcp_vertex().await;
-
-                let (input, given_inputs) = df.add_input();
-                df.add_edge(given_inputs, outbound_messages);
-
-                let receiver_port =
-                    df.add_sink(move |_ctx, recv: &RecvCtx<VecHandoff<EchoResponse>>| {
-                        for v in recv.take_inner() {
-                            log_message
-                                .send(format!("[CLIENT#{}] received back {:?}", idx, v.payload))
-                                .unwrap();
-                        }
-                    });
-
-                df.add_edge(incoming_messages, receiver_port);
-
-                let server_addr = format!("localhost:{}", server_port);
-
-                input.give(Some((
-                    server_addr.clone(),
-                    EchoRequest {
-                        return_addr: format!("localhost:{}", port),
-                        payload: format!("Hello world {}!", idx),
-                    },
-                )));
-
-                df.run_async().await.unwrap();
-            });
-        });
-    }
-
-    let expected_messages: HashSet<String> = [
-        "[CLIENT#0] received back \"Hello world 0!\"".into(),
-        "[CLIENT#1] received back \"Hello world 1!\"".into(),
-        "[CLIENT#2] received back \"Hello world 2!\"".into(),
-    ]
-    .into_iter()
-    .collect();
-
-    let mut actual_messages = HashSet::new();
-    while actual_messages.len() < expected_messages.len() {
-        actual_messages.insert(all_received_messages.recv().unwrap());
-    }
-
-    assert_eq!(expected_messages, actual_messages);
-}
-
-// This test sets up an echo server and runs a few connections to it.
-#[test]
-fn test_echo_server_builder() {
-    let (log_message, all_received_messages) = channel();
-
+fn start_echo_server() -> u16 {
     let (server_port_send, server_port_recv) = std::sync::mpsc::channel();
 
     // First, spin up the server.
@@ -167,7 +68,15 @@ fn test_echo_server_builder() {
         });
     }
 
-    let server_port = server_port_recv.recv().unwrap();
+    server_port_recv.recv().unwrap()
+}
+
+// This test sets up an echo server and runs a few connections to it.
+#[test]
+fn test_echo_server() {
+    let (log_message, all_received_messages) = channel();
+
+    let server_port = start_echo_server();
 
     // Connect to it some number of times.
     for idx in 0..3 {
@@ -225,4 +134,140 @@ fn test_echo_server_builder() {
     }
 
     assert_eq!(expected_messages, actual_messages);
+}
+
+// A simple echo client to use to exercise the server.
+#[derive(Debug)]
+struct EchoClient {
+    port: u16,
+    sender: Sender<(String, EchoRequest)>,
+    receiver: Receiver<EchoResponse>,
+    stop_tx: tokio::sync::watch::Sender<bool>,
+}
+
+impl EchoClient {
+    async fn new() -> Self {
+        let listener = TcpListener::bind("localhost:0").await.unwrap();
+        Self::new_from_listener(listener).await
+    }
+
+    async fn new_from_listener(listener: TcpListener) -> Self {
+        let port = listener.local_addr().unwrap().port();
+
+        let (incoming_send, incoming_recv) = tokio::sync::mpsc::channel(1024);
+        let (stop_tx, stop_rx) = tokio::sync::watch::channel(false);
+
+        tokio::spawn(async move {
+            loop {
+                let (socket, _) = listener.accept().await.unwrap();
+                let (reader, _) = socket.into_split();
+                let mut reader = FramedRead::new(reader, LengthDelimitedCodec::new());
+                let incoming_send = incoming_send.clone();
+                let mut stop_rx = stop_rx.clone();
+                tokio::spawn(async move {
+                    loop {
+                        tokio::select! {
+                            v = reader.next() => {
+                                match v {
+                                    Some(msg) => {
+                                        // TODO(justin): figure out error handling here.
+                                        let msg = msg.unwrap();
+                                        let out = bincode::deserialize(&msg).unwrap();
+                                        incoming_send.send(out).await.unwrap();
+                                    }
+                                    None => {
+                                        return;
+                                    }
+                                }
+                            }
+                            _ = stop_rx.changed() => {
+                                return;
+                            }
+                        }
+                    }
+                });
+            }
+        });
+
+        let (outgoing_send, mut outgoing_recv) = tokio::sync::mpsc::channel(1024);
+        tokio::spawn(async move {
+            // Don't do anything clever with this test implementation, just re-open
+            // a connection every time.
+            while let Some((addr, msg)) = outgoing_recv.recv().await {
+                let addr: String = addr;
+                let msg: EchoRequest = msg;
+                let conn = TcpStream::connect(addr).await.unwrap();
+                let mut conn = FramedWrite::new(conn, LengthDelimitedCodec::new());
+                let msg = bincode::serialize(&msg).unwrap();
+                conn.send(msg.into()).await.unwrap();
+            }
+        });
+
+        Self {
+            port,
+            sender: outgoing_send,
+            receiver: incoming_recv,
+            stop_tx,
+        }
+    }
+
+    async fn send(&mut self, server_addr: String, payload: String) {
+        self.sender
+            .send((
+                server_addr,
+                EchoRequest {
+                    return_addr: format!("localhost:{}", self.port),
+                    payload,
+                },
+            ))
+            .await
+            .unwrap();
+    }
+
+    async fn recv(&mut self) -> Option<EchoResponse> {
+        self.receiver.recv().await
+    }
+
+    fn stop(&mut self) {
+        self.stop_tx.send(true).unwrap();
+    }
+}
+
+impl Drop for EchoClient {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+#[test]
+fn test_echo_server_reconnect() {
+    let server_port = start_echo_server();
+    let server_addr = format!("localhost:{}", server_port);
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async move {
+        let mut client = EchoClient::new().await;
+
+        client.send(server_addr.clone(), "abc".into()).await;
+        let result = client.recv().await.unwrap();
+
+        assert_eq!(
+            result,
+            EchoResponse {
+                payload: "abc".into()
+            }
+        );
+
+        let mut client = EchoClient::new().await;
+
+        client.send(server_addr.clone(), "def".into()).await;
+        let result = client.recv().await.unwrap();
+
+        assert_eq!(
+            result,
+            EchoResponse {
+                payload: "def".into()
+            }
+        );
+    });
 }


### PR DESCRIPTION
Sort of minimal use of it so far since the logic here is pretty simple, but
should provide a foundation for things like address interning.

Wasn't sure if the wrap_{input,output} stuff aligns with your vision? LMK if
there's a cleaner/existing way to do that?