### PR TITLE
Get the distributed covid app running again

### DIFF
--- a/covid_tracing_dist/src/tracker.rs
+++ b/covid_tracing_dist/src/tracker.rs
@@ -111,9 +111,7 @@ pub(crate) async fn run_tracker(opts: Opts) {
     df.add_edge(diagnoses, diagnosed_in);
     df.add_edge(loop_out, loop_in);
 
-    let stream = TcpStream::connect(format!("localhost:{}", opts.addr))
-        .await
-        .unwrap();
+    let stream = TcpStream::connect(opts.addr).await.unwrap();
     let (network_out, network_in) = df.add_tcp_stream(stream);
 
     df.add_edge(notifs_out, encoder_in);

--- a/hydroflow/src/scheduled/net/mod.rs
+++ b/hydroflow/src/scheduled/net/mod.rs
@@ -91,7 +91,7 @@ impl Message {
     }
 
     pub fn decode(v: bytes::Bytes) -> Self {
-        let address = u32::from_le_bytes(v[0..ADDRESS_LEN].try_into().unwrap());
+        let address = u32::from_be_bytes(v[0..ADDRESS_LEN].try_into().unwrap());
         let batch = v.slice(ADDRESS_LEN..);
         Message { address, batch }
     }


### PR DESCRIPTION
This commit fixes two problems:

* There was an inconsistency with how the address was expected, and
* the endianness of the sender was changed, and was not changed for the receiver.