### PR TITLE
Implement strata, enabling per-tick non-monotonic aggregations

### DIFF
--- a/hydroflow/src/builder/hydroflow_builder.rs
+++ b/hydroflow/src/builder/hydroflow_builder.rs
@@ -73,10 +73,26 @@ impl HydroflowBuilder {
         Pull: 'static + PullSurface,
         Push: 'static + PushSurfaceReversed<ItemIn = Pull::ItemOut>,
     {
+        self.add_subgraph_stratified(name, 0, pivot)
+    }
+
+    /// Adds a `pivot` created via the Surface API, with the given stratum number.
+    pub fn add_subgraph_stratified<Name, Pull, Push>(
+        &mut self,
+        name: Name,
+        stratum: usize,
+        pivot: PivotSurface<Pull, Push>,
+    ) -> SubgraphId
+    where
+        Name: Into<Cow<'static, str>>,
+        Pull: 'static + PullSurface,
+        Push: 'static + PushSurfaceReversed<ItemIn = Pull::ItemOut>,
+    {
         let ((recv_ports, send_ports), (mut pull_build, mut push_build)) = pivot.into_parts();
 
-        self.hydroflow.add_subgraph(
+        self.hydroflow.add_subgraph_stratified(
             name,
+            stratum,
             recv_ports,
             send_ports,
             move |context, recv_ctx, send_ctx| {

--- a/hydroflow/src/scheduled/context.rs
+++ b/hydroflow/src/scheduled/context.rs
@@ -15,8 +15,13 @@ pub struct Context<'a> {
     pub(crate) handoffs: &'a mut [HandoffData],
     pub(crate) states: &'a mut [StateData],
     pub(crate) event_queue_send: &'a UnboundedSender<SubgraphId>,
+    pub(crate) current_epoch: usize,
 }
 impl<'a> Context<'a> {
+    pub fn current_epoch(&self) -> usize {
+        self.current_epoch
+    }
+
     pub fn waker(&self) -> std::task::Waker {
         use futures::task::ArcWake;
         use std::sync::Arc;

--- a/hydroflow/src/scheduled/context.rs
+++ b/hydroflow/src/scheduled/context.rs
@@ -16,10 +16,17 @@ pub struct Context<'a> {
     pub(crate) states: &'a mut [StateData],
     pub(crate) event_queue_send: &'a UnboundedSender<SubgraphId>,
     pub(crate) current_epoch: usize,
+    pub(crate) current_stratum: usize,
 }
 impl<'a> Context<'a> {
+    // Gets the current epoch (local time) count.
     pub fn current_epoch(&self) -> usize {
         self.current_epoch
+    }
+
+    // Gets the current stratum nubmer.
+    pub fn current_stratum(&self) -> usize {
+        self.current_stratum
     }
 
     pub fn waker(&self) -> std::task::Waker {

--- a/hydroflow/tests/groupby.rs
+++ b/hydroflow/tests/groupby.rs
@@ -175,19 +175,29 @@ fn groupby_nonmon_surface() {
     input.give(Iter(BATCH_A.iter().cloned()));
     input.flush();
     hf.tick_stratum();
+    assert_eq!((0, 0), (hf.current_epoch(), hf.current_stratum()));
+
     assert_eq!(None, output.get());
+
     hf.tick();
+    assert_eq!((1, 1), (hf.current_epoch(), hf.current_stratum()));
+
     assert_eq!(Some((BATCH_A.len(), "justin")), output.get());
 
     // Give BATCH_B but only run this stratum.
     input.give(Iter(BATCH_B.iter().cloned()));
     input.flush();
+
     hf.tick_stratum();
+    assert_eq!((1, 1), (hf.current_epoch(), hf.current_stratum()));
 
     // Give BATCH_C and run all to completion.
     input.give(Iter(BATCH_C.iter().cloned()));
     input.flush();
+
     hf.tick();
+    assert_eq!((3, 1), (hf.current_epoch(), hf.current_stratum()));
+
     // Second batch has 7+3 = 10 items.
     assert_eq!(Some((BATCH_B.len() + BATCH_C.len(), "mae")), output.get());
     assert_eq!(false, hf.next_stratum());


### PR DESCRIPTION
- Users can now optionally specify a _stratum number_ when adding a compiled subgraph, with the new `add_..._stratified()` methods. When not specified stratum number is zero.
- Scheduler will run each stratum to fixed point before continuing to the next strata (loop to beginning after final stratum)
- Scheduler keeps track of `epoch` -- number of times we've looped around strata.
- New `Hydroflow.run_stratum()` method runs only the current stratum.
- New `Hydroflow.next_stratum()` method increments to the next stratum with work available.