### PR TITLE
Enable the derive feature on hydroflow's serde

### DIFF
--- a/hydroflow/Cargo.toml
+++ b/hydroflow/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.6.9", features = ["codec"] }
 tuple_list = "0.1"
 byteorder = "1.4.3"
-serde = "1"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 bincode = "1.3"
 


### PR DESCRIPTION
Lacking this was causing `cargo test -p` to fail, even though `cargo test`
succeeded, since running the full `cargo test` would take the union of feature
flags across the workspace, even for individual packages.