### PR TITLE
Use SEND/RECV type tags instead of true/false const generics for `Port`s/`PortCtx`s

### DIFF
--- a/hydroflow/src/builder/build/mod.rs
+++ b/hydroflow/src/builder/build/mod.rs
@@ -20,19 +20,20 @@ pub mod push_partition;
 pub mod push_tee;
 
 use crate::compiled::Pusherator;
-use crate::scheduled::handoff::handoff_list::{BasePortList, RecvPortList, SendPortList};
+use crate::scheduled::handoff::handoff_list::PortList;
+use crate::scheduled::port::{RECV, SEND};
 
 pub trait PullBuildBase {
     type ItemOut;
     type Build<'slf, 'inp>: Iterator<Item = Self::ItemOut>;
 }
 pub trait PullBuild: PullBuildBase {
-    type InputHandoffs: RecvPortList;
+    type InputHandoffs: PortList<RECV>;
 
     /// Builds the iterator for a single run of the subgraph.
     fn build<'slf, 'hof>(
         &'slf mut self,
-        handoffs: <Self::InputHandoffs as BasePortList<false>>::Ctx<'hof>,
+        handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof>;
 }
 
@@ -41,11 +42,11 @@ pub trait PushBuildBase {
     type Build<'slf, 'hof>: Pusherator<Item = Self::ItemIn>;
 }
 pub trait PushBuild: PushBuildBase {
-    type OutputHandoffs: SendPortList;
+    type OutputHandoffs: PortList<SEND>;
 
     /// Builds the pusherator for a single run of the subgraph.
     fn build<'slf, 'hof>(
         &'slf mut self,
-        handoffs: <Self::OutputHandoffs as BasePortList<true>>::Ctx<'hof>,
+        handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof>;
 }

--- a/hydroflow/src/builder/build/pull_chain.rs
+++ b/hydroflow/src/builder/build/pull_chain.rs
@@ -1,6 +1,7 @@
 use super::{PullBuild, PullBuildBase};
 
-use crate::scheduled::handoff::handoff_list::{BasePortList, BasePortListSplit, RecvPortList};
+use crate::scheduled::handoff::handoff_list::{PortList, PortListSplit};
+use crate::scheduled::port::RECV;
 use crate::scheduled::type_list::Extend;
 
 pub struct ChainPullBuild<PrevA, PrevB>
@@ -9,8 +10,8 @@ where
     PrevB: PullBuild<ItemOut = PrevA::ItemOut>,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     prev_a: PrevA,
     prev_b: PrevB,
@@ -22,8 +23,8 @@ where
     PrevB: PullBuild<ItemOut = PrevA::ItemOut>,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     pub fn new(prev_a: PrevA, prev_b: PrevB) -> Self {
         Self { prev_a, prev_b }
@@ -36,8 +37,8 @@ where
     PrevB: PullBuild<ItemOut = PrevA::ItemOut>,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     type ItemOut = PrevA::ItemOut;
     type Build<'slf, 'hof> = std::iter::Chain<PrevA::Build<'slf, 'hof>, PrevB::Build<'slf, 'hof>>;
@@ -49,17 +50,16 @@ where
     PrevB: PullBuild<ItemOut = PrevA::ItemOut>,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     type InputHandoffs = <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended;
 
     fn build<'slf, 'hof>(
         &'slf mut self,
-        input: <Self::InputHandoffs as BasePortList<false>>::Ctx<'hof>,
+        input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
-        let (input_a, input_b) =
-            <Self::InputHandoffs as BasePortListSplit<_, false>>::split_ctx(input);
+        let (input_a, input_b) = <Self::InputHandoffs as PortListSplit<_, _>>::split_ctx(input);
         let iter_a = self.prev_a.build(input_a);
         let iter_b = self.prev_b.build(input_b);
         iter_a.chain(iter_b)

--- a/hydroflow/src/builder/build/pull_cross_join.rs
+++ b/hydroflow/src/builder/build/pull_cross_join.rs
@@ -1,7 +1,8 @@
 use super::{PullBuild, PullBuildBase};
 
 use crate::compiled::pull::{CrossJoin, CrossJoinState};
-use crate::scheduled::handoff::handoff_list::{BasePortList, BasePortListSplit, RecvPortList};
+use crate::scheduled::handoff::handoff_list::{PortList, PortListSplit};
+use crate::scheduled::port::RECV;
 use crate::scheduled::type_list::Extend;
 
 pub struct CrossJoinPullBuild<PrevA, PrevB>
@@ -12,8 +13,8 @@ where
     PrevB::ItemOut: 'static + Eq + Clone,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     prev_a: PrevA,
     prev_b: PrevB,
@@ -27,8 +28,8 @@ where
     PrevB::ItemOut: 'static + Eq + Clone,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     pub fn new(prev_a: PrevA, prev_b: PrevB) -> Self {
         Self {
@@ -47,8 +48,8 @@ where
     PrevB::ItemOut: 'static + Eq + Clone,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     type ItemOut = (PrevA::ItemOut, PrevB::ItemOut);
     type Build<'slf, 'hof> = CrossJoin<
@@ -68,17 +69,16 @@ where
     PrevB::ItemOut: 'static + Eq + Clone,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     type InputHandoffs = <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended;
 
     fn build<'slf, 'hof>(
         &'slf mut self,
-        input: <Self::InputHandoffs as BasePortList<false>>::Ctx<'hof>,
+        input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
-        let (input_a, input_b) =
-            <Self::InputHandoffs as BasePortListSplit<_, false>>::split_ctx(input);
+        let (input_a, input_b) = <Self::InputHandoffs as PortListSplit<_, _>>::split_ctx(input);
         let iter_a = self.prev_a.build(input_a);
         let iter_b = self.prev_b.build(input_b);
         CrossJoin::new(iter_a, iter_b, &mut self.state)

--- a/hydroflow/src/builder/build/pull_filter.rs
+++ b/hydroflow/src/builder/build/pull_filter.rs
@@ -1,6 +1,6 @@
 use super::{PullBuild, PullBuildBase};
 
-use crate::scheduled::handoff::handoff_list::BasePortList;
+use crate::scheduled::{handoff::handoff_list::PortList, port::RECV};
 
 pub struct FilterPullBuild<Prev, Func>
 where
@@ -43,7 +43,7 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
-        handoffs: <Self::InputHandoffs as BasePortList<false>>::Ctx<'hof>,
+        handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         self.prev.build(handoffs).filter(|x| (self.func)(x))
     }

--- a/hydroflow/src/builder/build/pull_filter_map.rs
+++ b/hydroflow/src/builder/build/pull_filter_map.rs
@@ -1,6 +1,6 @@
 use super::{PullBuild, PullBuildBase};
 
-use crate::scheduled::handoff::handoff_list::BasePortList;
+use crate::scheduled::{handoff::handoff_list::PortList, port::RECV};
 
 pub struct FilterMapPullBuild<Prev, Func>
 where
@@ -43,7 +43,7 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
-        handoffs: <Self::InputHandoffs as BasePortList<false>>::Ctx<'hof>,
+        handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         self.prev.build(handoffs).filter_map(|x| (self.func)(x))
     }

--- a/hydroflow/src/builder/build/pull_flatten.rs
+++ b/hydroflow/src/builder/build/pull_flatten.rs
@@ -1,6 +1,6 @@
 use super::{PullBuild, PullBuildBase};
 
-use crate::scheduled::handoff::handoff_list::BasePortList;
+use crate::scheduled::{handoff::handoff_list::PortList, port::RECV};
 
 pub struct FlattenPullBuild<Prev>
 where
@@ -36,7 +36,7 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
-        handoffs: <Self::InputHandoffs as BasePortList<false>>::Ctx<'hof>,
+        handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         self.prev.build(handoffs).flatten()
     }

--- a/hydroflow/src/builder/build/pull_handoff.rs
+++ b/hydroflow/src/builder/build/pull_handoff.rs
@@ -2,9 +2,9 @@ use super::{PullBuild, PullBuildBase};
 
 use std::marker::PhantomData;
 
-use crate::scheduled::handoff::handoff_list::BasePortList;
+use crate::scheduled::handoff::handoff_list::PortList;
 use crate::scheduled::handoff::Handoff;
-use crate::scheduled::port::OutputPort;
+use crate::scheduled::port::{OutputPort, RECV};
 use crate::{tl, tt};
 
 pub struct HandoffPullBuild<Hof>
@@ -50,7 +50,7 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
-        handoffs: <Self::InputHandoffs as BasePortList<false>>::Ctx<'hof>,
+        handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         let tl!(handoff) = handoffs;
         [handoff.take_inner()].into_iter()

--- a/hydroflow/src/builder/build/pull_iter.rs
+++ b/hydroflow/src/builder/build/pull_iter.rs
@@ -1,6 +1,6 @@
 use super::{PullBuild, PullBuildBase};
 
-use crate::scheduled::handoff::handoff_list::BasePortList;
+use crate::scheduled::{handoff::handoff_list::PortList, port::RECV};
 
 pub struct IterPullBuild<I, T>
 where
@@ -33,7 +33,7 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
-        _handoffs: <Self::InputHandoffs as BasePortList<false>>::Ctx<'hof>,
+        _handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         &mut self.it
     }

--- a/hydroflow/src/builder/build/pull_join.rs
+++ b/hydroflow/src/builder/build/pull_join.rs
@@ -3,7 +3,8 @@ use super::{PullBuild, PullBuildBase};
 use std::hash::Hash;
 
 use crate::compiled::pull::{JoinState, SymmetricHashJoin};
-use crate::scheduled::handoff::handoff_list::{BasePortList, BasePortListSplit, RecvPortList};
+use crate::scheduled::handoff::handoff_list::{PortList, PortListSplit};
+use crate::scheduled::port::RECV;
 use crate::scheduled::type_list::Extend;
 
 pub struct JoinPullBuild<PrevA, PrevB, Key, ValA, ValB>
@@ -15,8 +16,8 @@ where
     ValB: 'static + Eq + Clone,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     prev_a: PrevA,
     prev_b: PrevB,
@@ -31,8 +32,8 @@ where
     ValB: 'static + Eq + Clone,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     pub fn new(prev_a: PrevA, prev_b: PrevB) -> Self {
         Self {
@@ -52,8 +53,8 @@ where
     ValB: 'static + Eq + Clone,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     type ItemOut = (Key, ValA, ValB);
     type Build<'slf, 'hof> = SymmetricHashJoin<
@@ -75,17 +76,16 @@ where
     ValB: 'static + Eq + Clone,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     type InputHandoffs = <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended;
 
     fn build<'slf, 'hof>(
         &'slf mut self,
-        input: <Self::InputHandoffs as BasePortList<false>>::Ctx<'hof>,
+        input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
-        let (input_a, input_b) =
-            <Self::InputHandoffs as BasePortListSplit<_, false>>::split_ctx(input);
+        let (input_a, input_b) = <Self::InputHandoffs as PortListSplit<_, _>>::split_ctx(input);
         let iter_a = self.prev_a.build(input_a);
         let iter_b = self.prev_b.build(input_b);
         SymmetricHashJoin::new(iter_a, iter_b, &mut self.state)

--- a/hydroflow/src/builder/build/pull_map.rs
+++ b/hydroflow/src/builder/build/pull_map.rs
@@ -1,6 +1,6 @@
 use super::{PullBuild, PullBuildBase};
 
-use crate::scheduled::handoff::handoff_list::BasePortList;
+use crate::scheduled::{handoff::handoff_list::PortList, port::RECV};
 
 pub struct MapPullBuild<Prev, Func>
 where
@@ -43,7 +43,7 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
-        handoffs: <Self::InputHandoffs as BasePortList<false>>::Ctx<'hof>,
+        handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         self.prev.build(handoffs).map(|x| (self.func)(x))
     }

--- a/hydroflow/src/builder/build/push_filter.rs
+++ b/hydroflow/src/builder/build/push_filter.rs
@@ -1,7 +1,8 @@
 use super::{PushBuild, PushBuildBase};
 
 use crate::compiled::filter::Filter;
-use crate::scheduled::handoff::handoff_list::BasePortList;
+use crate::scheduled::handoff::handoff_list::PortList;
+use crate::scheduled::port::SEND;
 
 pub struct FilterPushBuild<Next, Func>
 where
@@ -45,7 +46,7 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
-        handoffs: <Self::OutputHandoffs as BasePortList<true>>::Ctx<'hof>,
+        handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         Filter::new(|x| (self.func)(x), self.next.build(handoffs))
     }

--- a/hydroflow/src/builder/build/push_filter_map.rs
+++ b/hydroflow/src/builder/build/push_filter_map.rs
@@ -3,7 +3,8 @@ use super::{PushBuild, PushBuildBase};
 use std::marker::PhantomData;
 
 use crate::compiled::filter_map::FilterMap;
-use crate::scheduled::handoff::handoff_list::BasePortList;
+use crate::scheduled::handoff::handoff_list::PortList;
+use crate::scheduled::port::SEND;
 
 pub struct FilterMapPushBuild<Next, Func, In>
 where
@@ -52,7 +53,7 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
-        handoffs: <Self::OutputHandoffs as BasePortList<true>>::Ctx<'hof>,
+        handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         FilterMap::new(|x| (self.func)(x), self.next.build(handoffs))
     }

--- a/hydroflow/src/builder/build/push_flatten.rs
+++ b/hydroflow/src/builder/build/push_flatten.rs
@@ -3,7 +3,8 @@ use super::{PushBuild, PushBuildBase};
 use std::marker::PhantomData;
 
 use crate::compiled::flatten::Flatten;
-use crate::scheduled::handoff::handoff_list::BasePortList;
+use crate::scheduled::handoff::handoff_list::PortList;
+use crate::scheduled::port::SEND;
 
 pub struct FlattenPushBuild<Next, In>
 where
@@ -44,7 +45,7 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
-        handoffs: <Self::OutputHandoffs as BasePortList<true>>::Ctx<'hof>,
+        handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         Flatten::new(self.next.build(handoffs))
     }

--- a/hydroflow/src/builder/build/push_for_each.rs
+++ b/hydroflow/src/builder/build/push_for_each.rs
@@ -3,7 +3,8 @@ use super::{PushBuild, PushBuildBase};
 use std::marker::PhantomData;
 
 use crate::compiled::for_each::ForEach;
-use crate::scheduled::handoff::handoff_list::BasePortList;
+use crate::scheduled::handoff::handoff_list::PortList;
+use crate::scheduled::port::SEND;
 use crate::tt;
 
 pub struct ForEachPushBuild<Func, In>
@@ -44,7 +45,7 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
-        (): <Self::OutputHandoffs as BasePortList<true>>::Ctx<'hof>,
+        (): <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         ForEach::new(|x| (self.func)(x))
     }

--- a/hydroflow/src/builder/build/push_handoff.rs
+++ b/hydroflow/src/builder/build/push_handoff.rs
@@ -3,9 +3,9 @@ use super::{PushBuild, PushBuildBase};
 use std::marker::PhantomData;
 
 use crate::compiled::push_handoff::PushHandoff;
-use crate::scheduled::handoff::handoff_list::BasePortList;
+use crate::scheduled::handoff::handoff_list::PortList;
 use crate::scheduled::handoff::{CanReceive, Handoff};
-use crate::scheduled::port::InputPort;
+use crate::scheduled::port::{InputPort, SEND};
 use crate::{tl, tt};
 
 pub struct HandoffPushBuild<Hof, In>
@@ -51,7 +51,7 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
-        handoffs: <Self::OutputHandoffs as BasePortList<true>>::Ctx<'hof>,
+        handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         let tl!(handoff) = handoffs;
         PushHandoff::new(handoff)

--- a/hydroflow/src/builder/build/push_map.rs
+++ b/hydroflow/src/builder/build/push_map.rs
@@ -3,7 +3,8 @@ use super::{PushBuild, PushBuildBase};
 use std::marker::PhantomData;
 
 use crate::compiled::map::Map;
-use crate::scheduled::handoff::handoff_list::BasePortList;
+use crate::scheduled::handoff::handoff_list::PortList;
+use crate::scheduled::port::SEND;
 
 pub struct MapPushBuild<Next, Func, In>
 where
@@ -52,7 +53,7 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
-        handoffs: <Self::OutputHandoffs as BasePortList<true>>::Ctx<'hof>,
+        handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         Map::new(|x| (self.func)(x), self.next.build(handoffs))
     }

--- a/hydroflow/src/builder/build/push_tee.rs
+++ b/hydroflow/src/builder/build/push_tee.rs
@@ -1,8 +1,8 @@
 use super::{PushBuild, PushBuildBase};
 
 use crate::compiled::tee::Tee;
-use crate::scheduled::handoff::handoff_list::{BasePortList, BasePortListSplit};
-use crate::scheduled::handoff::SendPortList;
+use crate::scheduled::handoff::handoff_list::{PortList, PortListSplit};
+use crate::scheduled::port::SEND;
 use crate::scheduled::type_list::Extend;
 
 pub struct TeePushBuild<NextA, NextB>
@@ -12,8 +12,8 @@ where
     NextA::ItemIn: Clone,
 
     NextA::OutputHandoffs: Extend<NextB::OutputHandoffs>,
-    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended: SendPortList
-        + BasePortListSplit<NextA::OutputHandoffs, true, Suffix = NextB::OutputHandoffs>,
+    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended:
+        PortList<SEND> + PortListSplit<SEND, NextA::OutputHandoffs, Suffix = NextB::OutputHandoffs>,
 {
     next_a: NextA,
     next_b: NextB,
@@ -25,8 +25,8 @@ where
     NextA::ItemIn: Clone,
 
     NextA::OutputHandoffs: Extend<NextB::OutputHandoffs>,
-    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended: SendPortList
-        + BasePortListSplit<NextA::OutputHandoffs, true, Suffix = NextB::OutputHandoffs>,
+    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended:
+        PortList<SEND> + PortListSplit<SEND, NextA::OutputHandoffs, Suffix = NextB::OutputHandoffs>,
 {
     pub fn new(next_a: NextA, next_b: NextB) -> Self {
         Self { next_a, next_b }
@@ -40,8 +40,8 @@ where
     NextA::ItemIn: Clone,
 
     NextA::OutputHandoffs: Extend<NextB::OutputHandoffs>,
-    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended: SendPortList
-        + BasePortListSplit<NextA::OutputHandoffs, true, Suffix = NextB::OutputHandoffs>,
+    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended:
+        PortList<SEND> + PortListSplit<SEND, NextA::OutputHandoffs, Suffix = NextB::OutputHandoffs>,
 {
     type ItemIn = NextA::ItemIn;
     type Build<'slf, 'hof> = Tee<Self::ItemIn, NextA::Build<'slf, 'hof>, NextB::Build<'slf, 'hof>>;
@@ -54,17 +54,16 @@ where
     NextA::ItemIn: Clone,
 
     NextA::OutputHandoffs: Extend<NextB::OutputHandoffs>,
-    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended: SendPortList
-        + BasePortListSplit<NextA::OutputHandoffs, true, Suffix = NextB::OutputHandoffs>,
+    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended:
+        PortList<SEND> + PortListSplit<SEND, NextA::OutputHandoffs, Suffix = NextB::OutputHandoffs>,
 {
     type OutputHandoffs = <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended;
 
     fn build<'slf, 'hof>(
         &'slf mut self,
-        input: <Self::OutputHandoffs as BasePortList<true>>::Ctx<'hof>,
+        input: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
-        let (input_a, input_b) =
-            <Self::OutputHandoffs as BasePortListSplit<_, true>>::split_ctx(input);
+        let (input_a, input_b) = <Self::OutputHandoffs as PortListSplit<_, _>>::split_ctx(input);
         let build_a = self.next_a.build(input_a);
         let build_b = self.next_b.build(input_b);
         Tee::new(build_a, build_b)

--- a/hydroflow/src/builder/surface/pull_chain.rs
+++ b/hydroflow/src/builder/surface/pull_chain.rs
@@ -1,7 +1,8 @@
 use super::{BaseSurface, PullSurface};
 
 use crate::builder::build::pull_chain::ChainPullBuild;
-use crate::scheduled::handoff::handoff_list::{BasePortListSplit, RecvPortList};
+use crate::scheduled::handoff::handoff_list::{PortList, PortListSplit};
+use crate::scheduled::port::RECV;
 use crate::scheduled::type_list::Extend;
 
 pub struct ChainPullSurface<PrevA, PrevB>
@@ -10,8 +11,8 @@ where
     PrevB: PullSurface<ItemOut = PrevA::ItemOut>,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     prev_a: PrevA,
     prev_b: PrevB,
@@ -22,8 +23,8 @@ where
     PrevB: PullSurface<ItemOut = PrevA::ItemOut>,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     pub fn new(prev_a: PrevA, prev_b: PrevB) -> Self {
         Self { prev_a, prev_b }
@@ -36,8 +37,8 @@ where
     PrevB: PullSurface<ItemOut = PrevA::ItemOut>,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     type ItemOut = PrevA::ItemOut;
 }
@@ -48,8 +49,8 @@ where
     PrevB: PullSurface<ItemOut = PrevA::ItemOut>,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     type InputHandoffs = <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended;
     type Build = ChainPullBuild<PrevA::Build, PrevB::Build>;

--- a/hydroflow/src/builder/surface/pull_cross_join.rs
+++ b/hydroflow/src/builder/surface/pull_cross_join.rs
@@ -1,7 +1,8 @@
 use super::{BaseSurface, PullSurface};
 
 use crate::builder::build::pull_cross_join::CrossJoinPullBuild;
-use crate::scheduled::handoff::handoff_list::{BasePortListSplit, RecvPortList};
+use crate::scheduled::handoff::handoff_list::{PortList, PortListSplit};
+use crate::scheduled::port::RECV;
 use crate::scheduled::type_list::Extend;
 
 pub struct CrossJoinPullSurface<PrevA, PrevB>
@@ -12,8 +13,8 @@ where
     PrevB::ItemOut: 'static + Eq + Clone,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     prev_a: PrevA,
     prev_b: PrevB,
@@ -26,8 +27,8 @@ where
     PrevB::ItemOut: 'static + Eq + Clone,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     pub fn new(prev_a: PrevA, prev_b: PrevB) -> Self {
         Self { prev_a, prev_b }
@@ -42,8 +43,8 @@ where
     PrevB::ItemOut: 'static + Eq + Clone,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     type ItemOut = (PrevA::ItemOut, PrevB::ItemOut);
 }
@@ -56,8 +57,8 @@ where
     PrevB::ItemOut: 'static + Eq + Clone,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     type InputHandoffs = <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended;
     type Build = CrossJoinPullBuild<PrevA::Build, PrevB::Build>;

--- a/hydroflow/src/builder/surface/pull_join.rs
+++ b/hydroflow/src/builder/surface/pull_join.rs
@@ -3,7 +3,8 @@ use super::{BaseSurface, PullSurface};
 use std::hash::Hash;
 
 use crate::builder::build::pull_join::JoinPullBuild;
-use crate::scheduled::handoff::handoff_list::{BasePortListSplit, RecvPortList};
+use crate::scheduled::handoff::handoff_list::{PortList, PortListSplit};
+use crate::scheduled::port::RECV;
 use crate::scheduled::type_list::Extend;
 
 pub struct JoinPullSurface<PrevA, PrevB>
@@ -12,8 +13,8 @@ where
     PrevB: PullSurface,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     prev_a: PrevA,
     prev_b: PrevB,
@@ -27,8 +28,8 @@ where
     ValB: 'static + Eq + Clone,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     pub fn new(prev_a: PrevA, prev_b: PrevB) -> Self {
         Self { prev_a, prev_b }
@@ -44,8 +45,8 @@ where
     ValB: 'static + Eq + Clone,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     type ItemOut = (Key, ValA, ValB);
 }
@@ -59,8 +60,8 @@ where
     ValB: 'static + Eq + Clone,
 
     PrevA::InputHandoffs: Extend<PrevB::InputHandoffs>,
-    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended: RecvPortList
-        + BasePortListSplit<PrevA::InputHandoffs, false, Suffix = PrevB::InputHandoffs>,
+    <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended:
+        PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     type InputHandoffs = <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended;
     type Build = JoinPullBuild<PrevA::Build, PrevB::Build, Key, ValA, ValB>;

--- a/hydroflow/src/builder/surface/push_partition.rs
+++ b/hydroflow/src/builder/surface/push_partition.rs
@@ -1,7 +1,8 @@
 use super::PushSurfaceReversed;
 
 use crate::builder::build::push_partition::PartitionPushBuild;
-use crate::scheduled::handoff::handoff_list::{BasePortListSplit, SendPortList};
+use crate::scheduled::handoff::handoff_list::{PortList, PortListSplit};
+use crate::scheduled::port::SEND;
 use crate::scheduled::type_list::Extend;
 
 pub struct PartitionPushSurfaceReversed<NextA, NextB, Func>
@@ -11,8 +12,8 @@ where
     NextB: PushSurfaceReversed<ItemIn = NextA::ItemIn>,
 
     NextA::OutputHandoffs: Extend<NextB::OutputHandoffs>,
-    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended: SendPortList
-        + BasePortListSplit<NextA::OutputHandoffs, true, Suffix = NextB::OutputHandoffs>,
+    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended:
+        PortList<SEND> + PortListSplit<SEND, NextA::OutputHandoffs, Suffix = NextB::OutputHandoffs>,
 {
     func: Func,
     next_a: NextA,
@@ -25,8 +26,8 @@ where
     NextB: PushSurfaceReversed<ItemIn = NextA::ItemIn>,
 
     NextA::OutputHandoffs: Extend<NextB::OutputHandoffs>,
-    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended: SendPortList
-        + BasePortListSplit<NextA::OutputHandoffs, true, Suffix = NextB::OutputHandoffs>,
+    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended:
+        PortList<SEND> + PortListSplit<SEND, NextA::OutputHandoffs, Suffix = NextB::OutputHandoffs>,
 {
     pub fn new(func: Func, next_a: NextA, next_b: NextB) -> Self {
         Self {
@@ -44,8 +45,8 @@ where
     NextB: PushSurfaceReversed<ItemIn = NextA::ItemIn>,
 
     NextA::OutputHandoffs: Extend<NextB::OutputHandoffs>,
-    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended: SendPortList
-        + BasePortListSplit<NextA::OutputHandoffs, true, Suffix = NextB::OutputHandoffs>,
+    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended:
+        PortList<SEND> + PortListSplit<SEND, NextA::OutputHandoffs, Suffix = NextB::OutputHandoffs>,
 {
     type ItemIn = NextA::ItemIn;
 

--- a/hydroflow/src/builder/surface/push_tee.rs
+++ b/hydroflow/src/builder/surface/push_tee.rs
@@ -1,7 +1,8 @@
 use super::PushSurfaceReversed;
 
 use crate::builder::build::push_tee::TeePushBuild;
-use crate::scheduled::handoff::handoff_list::{BasePortListSplit, SendPortList};
+use crate::scheduled::handoff::handoff_list::{PortList, PortListSplit};
+use crate::scheduled::port::SEND;
 use crate::scheduled::type_list::Extend;
 
 pub struct TeePushSurfaceReversed<NextA, NextB>
@@ -11,8 +12,8 @@ where
     NextA::ItemIn: Clone,
 
     NextA::OutputHandoffs: Extend<NextB::OutputHandoffs>,
-    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended: SendPortList
-        + BasePortListSplit<NextA::OutputHandoffs, true, Suffix = NextB::OutputHandoffs>,
+    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended:
+        PortList<SEND> + PortListSplit<SEND, NextA::OutputHandoffs, Suffix = NextB::OutputHandoffs>,
 {
     next_a: NextA,
     next_b: NextB,
@@ -24,8 +25,8 @@ where
     NextA::ItemIn: Clone,
 
     NextA::OutputHandoffs: Extend<NextB::OutputHandoffs>,
-    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended: SendPortList
-        + BasePortListSplit<NextA::OutputHandoffs, true, Suffix = NextB::OutputHandoffs>,
+    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended:
+        PortList<SEND> + PortListSplit<SEND, NextA::OutputHandoffs, Suffix = NextB::OutputHandoffs>,
 {
     pub fn new(next_a: NextA, next_b: NextB) -> Self {
         Self { next_a, next_b }
@@ -39,8 +40,8 @@ where
     NextA::ItemIn: Clone,
 
     NextA::OutputHandoffs: Extend<NextB::OutputHandoffs>,
-    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended: SendPortList
-        + BasePortListSplit<NextA::OutputHandoffs, true, Suffix = NextB::OutputHandoffs>,
+    <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended:
+        PortList<SEND> + PortListSplit<SEND, NextA::OutputHandoffs, Suffix = NextB::OutputHandoffs>,
 {
     type ItemIn = NextA::ItemIn;
 

--- a/hydroflow/src/scheduled/graph.rs
+++ b/hydroflow/src/scheduled/graph.rs
@@ -6,8 +6,9 @@ use std::sync::mpsc::{self, Receiver, RecvError, SyncSender};
 use ref_cast::RefCast;
 
 use super::context::Context;
-use super::handoff::{Handoff, HandoffMeta, RecvPortList, SendPortList};
-use super::port::{InputPort, OutputPort, RecvCtx, SendCtx};
+use super::handoff::handoff_list::PortList;
+use super::handoff::{Handoff, HandoffMeta};
+use super::port::{InputPort, OutputPort, RecvCtx, SendCtx, RECV, SEND};
 use super::reactor::Reactor;
 use super::state::StateHandle;
 #[cfg(feature = "variadic_generics")]
@@ -148,8 +149,8 @@ impl Hydroflow {
         mut subgraph: F,
     ) -> SubgraphId
     where
-        R: 'static + RecvPortList,
-        W: 'static + SendPortList,
+        R: 'static + PortList<RECV>,
+        W: 'static + PortList<SEND>,
         F: 'static + FnMut(&Context<'_>, R::Ctx<'_>, W::Ctx<'_>),
     {
         let sg_id = self.subgraphs.len();

--- a/hydroflow/src/scheduled/handoff/mod.rs
+++ b/hydroflow/src/scheduled/handoff/mod.rs
@@ -2,7 +2,6 @@ pub mod handoff_list;
 mod tee;
 mod vector;
 
-pub use handoff_list::{HandoffList, RecvPortList, SendPortList};
 pub use tee::TeeingHandoff;
 pub use vector::VecHandoff;
 

--- a/hydroflow/src/scheduled/port.rs
+++ b/hydroflow/src/scheduled/port.rs
@@ -8,10 +8,21 @@ use crate::scheduled::handoff::{CanReceive, Handoff, TryCanReceive};
 
 use super::HandoffId;
 
+/// An empty trait used to denote [`Polarity`]: either **send** or **receive**.
+///
+/// [`InputPort`] and [`RecvPort`] have identical representations (via [`Port`]) but are not
+/// interchangable, so [`SEND`] and [`RECV`] which implement this trait are used to differentiate
+/// between the two polarities.
 #[sealed]
 pub trait Polarity: 'static {}
 
+/// An uninstantiable type used to tag port [`Polarity`] as **send**.
+///
+/// See also: [`RECV`].
 pub enum SEND {}
+/// An uninstantiable type used to tag port [`Polarity`] as **receive**.
+///
+/// See also: [`SEND`].
 pub enum RECV {}
 #[sealed]
 impl Polarity for SEND {}
@@ -40,7 +51,7 @@ pub struct PortCtx<S: Polarity, H> {
 pub type SendCtx<H> = PortCtx<SEND, H>;
 pub type RecvCtx<H> = PortCtx<RECV, H>;
 
-/// Context provided to a compiled component for writing to an [OutputPort].
+/// Context provided to a subgraph for writing to an [`OutputPort`].
 impl<H: Handoff> SendCtx<H> {
     // TODO: represent backpressure in this return value.
     pub fn give<T>(&self, item: T) -> T
@@ -58,7 +69,7 @@ impl<H: Handoff> SendCtx<H> {
     }
 }
 
-/// Context provided to a compiled component for reading from an [InputPort].
+/// Context provided to a subgraph for reading from an [`InputPort`].
 impl<H: Handoff> RecvCtx<H> {
     pub fn take_inner(&self) -> H::Inner {
         self.handoff.take_inner()


### PR DESCRIPTION
In the big refactor I used true/false const generics to differentiate between send/recv ports. This switches to use more descriptive tag types (same setup as the tag types in the lattice types).