### PR TITLE
Revert "Temporarily pin toolchain to nightly-2022-02-09" due to nightly fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2022-02-09
+          toolchain: nightly
           override: true
 
       - name: Run cargo check
@@ -60,7 +60,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2022-02-09
+          toolchain: nightly
           override: true
           components: rustfmt
 
@@ -82,7 +82,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2022-02-09
+          toolchain: nightly
           override: true
           components: rustfmt, clippy
 
@@ -113,7 +113,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2022-02-09
+          toolchain: nightly
           override: true
 
       - name: Run cargo doc
@@ -169,7 +169,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2022-02-09
+          toolchain: nightly
           override: true
 
       - name: Checkout gh-pages

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly-2022-02-09"


### PR DESCRIPTION
This reverts commit 92b4cfb043c6789497f74d429d7f3fa045d87355.

Rust nightly fixed by https://github.com/rust-lang/rust/pull/93892#event-6104854781