### PR TITLE
Rewrite KVS in dataflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,15 +509,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +537,7 @@ name = "kvs"
 version = "0.1.0"
 dependencies = [
  "hydroflow",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -562,9 +554,9 @@ checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -595,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.14"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
 dependencies = [
  "libc",
  "log",
@@ -685,27 +677,25 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
- "instant",
  "lock_api",
  "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
 dependencies = [
  "cfg-if",
- "instant",
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1060,6 +1050,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
+name = "socket2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
  "bytes",
  "libc",
@@ -1210,6 +1210,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "winapi",
 ]
@@ -1391,6 +1392,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "xshell"

--- a/hydroflow/src/builder/build/mod.rs
+++ b/hydroflow/src/builder/build/mod.rs
@@ -6,6 +6,7 @@ pub mod pull_cross_join;
 pub mod pull_filter;
 pub mod pull_filter_map;
 pub mod pull_flatten;
+pub mod pull_half_hash_join;
 pub mod pull_handoff;
 pub mod pull_iter;
 pub mod pull_join;

--- a/hydroflow/src/builder/build/pull_half_hash_join.rs
+++ b/hydroflow/src/builder/build/pull_half_hash_join.rs
@@ -1,0 +1,109 @@
+use super::{PullBuild, PullBuildBase};
+
+use std::hash::Hash;
+use std::marker::PhantomData;
+
+use crate::compiled::pull::{HalfHashJoin, HalfHashJoinState};
+use crate::lang::lattice::{LatticeRepr, Merge};
+use crate::scheduled::context::Context;
+use crate::scheduled::handoff::handoff_list::{PortList, PortListSplit};
+use crate::scheduled::port::RECV;
+use crate::scheduled::type_list::Extend;
+
+pub struct HalfHashJoinPullBuild<PrevBuf, PrevStream, Key, L, Update, StreamVal>
+where
+    PrevBuf: PullBuild<ItemOut = (Key, Update::Repr)>,
+    PrevStream: PullBuild<ItemOut = (Key, StreamVal)>,
+    Key: 'static + Eq,
+    L: 'static + LatticeRepr + Merge<Update>,
+    Update: 'static + LatticeRepr,
+    StreamVal: 'static,
+
+    PrevBuf::InputHandoffs: Extend<PrevStream::InputHandoffs>,
+    <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended: PortList<RECV>
+        + PortListSplit<RECV, PrevBuf::InputHandoffs, Suffix = PrevStream::InputHandoffs>,
+{
+    prev_a: PrevBuf,
+    prev_b: PrevStream,
+    state: HalfHashJoinState<Key, L>,
+    _marker: PhantomData<Update>,
+}
+impl<PrevBuf, PrevStream, Key, L, Update, StreamVal>
+    HalfHashJoinPullBuild<PrevBuf, PrevStream, Key, L, Update, StreamVal>
+where
+    PrevBuf: PullBuild<ItemOut = (Key, Update::Repr)>,
+    PrevStream: PullBuild<ItemOut = (Key, StreamVal)>,
+    Key: 'static + Eq + Hash,
+    L: 'static + LatticeRepr + Merge<Update>,
+    Update: 'static + LatticeRepr,
+    StreamVal: 'static,
+
+    PrevBuf::InputHandoffs: Extend<PrevStream::InputHandoffs>,
+    <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended: PortList<RECV>
+        + PortListSplit<RECV, PrevBuf::InputHandoffs, Suffix = PrevStream::InputHandoffs>,
+{
+    pub fn new(prev_a: PrevBuf, prev_b: PrevStream) -> Self {
+        Self {
+            prev_a,
+            prev_b,
+            state: Default::default(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<PrevBuf, PrevStream, Key, L, Update, StreamVal> PullBuildBase
+    for HalfHashJoinPullBuild<PrevBuf, PrevStream, Key, L, Update, StreamVal>
+where
+    PrevBuf: PullBuild<ItemOut = (Key, Update::Repr)>,
+    PrevStream: PullBuild<ItemOut = (Key, StreamVal)>,
+    Key: 'static + Eq + Hash + Clone,
+    L: 'static + LatticeRepr + Merge<Update>,
+    L::Repr: Default,
+    Update: 'static + LatticeRepr,
+    StreamVal: 'static + Clone,
+
+    PrevBuf::InputHandoffs: Extend<PrevStream::InputHandoffs>,
+    <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended: PortList<RECV>
+        + PortListSplit<RECV, PrevBuf::InputHandoffs, Suffix = PrevStream::InputHandoffs>,
+{
+    type ItemOut = (Key, StreamVal, L::Repr);
+    type Build<'slf, 'hof> = HalfHashJoin<
+        'slf,
+        Key,
+        PrevBuf::Build<'slf, 'hof>,
+        L,
+        Update,
+        PrevStream::Build<'slf, 'hof>,
+        StreamVal,
+    >;
+}
+
+impl<PrevBuf, PrevStream, Key, L, Update, StreamVal> PullBuild
+    for HalfHashJoinPullBuild<PrevBuf, PrevStream, Key, L, Update, StreamVal>
+where
+    PrevBuf: PullBuild<ItemOut = (Key, Update::Repr)>,
+    PrevStream: PullBuild<ItemOut = (Key, StreamVal)>,
+    Key: 'static + Eq + Hash + Clone,
+    L: 'static + LatticeRepr + Merge<Update>,
+    L::Repr: Default + Clone,
+    Update: 'static + LatticeRepr,
+    StreamVal: 'static + Clone,
+
+    PrevBuf::InputHandoffs: Extend<PrevStream::InputHandoffs>,
+    <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended: PortList<RECV>
+        + PortListSplit<RECV, PrevBuf::InputHandoffs, Suffix = PrevStream::InputHandoffs>,
+{
+    type InputHandoffs = <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended;
+
+    fn build<'slf, 'hof>(
+        &'slf mut self,
+        context: &Context<'_>,
+        input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
+    ) -> Self::Build<'slf, 'hof> {
+        let (input_a, input_b) = <Self::InputHandoffs as PortListSplit<_, _>>::split_ctx(input);
+        let iter_a = self.prev_a.build(context, input_a);
+        let iter_b = self.prev_b.build(context, input_b);
+        HalfHashJoin::new(iter_a, iter_b, &mut self.state)
+    }
+}

--- a/hydroflow/src/builder/surface/pull_half_hash_join.rs
+++ b/hydroflow/src/builder/surface/pull_half_hash_join.rs
@@ -1,0 +1,92 @@
+use super::{BaseSurface, PullSurface};
+
+use std::hash::Hash;
+use std::marker::PhantomData;
+
+use crate::builder::build::pull_half_hash_join::HalfHashJoinPullBuild;
+use crate::lang::lattice::{LatticeRepr, Merge};
+use crate::scheduled::handoff::handoff_list::{PortList, PortListSplit};
+use crate::scheduled::port::RECV;
+use crate::scheduled::type_list::Extend;
+
+pub struct HalfHashJoinPullSurface<PrevStream, PrevBuf, L, Update>
+where
+    PrevBuf: PullSurface,
+    PrevStream: PullSurface,
+    L: LatticeRepr,
+
+    PrevBuf::InputHandoffs: Extend<PrevStream::InputHandoffs>,
+    <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended: PortList<RECV>
+        + PortListSplit<RECV, PrevBuf::InputHandoffs, Suffix = PrevStream::InputHandoffs>,
+{
+    prev_stream: PrevStream,
+    prev_buf: PrevBuf,
+    _marker: PhantomData<(L, Update)>,
+}
+impl<PrevBuf, PrevStream, Key, L, Update, StreamVal>
+    HalfHashJoinPullSurface<PrevStream, PrevBuf, L, Update>
+where
+    PrevBuf: PullSurface<ItemOut = (Key, Update::Repr)>,
+    PrevStream: PullSurface<ItemOut = (Key, StreamVal)>,
+    Key: 'static + Eq + Hash + Clone,
+    L: 'static + LatticeRepr + Merge<Update>,
+    Update: 'static + LatticeRepr,
+    StreamVal: 'static + Clone,
+
+    PrevBuf::InputHandoffs: Extend<PrevStream::InputHandoffs>,
+    <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended: PortList<RECV>
+        + PortListSplit<RECV, PrevBuf::InputHandoffs, Suffix = PrevStream::InputHandoffs>,
+{
+    pub fn new(prev_stream: PrevStream, prev_buf: PrevBuf) -> Self {
+        Self {
+            prev_stream,
+            prev_buf,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<PrevBuf, PrevStream, Key, L, Update, StreamVal> BaseSurface
+    for HalfHashJoinPullSurface<PrevStream, PrevBuf, L, Update>
+where
+    PrevBuf: PullSurface<ItemOut = (Key, Update::Repr)>,
+    PrevStream: PullSurface<ItemOut = (Key, StreamVal)>,
+    Key: 'static + Eq + Hash + Clone,
+    L: 'static + LatticeRepr + Merge<Update>,
+    Update: 'static + LatticeRepr,
+    StreamVal: 'static + Clone,
+
+    PrevBuf::InputHandoffs: Extend<PrevStream::InputHandoffs>,
+    <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended: PortList<RECV>
+        + PortListSplit<RECV, PrevBuf::InputHandoffs, Suffix = PrevStream::InputHandoffs>,
+{
+    type ItemOut = (Key, StreamVal, L::Repr);
+}
+
+impl<PrevBuf, PrevStream, Key, L, Update, StreamVal> PullSurface
+    for HalfHashJoinPullSurface<PrevStream, PrevBuf, L, Update>
+where
+    PrevBuf: PullSurface<ItemOut = (Key, Update::Repr)>,
+    PrevStream: PullSurface<ItemOut = (Key, StreamVal)>,
+    Key: 'static + Eq + Hash + Clone,
+    L: 'static + LatticeRepr + Merge<Update>,
+    L::Repr: Default + Clone,
+    Update: 'static + LatticeRepr,
+    StreamVal: 'static + Clone,
+
+    PrevBuf::InputHandoffs: Extend<PrevStream::InputHandoffs>,
+    <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended: PortList<RECV>
+        + PortListSplit<RECV, PrevBuf::InputHandoffs, Suffix = PrevStream::InputHandoffs>,
+{
+    type InputHandoffs = <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended;
+    type Build =
+        HalfHashJoinPullBuild<PrevBuf::Build, PrevStream::Build, Key, L, Update, StreamVal>;
+
+    fn into_parts(self) -> (Self::InputHandoffs, Self::Build) {
+        let (connect_a, build_a) = self.prev_buf.into_parts();
+        let (connect_b, build_b) = self.prev_stream.into_parts();
+        let connect = connect_a.extend(connect_b);
+        let build = HalfHashJoinPullBuild::new(build_a, build_b);
+        (connect, build)
+    }
+}

--- a/hydroflow/src/compiled/pull.rs
+++ b/hydroflow/src/compiled/pull.rs
@@ -11,6 +11,82 @@ where
 {
     state: L::Repr,
 }
+pub struct HalfHashJoinState<K, L>
+where
+    L: LatticeRepr,
+{
+    tab: HashMap<K, L::Repr>,
+}
+
+impl<K, L> Default for HalfHashJoinState<K, L>
+where
+    L: LatticeRepr,
+{
+    fn default() -> Self {
+        Self {
+            tab: HashMap::new(),
+        }
+    }
+}
+
+pub struct HalfHashJoin<'a, K, Buf, L, Update, Stream, StreamV>
+where
+    K: Eq + std::hash::Hash,
+    L: LatticeRepr + Merge<Update>,
+    Update: LatticeRepr,
+    Buf: Iterator<Item = (K, Update::Repr)>,
+    Stream: Iterator<Item = (K, StreamV)>,
+{
+    buf: Buf,
+    stream: Stream,
+    state: &'a mut HalfHashJoinState<K, L>,
+    _marker: PhantomData<Update>,
+}
+
+impl<'a, K, Buf, L, Update, Stream, StreamV> Iterator
+    for HalfHashJoin<'a, K, Buf, L, Update, Stream, StreamV>
+where
+    K: Eq + std::hash::Hash + Clone,
+    L: LatticeRepr + Merge<Update>,
+    L::Repr: Default,
+    Update: LatticeRepr,
+    StreamV: Clone,
+    Buf: Iterator<Item = (K, Update::Repr)>,
+    Stream: Iterator<Item = (K, StreamV)>,
+{
+    type Item = (K, StreamV, L::Repr);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        for (k, v) in &mut self.buf {
+            <L as Merge<Update>>::merge(self.state.tab.entry(k).or_default(), v);
+        }
+
+        for (k, v) in &mut self.stream {
+            if let Some(vals) = self.state.tab.get(&k) {
+                return Some((k, v, vals.clone()));
+            }
+        }
+        None
+    }
+}
+impl<'a, K, Buf, L, Update, Stream, StreamV> HalfHashJoin<'a, K, Buf, L, Update, Stream, StreamV>
+where
+    K: Eq + std::hash::Hash,
+    Buf: Iterator<Item = (K, Update::Repr)>,
+    Stream: Iterator<Item = (K, StreamV)>,
+    Update: LatticeRepr,
+    L: LatticeRepr + Merge<Update>,
+    L::Repr: Clone,
+{
+    pub fn new(buf: Buf, stream: Stream, state: &'a mut HalfHashJoinState<K, L>) -> Self {
+        Self {
+            buf,
+            stream,
+            state,
+            _marker: PhantomData,
+        }
+    }
+}
 
 impl<L> Default for BatchJoinState<L>
 where

--- a/kvs/Cargo.toml
+++ b/kvs/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 hydroflow = { path = "../hydroflow" }
+tokio-stream = { version = "0.1.8" }

--- a/kvs/src/main.rs
+++ b/kvs/src/main.rs
@@ -1,35 +1,28 @@
 #![feature(never_type)]
 
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::time::Duration;
 
 use hydroflow::{
+    builder::{
+        prelude::{BaseSurface, PullSurface, PushSurface},
+        surface::pull_iter::IterPullSurface,
+        HydroflowBuilder,
+    },
     lang::{
         collections::Single,
-        lattice::{
-            dom_pair::DomPairRepr, map_union::MapUnionRepr, ord::MaxRepr, LatticeRepr, Merge,
-        },
+        lattice::{map_union::MapUnionRepr, ord::MaxRepr, set_union::SetUnionRepr},
         tag,
     },
+    scheduled::handoff::VecHandoff,
     tokio::{
         self,
-        sync::{
-            mpsc::{channel, Receiver, Sender},
-            Mutex,
-        },
+        sync::mpsc::{channel, Receiver, Sender},
     },
 };
+use tokio_stream::{wrappers::ReceiverStream, StreamExt};
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 struct ActorId(u64);
-
-type Timestamp = HashMap<usize, u64>;
-
-type ClockRepr = MapUnionRepr<tag::HASH_MAP, usize, MaxRepr<u64>>;
-type ClockUpdateRepr = MapUnionRepr<tag::SINGLE, usize, MaxRepr<u64>>;
-
-type DataRepr<K, V> = MapUnionRepr<tag::HASH_MAP, K, DomPairRepr<ClockRepr, MaxRepr<V>>>;
-type BatchRepr<K, V> = MapUnionRepr<tag::VEC, K, DomPairRepr<ClockRepr, MaxRepr<V>>>;
-type UpdateRepr<K, V> = MapUnionRepr<tag::SINGLE, K, DomPairRepr<ClockRepr, MaxRepr<V>>>;
 
 #[derive(Clone, Debug)]
 enum Message<K, V>
@@ -40,7 +33,7 @@ where
     // A KV set request from a client.
     Set(K, V),
     // A set of data that I am responsible for, sent to me by another worker.
-    Batch((usize, u64), Vec<(K, (Timestamp, V))>),
+    Batch((usize, u64), Vec<(K, V)>),
 }
 
 unsafe impl<K, V> Send for Message<K, V>
@@ -57,6 +50,7 @@ fn main() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async move {
         loop {
+            tokio::time::sleep(Duration::from_millis(10)).await;
             for s in &senders {
                 i += 1;
                 s.send(Message::Set(format!("foo{}", i % 100), "bar".into()))
@@ -108,9 +102,28 @@ where
     senders
 }
 
-// TODO(justin): add a stack-allocated implementation of this.
-fn owners<K: std::hash::Hash>(n: u64, _v: &K) -> Vec<usize> {
-    (0..n as usize).collect()
+// TODO(justin): this thing is hacky.
+#[derive(Debug, Copy, Clone)]
+struct PerQuantumPulser {
+    on: bool,
+}
+
+impl PerQuantumPulser {
+    fn new() -> Self {
+        PerQuantumPulser { on: true }
+    }
+}
+
+impl Iterator for PerQuantumPulser {
+    type Item = ();
+    fn next(&mut self) -> Option<()> {
+        self.on = !self.on;
+        if self.on {
+            None
+        } else {
+            Some(())
+        }
+    }
 }
 
 fn spawn_threads<K, V>(workers: u64) -> Vec<Sender<Message<K, V>>>
@@ -120,80 +133,113 @@ where
 {
     spawn(
         workers,
-        move |id, mut receiver: Receiver<Message<K, V>>, senders| {
+        move |id, receiver: Receiver<Message<K, V>>, senders: Vec<Sender<Message<K, V>>>| {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async move {
-                let clock: <ClockRepr as LatticeRepr>::Repr = Default::default();
-                let clock = Arc::new(Mutex::new(clock));
-                let mut epoch = 0_u64;
+                let mut hf = HydroflowBuilder::default();
 
-                let current_updates: <DataRepr<K, V> as LatticeRepr>::Repr = Default::default();
-                let current_updates = Arc::new(Mutex::new(current_updates));
+                let (z_send, z_recv) = hf.add_channel_input::<_, Option<u64>, VecHandoff<u64>>("ticks");
 
-                let data: <DataRepr<K, V> as LatticeRepr>::Repr = Default::default();
-                let data = Arc::new(Mutex::new(data));
-
-                let event_updates = current_updates.clone();
-
-                let event_loop = tokio::spawn(async move {
-                    while let Some(msg) = receiver.recv().await {
-                        match msg {
-                            Message::Set(k, v) => {
-                                let mut updates = event_updates.lock().await;
-                                <DataRepr<K, V> as Merge<UpdateRepr<K, V>>>::merge(
-                                    &mut updates,
-                                    Single((k, (clock.lock().await.clone(), v))),
-                                );
-                            }
-                            Message::Batch((from, epoch), mut batch) => {
-                                let mut clock = clock.lock().await;
-                                <ClockRepr as Merge<ClockUpdateRepr>>::merge(
-                                    &mut clock,
-                                    Single((from, epoch)),
-                                );
-                                for (k, v) in batch.drain(..) {
-                                    let mut data = data.lock().await;
-                                    <DataRepr<K, V> as Merge<UpdateRepr<K, V>>>::merge(
-                                        &mut data,
-                                        Single((k, v)),
-                                    );
-                                }
-                            }
-                        }
-                    }
-                });
-
+                // Construct the ticker.
                 let epoch_duration = Duration::from_millis(100);
                 tokio::spawn(async move {
+                    let mut tick = 0;
                     loop {
                         tokio::time::sleep(epoch_duration).await;
-                        epoch += 1;
-                        let my_clock = Single((id, epoch));
-                        // let mut clock = clock.lock().await;
-                        // <ClockRepr as Merge<ClockUpdateRepr>>::merge(&mut clock, Single((id, epoch)));
-                        let mut batches: Vec<<BatchRepr<K, V> as LatticeRepr>::Repr> =
-                            (0..workers).map(|_| Default::default()).collect();
-
-                        for (k, (mut ts, v)) in current_updates.lock().await.drain() {
-                            <ClockRepr as Merge<ClockUpdateRepr>>::merge(&mut ts, my_clock);
-                            // TODO(justin): save a clone here.
-                            for owner in owners(workers, &k) {
-                                <BatchRepr<K, V> as Merge<UpdateRepr<K, V>>>::merge(
-                                    &mut batches[owner],
-                                    Single((k.clone(), (ts.clone(), v.clone()))),
-                                );
-                            }
-                        }
-
-                        // TODO(justin): do this in parallel?
-                        // TODO(justin): reuse the memory by keeping the vecs around?
-                        for (s, batch) in senders.iter().zip(batches.into_iter()) {
-                            s.send(Message::Batch((id, epoch), batch)).await.unwrap();
-                        }
+                        z_send.give(Some(tick));
+                        z_send.flush();
+                        tick += 1;
                     }
                 });
 
-                event_loop.await.unwrap();
+                let (reads_send, reads_recv) =
+                    hf.add_channel_input::<_, Option<K>, VecHandoff<K>>("reads");
+
+                let _ = reads_send;
+
+                let q_recv = hf.add_input_from_stream::<_, Option<_>, VecHandoff<_>, _>("writes", ReceiverStream::new(receiver).map(Some));
+
+                // Make the ownership table. Everyone owns everything.
+                let ownership = (0..senders.len()).map(|i| ((), Single(i)));
+
+                let (x_send, x_recv) =
+                    hf.make_edge::<_, VecHandoff<(usize, u64, Vec<(K, V)>)>, Option<(usize, u64, Vec<(K, V)>)>>("received_batches");
+                let (y_send, y_recv) = hf.make_edge::<_, VecHandoff<(K, V)>, Option<(K, V)>>("write_requests");
+
+                hf.add_subgraph(
+                    "write_handler",
+                    y_recv
+                        .flatten()
+                        .map(|(k, v)| Single((k, v)))
+                        .batch_with::<_, MapUnionRepr<tag::HASH_MAP, K, MaxRepr<V>>, MapUnionRepr<tag::SINGLE, K, MaxRepr<V>>, _>(z_recv.flatten())
+                        .flat_map(|(epoch, batch)| {
+                            batch.into_iter().map(move |x| (epoch, x))
+                        })
+                        // TODO(justin): have a real hasher here, right now have
+                        // exactly one bucket everyone gets written into.
+                        .map(|(epoch, kv)| {
+                            ((), (epoch, kv))
+                        })
+                        .stream_join::<_, _, _, SetUnionRepr<tag::VEC, usize>, SetUnionRepr<tag::SINGLE, usize>>(IterPullSurface::new(ownership))
+                        .flat_map(|((), (epoch, (k, v)), receiver)| {
+                            receiver.into_iter().map(move |i|
+                                Single(((i, epoch), Single((k.clone(), v.clone()))))
+                            )
+                        })
+                        .batch_with::<
+                            _,
+                            MapUnionRepr<tag::HASH_MAP, (usize, u64), SetUnionRepr<tag::VEC, (K, V)>>,
+                            MapUnionRepr<tag::SINGLE, (usize, u64), SetUnionRepr<tag::SINGLE, (K, V)>>,
+                            _,
+                        >(IterPullSurface::new(PerQuantumPulser::new()))
+                        .map(|((), batch)| batch)
+                        .filter(|batch| !batch.is_empty())
+                        .flatten()
+                        .pull_to_push()
+                        .for_each(move |((receiver, epoch), batch)| {
+                            // TODO(justin): do we need to tag this with our current vector clock as well?
+                            senders[receiver].try_send(Message::Batch((id, epoch), batch)).unwrap();
+                        }),
+                );
+
+                hf.add_subgraph(
+                    "demultiplexer",
+                    q_recv.flatten().pull_to_push().partition(
+                        |x| matches!(x, Message::Set(_, _)),
+                        hf.start_tee()
+                            .map(|msg| {
+                                if let Message::Set(k, v) = msg {
+                                    Some((k, v))
+                                } else {
+                                    unreachable!()
+                                }
+                            })
+                            .push_to(y_send),
+                        hf.start_tee()
+                            .map(|msg| {
+                                if let Message::Batch((id, epoch), batch) = msg {
+                                    Some((id, epoch, batch))
+                                } else {
+                                    unreachable!()
+                                }
+                            })
+                            .push_to(x_send),
+                    ),
+                );
+
+                hf.add_subgraph("read_handler", reads_recv.flatten().map(|k| (k, ())).stream_join::<_, _, _, MaxRepr<V>, MaxRepr<V>>(
+                    x_recv.flatten().flat_map(|(id, epoch, batch)| {
+                        println!("got batch: {:?} {:?} {:?}", id, epoch, batch);
+                        // TODO(justin): this doesn't do the clocks. I
+                        // think we need to do some weird join against a
+                        // singleton that I don't really understand yet.
+                        batch.into_iter()
+                    })).pull_to_push().for_each(|x| {
+                        println!("read: {:?}", x)
+                    })
+                );
+
+                hf.build().run_async().await.unwrap();
             })
         },
     )


### PR DESCRIPTION
This is a first pass at a dataflow based KVS. It is missing a bunch of clock
stuff, but I was getting anxious about not merging this so here's an early
version of it.

The structure of the program is roughly as follows:

```mermaid
graph BT
    Y[Read Requests] --> Z[Streaming Join]
    X[Received Batches] --> Z
    Z --> Q[Respond to Read Request]

    F[Write Requests] --> B
    A[Epoch Timer] --> B[Batcher / Merger]
    B --> C[Join]
    G[Ownership] --> C
    C --> E[Network Shuffle]
```