### PR TITLE
Fix some Compare implementations

### DIFF
--- a/hydroflow/src/lang/lattice/dom_pair.rs
+++ b/hydroflow/src/lang/lattice/dom_pair.rs
@@ -76,7 +76,10 @@ where
         this: &<DomPairRepr<SelfRA, SelfRB> as LatticeRepr>::Repr,
         other: &<DomPairRepr<DeltaRA, DeltaRB> as LatticeRepr>::Repr,
     ) -> Option<Ordering> {
-        SelfRA::compare(&this.0, &other.0).or_else(|| SelfRB::compare(&this.1, &other.1))
+        match SelfRA::compare(&this.0, &other.0) {
+            Some(Ordering::Equal) => SelfRB::compare(&this.1, &other.1),
+            otherwise => otherwise,
+        }
     }
 }
 


### PR DESCRIPTION
The Compare implementations for DomPair and MapUnion were incorrect.  I'd like
to add some tests around this but I think maybe there's something more holistic
to be done here, given all the algebraic properties we have of lattices this
seems like it should be very amenable to property-based-testing.

The MapUnion implementation in particular feels very...icky. We probably want
something a bit more specialized for various tags that permit a better
implementation, like exploiting order or fast random lookups. But maybe there's
a nicer way to implement it here? Not sure, couldn't think of anything.