### PR TITLE
Add context to surface build

### DIFF
--- a/hydroflow/src/builder/build/mod.rs
+++ b/hydroflow/src/builder/build/mod.rs
@@ -20,6 +20,7 @@ pub mod push_partition;
 pub mod push_tee;
 
 use crate::compiled::Pusherator;
+use crate::scheduled::context::Context;
 use crate::scheduled::handoff::handoff_list::PortList;
 use crate::scheduled::port::{RECV, SEND};
 
@@ -33,6 +34,7 @@ pub trait PullBuild: PullBuildBase {
     /// Builds the iterator for a single run of the subgraph.
     fn build<'slf, 'hof>(
         &'slf mut self,
+        context: &Context<'_>,
         handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof>;
 }
@@ -47,6 +49,7 @@ pub trait PushBuild: PushBuildBase {
     /// Builds the pusherator for a single run of the subgraph.
     fn build<'slf, 'hof>(
         &'slf mut self,
+        context: &Context<'_>,
         handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof>;
 }

--- a/hydroflow/src/builder/build/pull_chain.rs
+++ b/hydroflow/src/builder/build/pull_chain.rs
@@ -1,5 +1,6 @@
 use super::{PullBuild, PullBuildBase};
 
+use crate::scheduled::context::Context;
 use crate::scheduled::handoff::handoff_list::{PortList, PortListSplit};
 use crate::scheduled::port::RECV;
 use crate::scheduled::type_list::Extend;
@@ -57,11 +58,12 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
+        context: &Context<'_>,
         input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         let (input_a, input_b) = <Self::InputHandoffs as PortListSplit<_, _>>::split_ctx(input);
-        let iter_a = self.prev_a.build(input_a);
-        let iter_b = self.prev_b.build(input_b);
+        let iter_a = self.prev_a.build(context, input_a);
+        let iter_b = self.prev_b.build(context, input_b);
         iter_a.chain(iter_b)
     }
 }

--- a/hydroflow/src/builder/build/pull_cross_join.rs
+++ b/hydroflow/src/builder/build/pull_cross_join.rs
@@ -1,6 +1,7 @@
 use super::{PullBuild, PullBuildBase};
 
 use crate::compiled::pull::{CrossJoin, CrossJoinState};
+use crate::scheduled::context::Context;
 use crate::scheduled::handoff::handoff_list::{PortList, PortListSplit};
 use crate::scheduled::port::RECV;
 use crate::scheduled::type_list::Extend;
@@ -76,11 +77,12 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
+        context: &Context<'_>,
         input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         let (input_a, input_b) = <Self::InputHandoffs as PortListSplit<_, _>>::split_ctx(input);
-        let iter_a = self.prev_a.build(input_a);
-        let iter_b = self.prev_b.build(input_b);
+        let iter_a = self.prev_a.build(context, input_a);
+        let iter_b = self.prev_b.build(context, input_b);
         CrossJoin::new(iter_a, iter_b, &mut self.state)
     }
 }

--- a/hydroflow/src/builder/build/pull_filter.rs
+++ b/hydroflow/src/builder/build/pull_filter.rs
@@ -1,6 +1,6 @@
 use super::{PullBuild, PullBuildBase};
 
-use crate::scheduled::{handoff::handoff_list::PortList, port::RECV};
+use crate::scheduled::{context::Context, handoff::handoff_list::PortList, port::RECV};
 
 pub struct FilterPullBuild<Prev, Func>
 where
@@ -43,8 +43,11 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
+        context: &Context<'_>,
         handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
-        self.prev.build(handoffs).filter(|x| (self.func)(x))
+        self.prev
+            .build(context, handoffs)
+            .filter(|x| (self.func)(x))
     }
 }

--- a/hydroflow/src/builder/build/pull_filter_map.rs
+++ b/hydroflow/src/builder/build/pull_filter_map.rs
@@ -1,6 +1,6 @@
 use super::{PullBuild, PullBuildBase};
 
-use crate::scheduled::{handoff::handoff_list::PortList, port::RECV};
+use crate::scheduled::{context::Context, handoff::handoff_list::PortList, port::RECV};
 
 pub struct FilterMapPullBuild<Prev, Func>
 where
@@ -43,8 +43,11 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
+        context: &Context<'_>,
         handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
-        self.prev.build(handoffs).filter_map(|x| (self.func)(x))
+        self.prev
+            .build(context, handoffs)
+            .filter_map(|x| (self.func)(x))
     }
 }

--- a/hydroflow/src/builder/build/pull_flatten.rs
+++ b/hydroflow/src/builder/build/pull_flatten.rs
@@ -1,6 +1,6 @@
 use super::{PullBuild, PullBuildBase};
 
-use crate::scheduled::{handoff::handoff_list::PortList, port::RECV};
+use crate::scheduled::{context::Context, handoff::handoff_list::PortList, port::RECV};
 
 pub struct FlattenPullBuild<Prev>
 where
@@ -36,8 +36,9 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
+        context: &Context<'_>,
         handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
-        self.prev.build(handoffs).flatten()
+        self.prev.build(context, handoffs).flatten()
     }
 }

--- a/hydroflow/src/builder/build/pull_handoff.rs
+++ b/hydroflow/src/builder/build/pull_handoff.rs
@@ -2,6 +2,7 @@ use super::{PullBuild, PullBuildBase};
 
 use std::marker::PhantomData;
 
+use crate::scheduled::context::Context;
 use crate::scheduled::handoff::handoff_list::PortList;
 use crate::scheduled::handoff::Handoff;
 use crate::scheduled::port::{RecvPort, RECV};
@@ -50,6 +51,7 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
+        _context: &Context<'_>,
         handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         let tl!(handoff) = handoffs;

--- a/hydroflow/src/builder/build/pull_iter.rs
+++ b/hydroflow/src/builder/build/pull_iter.rs
@@ -1,6 +1,6 @@
 use super::{PullBuild, PullBuildBase};
 
-use crate::scheduled::{handoff::handoff_list::PortList, port::RECV};
+use crate::scheduled::{context::Context, handoff::handoff_list::PortList, port::RECV};
 
 pub struct IterPullBuild<I, T>
 where
@@ -33,6 +33,7 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
+        _context: &Context<'_>,
         _handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         &mut self.it

--- a/hydroflow/src/builder/build/pull_join.rs
+++ b/hydroflow/src/builder/build/pull_join.rs
@@ -3,6 +3,7 @@ use super::{PullBuild, PullBuildBase};
 use std::hash::Hash;
 
 use crate::compiled::pull::{JoinState, SymmetricHashJoin};
+use crate::scheduled::context::Context;
 use crate::scheduled::handoff::handoff_list::{PortList, PortListSplit};
 use crate::scheduled::port::RECV;
 use crate::scheduled::type_list::Extend;
@@ -83,11 +84,12 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
+        context: &Context<'_>,
         input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         let (input_a, input_b) = <Self::InputHandoffs as PortListSplit<_, _>>::split_ctx(input);
-        let iter_a = self.prev_a.build(input_a);
-        let iter_b = self.prev_b.build(input_b);
+        let iter_a = self.prev_a.build(context, input_a);
+        let iter_b = self.prev_b.build(context, input_b);
         SymmetricHashJoin::new(iter_a, iter_b, &mut self.state)
     }
 }

--- a/hydroflow/src/builder/build/pull_map.rs
+++ b/hydroflow/src/builder/build/pull_map.rs
@@ -1,6 +1,6 @@
 use super::{PullBuild, PullBuildBase};
 
-use crate::scheduled::{handoff::handoff_list::PortList, port::RECV};
+use crate::scheduled::{context::Context, handoff::handoff_list::PortList, port::RECV};
 
 pub struct MapPullBuild<Prev, Func>
 where
@@ -43,8 +43,9 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
+        context: &Context<'_>,
         handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
-        self.prev.build(handoffs).map(|x| (self.func)(x))
+        self.prev.build(context, handoffs).map(|x| (self.func)(x))
     }
 }

--- a/hydroflow/src/builder/build/push_filter.rs
+++ b/hydroflow/src/builder/build/push_filter.rs
@@ -1,6 +1,7 @@
 use super::{PushBuild, PushBuildBase};
 
 use crate::compiled::filter::Filter;
+use crate::scheduled::context::Context;
 use crate::scheduled::handoff::handoff_list::PortList;
 use crate::scheduled::port::SEND;
 
@@ -46,8 +47,9 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
+        context: &Context<'_>,
         handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
-        Filter::new(|x| (self.func)(x), self.next.build(handoffs))
+        Filter::new(|x| (self.func)(x), self.next.build(context, handoffs))
     }
 }

--- a/hydroflow/src/builder/build/push_filter_map.rs
+++ b/hydroflow/src/builder/build/push_filter_map.rs
@@ -3,6 +3,7 @@ use super::{PushBuild, PushBuildBase};
 use std::marker::PhantomData;
 
 use crate::compiled::filter_map::FilterMap;
+use crate::scheduled::context::Context;
 use crate::scheduled::handoff::handoff_list::PortList;
 use crate::scheduled::port::SEND;
 
@@ -53,8 +54,9 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
+        context: &Context<'_>,
         handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
-        FilterMap::new(|x| (self.func)(x), self.next.build(handoffs))
+        FilterMap::new(|x| (self.func)(x), self.next.build(context, handoffs))
     }
 }

--- a/hydroflow/src/builder/build/push_flatten.rs
+++ b/hydroflow/src/builder/build/push_flatten.rs
@@ -3,6 +3,7 @@ use super::{PushBuild, PushBuildBase};
 use std::marker::PhantomData;
 
 use crate::compiled::flatten::Flatten;
+use crate::scheduled::context::Context;
 use crate::scheduled::handoff::handoff_list::PortList;
 use crate::scheduled::port::SEND;
 
@@ -45,8 +46,9 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
+        context: &Context<'_>,
         handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
-        Flatten::new(self.next.build(handoffs))
+        Flatten::new(self.next.build(context, handoffs))
     }
 }

--- a/hydroflow/src/builder/build/push_for_each.rs
+++ b/hydroflow/src/builder/build/push_for_each.rs
@@ -3,6 +3,7 @@ use super::{PushBuild, PushBuildBase};
 use std::marker::PhantomData;
 
 use crate::compiled::for_each::ForEach;
+use crate::scheduled::context::Context;
 use crate::scheduled::handoff::handoff_list::PortList;
 use crate::scheduled::port::SEND;
 use crate::tt;
@@ -45,6 +46,7 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
+        _context: &Context<'_>,
         (): <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         ForEach::new(|x| (self.func)(x))

--- a/hydroflow/src/builder/build/push_handoff.rs
+++ b/hydroflow/src/builder/build/push_handoff.rs
@@ -3,6 +3,7 @@ use super::{PushBuild, PushBuildBase};
 use std::marker::PhantomData;
 
 use crate::compiled::push_handoff::PushHandoff;
+use crate::scheduled::context::Context;
 use crate::scheduled::handoff::handoff_list::PortList;
 use crate::scheduled::handoff::{CanReceive, Handoff};
 use crate::scheduled::port::{SendPort, SEND};
@@ -51,6 +52,7 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
+        _context: &Context<'_>,
         handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         let tl!(handoff) = handoffs;

--- a/hydroflow/src/builder/build/push_map.rs
+++ b/hydroflow/src/builder/build/push_map.rs
@@ -3,6 +3,7 @@ use super::{PushBuild, PushBuildBase};
 use std::marker::PhantomData;
 
 use crate::compiled::map::Map;
+use crate::scheduled::context::Context;
 use crate::scheduled::handoff::handoff_list::PortList;
 use crate::scheduled::port::SEND;
 
@@ -53,8 +54,9 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
+        context: &Context<'_>,
         handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
-        Map::new(|x| (self.func)(x), self.next.build(handoffs))
+        Map::new(|x| (self.func)(x), self.next.build(context, handoffs))
     }
 }

--- a/hydroflow/src/builder/build/push_partition.rs
+++ b/hydroflow/src/builder/build/push_partition.rs
@@ -1,6 +1,7 @@
 use super::{PushBuild, PushBuildBase};
 
 use crate::compiled::partition::Partition;
+use crate::scheduled::context::Context;
 use crate::scheduled::handoff::handoff_list::{PortList, PortListSplit};
 use crate::scheduled::port::SEND;
 use crate::scheduled::type_list::Extend;
@@ -78,11 +79,12 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
+        context: &Context<'_>,
         input: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         let (input_a, input_b) = <Self::OutputHandoffs as PortListSplit<_, _>>::split_ctx(input);
-        let build_a = self.next_a.build(input_a);
-        let build_b = self.next_b.build(input_b);
+        let build_a = self.next_a.build(context, input_a);
+        let build_b = self.next_b.build(context, input_b);
         Partition::new(|x| (self.func)(x), build_a, build_b)
     }
 }

--- a/hydroflow/src/builder/build/push_tee.rs
+++ b/hydroflow/src/builder/build/push_tee.rs
@@ -1,6 +1,7 @@
 use super::{PushBuild, PushBuildBase};
 
 use crate::compiled::tee::Tee;
+use crate::scheduled::context::Context;
 use crate::scheduled::handoff::handoff_list::{PortList, PortListSplit};
 use crate::scheduled::port::SEND;
 use crate::scheduled::type_list::Extend;
@@ -61,11 +62,12 @@ where
 
     fn build<'slf, 'hof>(
         &'slf mut self,
+        context: &Context<'_>,
         input: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
     ) -> Self::Build<'slf, 'hof> {
         let (input_a, input_b) = <Self::OutputHandoffs as PortListSplit<_, _>>::split_ctx(input);
-        let build_a = self.next_a.build(input_a);
-        let build_b = self.next_b.build(input_b);
+        let build_a = self.next_a.build(context, input_a);
+        let build_b = self.next_b.build(context, input_b);
         Tee::new(build_a, build_b)
     }
 }

--- a/hydroflow/src/builder/hydroflow_builder.rs
+++ b/hydroflow/src/builder/hydroflow_builder.rs
@@ -59,13 +59,16 @@ impl HydroflowBuilder {
     {
         let ((recv_ports, send_ports), (mut pull_build, mut push_build)) = pivot.into_parts();
 
-        self.hydroflow
-            .add_subgraph(recv_ports, send_ports, move |_ctx, recv_ctx, send_ctx| {
-                let pull = pull_build.build(recv_ctx);
-                let push = push_build.build(send_ctx);
+        self.hydroflow.add_subgraph(
+            recv_ports,
+            send_ports,
+            move |context, recv_ctx, send_ctx| {
+                let pull = pull_build.build(context, recv_ctx);
+                let push = push_build.build(context, send_ctx);
                 let pivot = Pivot::new(pull, push);
                 pivot.run();
-            })
+            },
+        )
     }
 
     /// Creates a new external channel input.


### PR DESCRIPTION
This will be needed once more features are added to context.
We also have the option to remove the wonky handoff list structure via
this.