### PR TITLE
Add groupby tests/examples

### DIFF
--- a/hydroflow/src/builder/surface/mod.rs
+++ b/hydroflow/src/builder/surface/mod.rs
@@ -94,6 +94,19 @@ pub trait BaseSurface {
         filter_map::FilterMapSurface::new(self, func)
     }
 
+    fn map_scan<State, Func, Out>(
+        self,
+        mut initial_state: State,
+        mut func: Func,
+    ) -> map::MapSurface<Self, MapScanMapFunc<Self, State, Func, Out>>
+    where
+        Self: Sized,
+        Func: FnMut(&mut State, Self::ItemOut) -> Out,
+    {
+        // TODO(mingwei): use state API.
+        self.map(move |item| func(&mut initial_state, item))
+    }
+
     fn inspect<Func>(self, mut func: Func) -> map::MapSurface<Self, InspectMapFunc<Self, Func>>
     where
         Self: Sized,
@@ -106,7 +119,15 @@ pub trait BaseSurface {
     }
 }
 
-pub type InspectMapFunc<Prev: BaseSurface, Func> = impl FnMut(Prev::ItemOut) -> Prev::ItemOut;
+pub type InspectMapFunc<Prev, Func>
+where
+    Prev: BaseSurface,
+= impl FnMut(Prev::ItemOut) -> Prev::ItemOut;
+
+pub type MapScanMapFunc<Prev, State, Func, Out>
+where
+    Prev: BaseSurface,
+= impl FnMut(Prev::ItemOut) -> Out;
 
 pub trait PullSurface: BaseSurface {
     type InputHandoffs: PortList<RECV>;

--- a/hydroflow/tests/groupby.rs
+++ b/hydroflow/tests/groupby.rs
@@ -7,14 +7,19 @@ use hydroflow::scheduled::graph::Hydroflow;
 use hydroflow::scheduled::graph_ext::GraphExt;
 use hydroflow::scheduled::handoff::VecHandoff;
 
+/// First batch of items for monotonic threshold test.
 const BATCH_A: [&'static str; 7] = ["megan", "davis", "mingwei", "john", "justin", "joe", "mae"];
+/// Second batch.
 const BATCH_B: [&'static str; 7] = [
     "mingwei", "lauren", "justin", "mae", "mingwei", "justin", "pierce",
 ];
+/// Third & final batch.
 const BATCH_C: [&'static str; 2] = ["joe", "mae"];
 
+/// Basic monotonic threshold: release a value once after it has been seen three times.
+/// Uses the core API.
 #[test]
-fn groupby_core_monotonic() {
+fn groupby_monotonic_core() {
     let mut hf = Hydroflow::new();
 
     let (source_send, source_recv) = hf.make_edge::<_, VecHandoff<&'static str>>("source handoff");
@@ -62,14 +67,10 @@ fn groupby_core_monotonic() {
     assert_eq!(&["mingwei", "justin", "mae"], &**output.borrow());
 }
 
+/// Basic monotonic threshold: release a value once after it has been seen three times.
+/// Uses the surface (builder) API.
 #[test]
-#[ignore]
-fn groupby_core_nonmon() {
-    todo!("(mingwei): Requires strata.");
-}
-
-#[test]
-fn groupby_surface_monotonic() {
+fn groupby_monotonic_surface() {
     use hydroflow::builder::prelude::*;
 
     let mut hf_builder = HydroflowBuilder::new();
@@ -109,4 +110,10 @@ fn groupby_surface_monotonic() {
     input.flush();
     hf.tick();
     assert_eq!(&["mingwei", "justin", "mae"], &**output.borrow());
+}
+
+#[test]
+#[ignore]
+fn groupby_nonmon_core() {
+    todo!("(mingwei): Requires strata.");
 }

--- a/hydroflow/tests/groupby.rs
+++ b/hydroflow/tests/groupby.rs
@@ -1,0 +1,69 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use hydroflow::lang::collections::Iter;
+use hydroflow::scheduled::graph::Hydroflow;
+use hydroflow::scheduled::graph_ext::GraphExt;
+use hydroflow::scheduled::handoff::VecHandoff;
+
+const BATCH_A: [&'static str; 7] = ["megan", "davis", "mingwei", "john", "justin", "joe", "mae"];
+const BATCH_B: [&'static str; 7] = [
+    "mingwei", "lauren", "justin", "mae", "mingwei", "justin", "pierce",
+];
+const BATCH_C: [&'static str; 2] = ["joe", "mae"];
+
+#[test]
+fn groupby_core_monotonic() {
+    let mut hf = Hydroflow::new();
+
+    let (source_send, source_recv) = hf.make_edge::<_, VecHandoff<&'static str>>("source handoff");
+    let input = hf.add_input("source", source_send);
+
+    let (sink_send, sink_recv) = hf.make_edge::<_, VecHandoff<&'static str>>("sink handoff");
+
+    let mut groups = HashMap::<&'static str, u32>::new();
+    hf.add_subgraph_in_out(
+        "group by",
+        source_recv,
+        sink_send,
+        move |_ctx, recv, send| {
+            for item in recv.take_inner() {
+                let count = groups.entry(item).or_default();
+                *count += 1;
+                if 3 == *count {
+                    send.give(Some(item));
+                }
+            }
+        },
+    );
+
+    let output = <Rc<RefCell<Vec<&'static str>>>>::default();
+    let output_ref = output.clone();
+    hf.add_subgraph_sink("sink", sink_recv, move |_ctx, recv| {
+        for v in recv.take_inner().into_iter() {
+            output_ref.borrow_mut().push(v);
+        }
+    });
+
+    input.give(Iter(BATCH_A.iter().cloned()));
+    input.flush();
+    hf.tick();
+    assert_eq!(0, output.borrow().len());
+
+    input.give(Iter(BATCH_B.iter().cloned()));
+    input.flush();
+    hf.tick();
+    assert_eq!(&["mingwei", "justin"], &**output.borrow());
+
+    input.give(Iter(BATCH_C.iter().cloned()));
+    input.flush();
+    hf.tick();
+    assert_eq!(&["mingwei", "justin", "mae"], &**output.borrow());
+}
+
+#[test]
+#[ignore]
+fn groupby_core_nonmon() {
+    todo!("(mingwei): Requires strata.");
+}


### PR DESCRIPTION
Add ad-hoc core groupby test

Add scan to surface API

- Also add groupby_surface_monotonic test

For now the `scan` API provides little benefit over just using a manual
`move` closure, but in the future we can integrate it with the State API
as well as with lattice types.