### PR TITLE
Fix hf.run_async() busy spinning.

### DIFF
--- a/hydroflow/src/scheduled/context.rs
+++ b/hydroflow/src/scheduled/context.rs
@@ -1,4 +1,6 @@
-use std::{any::Any, sync::mpsc::SyncSender};
+use std::any::Any;
+
+use tokio::sync::mpsc::UnboundedSender;
 
 use super::{
     graph::{HandoffData, StateData},
@@ -12,7 +14,7 @@ pub struct Context<'a> {
     pub(crate) subgraph_id: SubgraphId,
     pub(crate) handoffs: &'a mut [HandoffData],
     pub(crate) states: &'a mut [StateData],
-    pub(crate) event_queue_send: &'a mut SyncSender<SubgraphId>,
+    pub(crate) event_queue_send: &'a UnboundedSender<SubgraphId>,
 }
 impl<'a> Context<'a> {
     pub fn waker(&self) -> std::task::Waker {
@@ -21,7 +23,7 @@ impl<'a> Context<'a> {
 
         struct ContextWaker {
             subgraph_id: SubgraphId,
-            event_queue_send: SyncSender<SubgraphId>,
+            event_queue_send: UnboundedSender<SubgraphId>,
         }
         impl ArcWake for ContextWaker {
             fn wake_by_ref(arc_self: &Arc<Self>) {

--- a/hydroflow/src/scheduled/reactor.rs
+++ b/hydroflow/src/scheduled/reactor.rs
@@ -1,4 +1,5 @@
-use std::sync::mpsc::{SyncSender, TrySendError};
+use tokio::sync::mpsc::error::SendError;
+use tokio::sync::mpsc::UnboundedSender;
 
 use super::SubgraphId;
 
@@ -8,15 +9,15 @@ use super::SubgraphId;
  */
 #[derive(Clone)]
 pub struct Reactor {
-    event_queue_send: SyncSender<SubgraphId>,
+    event_queue_send: UnboundedSender<SubgraphId>,
 }
 impl Reactor {
-    pub fn new(event_queue_send: SyncSender<SubgraphId>) -> Self {
+    pub fn new(event_queue_send: UnboundedSender<SubgraphId>) -> Self {
         Self { event_queue_send }
     }
 
-    pub fn trigger(&self, sg_id: SubgraphId) -> Result<(), TrySendError<usize>> {
-        self.event_queue_send.try_send(sg_id)
+    pub fn trigger(&self, sg_id: SubgraphId) -> Result<(), SendError<usize>> {
+        self.event_queue_send.send(sg_id)
     }
 
     #[cfg(feature = "async")]


### PR DESCRIPTION
This replaces the std mpsc event channels with tokio unbounded channels
so we can .await them.

Fixes #87