### PR TITLE
Batch join

### DIFF
--- a/hydroflow/src/builder/build/mod.rs
+++ b/hydroflow/src/builder/build/mod.rs
@@ -1,5 +1,6 @@
 //! Internal "subgraph builders" to implement the Surface API. For more info see [super].
 
+pub mod pull_batch;
 pub mod pull_chain;
 pub mod pull_cross_join;
 pub mod pull_filter;

--- a/hydroflow/src/builder/build/pull_batch.rs
+++ b/hydroflow/src/builder/build/pull_batch.rs
@@ -1,0 +1,98 @@
+use super::{PullBuild, PullBuildBase};
+
+use std::hash::Hash;
+
+use crate::compiled::pull::{BatchJoin, BatchJoinState};
+use crate::scheduled::context::Context;
+use crate::scheduled::handoff::handoff_list::{PortList, PortListSplit};
+use crate::scheduled::port::RECV;
+use crate::scheduled::type_list::Extend;
+
+pub struct BatchPullBuild<PrevBuf, PrevStream, Key, BufVal, StreamVal>
+where
+    PrevBuf: PullBuild<ItemOut = (Key, BufVal)>,
+    PrevStream: PullBuild<ItemOut = (Key, StreamVal)>,
+    Key: 'static + Eq,
+    BufVal: 'static,
+    StreamVal: 'static,
+
+    PrevBuf::InputHandoffs: Extend<PrevStream::InputHandoffs>,
+    <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended: PortList<RECV>
+        + PortListSplit<RECV, PrevBuf::InputHandoffs, Suffix = PrevStream::InputHandoffs>,
+{
+    prev_a: PrevBuf,
+    prev_b: PrevStream,
+    state: BatchJoinState<Key, BufVal>,
+}
+impl<PrevBuf, PrevStream, Key, BufVal, StreamVal>
+    BatchPullBuild<PrevBuf, PrevStream, Key, BufVal, StreamVal>
+where
+    PrevBuf: PullBuild<ItemOut = (Key, BufVal)>,
+    PrevStream: PullBuild<ItemOut = (Key, StreamVal)>,
+    Key: 'static + Eq + Hash,
+    BufVal: 'static,
+    StreamVal: 'static,
+
+    PrevBuf::InputHandoffs: Extend<PrevStream::InputHandoffs>,
+    <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended: PortList<RECV>
+        + PortListSplit<RECV, PrevBuf::InputHandoffs, Suffix = PrevStream::InputHandoffs>,
+{
+    pub fn new(prev_a: PrevBuf, prev_b: PrevStream) -> Self {
+        Self {
+            prev_a,
+            prev_b,
+            state: Default::default(),
+        }
+    }
+}
+
+impl<PrevBuf, PrevStream, Key, BufVal, StreamVal> PullBuildBase
+    for BatchPullBuild<PrevBuf, PrevStream, Key, BufVal, StreamVal>
+where
+    PrevBuf: PullBuild<ItemOut = (Key, BufVal)>,
+    PrevStream: PullBuild<ItemOut = (Key, StreamVal)>,
+    Key: 'static + Eq + Hash,
+    BufVal: 'static,
+    StreamVal: 'static,
+
+    PrevBuf::InputHandoffs: Extend<PrevStream::InputHandoffs>,
+    <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended: PortList<RECV>
+        + PortListSplit<RECV, PrevBuf::InputHandoffs, Suffix = PrevStream::InputHandoffs>,
+{
+    type ItemOut = (Key, StreamVal, Vec<BufVal>);
+    type Build<'slf, 'hof> = BatchJoin<
+        'slf,
+        Key,
+        PrevBuf::Build<'slf, 'hof>,
+        BufVal,
+        PrevStream::Build<'slf, 'hof>,
+        StreamVal,
+    >;
+}
+
+impl<PrevBuf, PrevStream, Key, BufVal, StreamVal> PullBuild
+    for BatchPullBuild<PrevBuf, PrevStream, Key, BufVal, StreamVal>
+where
+    PrevBuf: PullBuild<ItemOut = (Key, BufVal)>,
+    PrevStream: PullBuild<ItemOut = (Key, StreamVal)>,
+    Key: 'static + Eq + Hash,
+    BufVal: 'static,
+    StreamVal: 'static,
+
+    PrevBuf::InputHandoffs: Extend<PrevStream::InputHandoffs>,
+    <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended: PortList<RECV>
+        + PortListSplit<RECV, PrevBuf::InputHandoffs, Suffix = PrevStream::InputHandoffs>,
+{
+    type InputHandoffs = <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended;
+
+    fn build<'slf, 'hof>(
+        &'slf mut self,
+        context: &Context<'_>,
+        input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
+    ) -> Self::Build<'slf, 'hof> {
+        let (input_a, input_b) = <Self::InputHandoffs as PortListSplit<_, _>>::split_ctx(input);
+        let iter_a = self.prev_a.build(context, input_a);
+        let iter_b = self.prev_b.build(context, input_b);
+        BatchJoin::new(iter_a, iter_b, &mut self.state)
+    }
+}

--- a/hydroflow/src/builder/surface/pull_batch.rs
+++ b/hydroflow/src/builder/surface/pull_batch.rs
@@ -1,0 +1,78 @@
+use super::{BaseSurface, PullSurface};
+
+use std::hash::Hash;
+
+use crate::builder::build::pull_batch::BatchPullBuild;
+use crate::scheduled::handoff::handoff_list::{PortList, PortListSplit};
+use crate::scheduled::port::RECV;
+use crate::scheduled::type_list::Extend;
+
+pub struct BatchPullSurface<PrevBuf, PrevStream>
+where
+    PrevBuf: PullSurface,
+    PrevStream: PullSurface,
+
+    PrevBuf::InputHandoffs: Extend<PrevStream::InputHandoffs>,
+    <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended: PortList<RECV>
+        + PortListSplit<RECV, PrevBuf::InputHandoffs, Suffix = PrevStream::InputHandoffs>,
+{
+    prev_a: PrevBuf,
+    prev_b: PrevStream,
+}
+impl<PrevBuf, PrevStream, Key, BufVal, StreamVal> BatchPullSurface<PrevBuf, PrevStream>
+where
+    PrevBuf: PullSurface<ItemOut = (Key, BufVal)>,
+    PrevStream: PullSurface<ItemOut = (Key, StreamVal)>,
+    Key: 'static + Eq + Hash,
+    BufVal: 'static,
+    StreamVal: 'static,
+
+    PrevBuf::InputHandoffs: Extend<PrevStream::InputHandoffs>,
+    <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended: PortList<RECV>
+        + PortListSplit<RECV, PrevBuf::InputHandoffs, Suffix = PrevStream::InputHandoffs>,
+{
+    pub fn new(prev_a: PrevBuf, prev_b: PrevStream) -> Self {
+        Self { prev_a, prev_b }
+    }
+}
+
+impl<PrevBuf, PrevStream, Key, BufVal, StreamVal> BaseSurface
+    for BatchPullSurface<PrevBuf, PrevStream>
+where
+    PrevBuf: PullSurface<ItemOut = (Key, BufVal)>,
+    PrevStream: PullSurface<ItemOut = (Key, StreamVal)>,
+    Key: 'static + Eq + Hash,
+    BufVal: 'static,
+    StreamVal: 'static,
+
+    PrevBuf::InputHandoffs: Extend<PrevStream::InputHandoffs>,
+    <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended: PortList<RECV>
+        + PortListSplit<RECV, PrevBuf::InputHandoffs, Suffix = PrevStream::InputHandoffs>,
+{
+    type ItemOut = (Key, StreamVal, Vec<BufVal>);
+}
+
+impl<PrevBuf, PrevStream, Key, BufVal, StreamVal> PullSurface
+    for BatchPullSurface<PrevBuf, PrevStream>
+where
+    PrevBuf: PullSurface<ItemOut = (Key, BufVal)>,
+    PrevStream: PullSurface<ItemOut = (Key, StreamVal)>,
+    Key: 'static + Eq + Hash,
+    BufVal: 'static,
+    StreamVal: 'static,
+
+    PrevBuf::InputHandoffs: Extend<PrevStream::InputHandoffs>,
+    <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended: PortList<RECV>
+        + PortListSplit<RECV, PrevBuf::InputHandoffs, Suffix = PrevStream::InputHandoffs>,
+{
+    type InputHandoffs = <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended;
+    type Build = BatchPullBuild<PrevBuf::Build, PrevStream::Build, Key, BufVal, StreamVal>;
+
+    fn into_parts(self) -> (Self::InputHandoffs, Self::Build) {
+        let (connect_a, build_a) = self.prev_a.into_parts();
+        let (connect_b, build_b) = self.prev_b.into_parts();
+        let connect = connect_a.extend(connect_b);
+        let build = BatchPullBuild::new(build_a, build_b);
+        (connect, build)
+    }
+}

--- a/hydroflow/src/scheduled/mod.rs
+++ b/hydroflow/src/scheduled/mod.rs
@@ -16,3 +16,67 @@ pub mod util;
 pub type SubgraphId = usize;
 pub type HandoffId = usize;
 pub type StateId = usize;
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, rc::Rc};
+
+    use crate::{
+        builder::{
+            prelude::{BaseSurface, PullSurface, PushSurface},
+            HydroflowBuilder,
+        },
+        scheduled::handoff::VecHandoff,
+    };
+
+    #[test]
+    fn test_batcher() {
+        let outputs = Rc::new(RefCell::new(Vec::new()));
+        let mut df = HydroflowBuilder::default();
+
+        let (stream_input, stream_hoff) = df.add_channel_input::<Option<u64>, VecHandoff<_>>();
+        let (ticks_input, ticks_hoff) = df.add_channel_input::<Option<u64>, VecHandoff<_>>();
+
+        let outputs_inner = outputs.clone();
+        df.add_subgraph(
+            stream_hoff
+                .flatten()
+                .map(|x| ((), x))
+                .batch_with(ticks_hoff.flatten().map(|x| ((), x)))
+                .map(|((), x, v)| (x, v))
+                .pull_to_push()
+                .for_each(move |x| (*outputs_inner).borrow_mut().push(x)),
+        );
+
+        let mut df = df.build();
+
+        stream_input.give(Some(1));
+        stream_input.give(Some(2));
+        stream_input.give(Some(3));
+        stream_input.flush();
+        ticks_input.give(Some(1));
+        ticks_input.flush();
+
+        df.tick();
+        assert_eq!(vec![(1, vec![1, 2, 3])], *outputs.borrow());
+
+        ticks_input.give(Some(2));
+        ticks_input.flush();
+
+        df.tick();
+        assert_eq!(vec![(1, vec![1, 2, 3])], *outputs.borrow());
+
+        stream_input.give(Some(4));
+        stream_input.give(Some(5));
+        stream_input.flush();
+
+        df.tick();
+        assert_eq!(vec![(1, vec![1, 2, 3])], *outputs.borrow());
+
+        ticks_input.give(Some(3));
+        ticks_input.flush();
+
+        df.tick();
+        assert_eq!(vec![(1, vec![1, 2, 3]), (3, vec![4, 5])], *outputs.borrow());
+    }
+}


### PR DESCRIPTION
This commit introduces a "batching" operator, that buffers up data on one side until provoked to flush by the other side. I think the most common mode for this will be using unit as the key, but you can also partition up the batches by key and flush them independently.