### PR TITLE
Combine old 'hof with context under new 'ctx lifetime

### DIFF
--- a/hydroflow/src/builder/build/mod.rs
+++ b/hydroflow/src/builder/build/mod.rs
@@ -34,24 +34,24 @@ pub trait PullBuild: PullBuildBase {
     type InputHandoffs: PortList<RECV>;
 
     /// Builds the iterator for a single run of the subgraph.
-    fn build<'slf, 'hof>(
+    fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &Context<'_>,
-        handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
-    ) -> Self::Build<'slf, 'hof>;
+        context: &'ctx Context<'ctx>,
+        handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
+    ) -> Self::Build<'slf, 'ctx>;
 }
 
 pub trait PushBuildBase {
     type ItemIn;
-    type Build<'slf, 'hof>: Pusherator<Item = Self::ItemIn>;
+    type Build<'slf, 'ctx>: Pusherator<Item = Self::ItemIn>;
 }
 pub trait PushBuild: PushBuildBase {
     type OutputHandoffs: PortList<SEND>;
 
     /// Builds the pusherator for a single run of the subgraph.
-    fn build<'slf, 'hof>(
+    fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &Context<'_>,
-        handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
-    ) -> Self::Build<'slf, 'hof>;
+        context: &'ctx Context<'ctx>,
+        handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'ctx>,
+    ) -> Self::Build<'slf, 'ctx>;
 }

--- a/hydroflow/src/builder/build/pull_batch.rs
+++ b/hydroflow/src/builder/build/pull_batch.rs
@@ -62,8 +62,8 @@ where
         + PortListSplit<RECV, PrevBuf::InputHandoffs, Suffix = PrevStream::InputHandoffs>,
 {
     type ItemOut = (Tick, L::Repr);
-    type Build<'slf, 'hof> =
-        BatchJoin<'slf, PrevBuf::Build<'slf, 'hof>, PrevStream::Build<'slf, 'hof>, L, Update, Tick>;
+    type Build<'slf, 'ctx> =
+        BatchJoin<'slf, PrevBuf::Build<'slf, 'ctx>, PrevStream::Build<'slf, 'ctx>, L, Update, Tick>;
 }
 
 impl<PrevBuf, PrevStream, L, Update, Tick> PullBuild
@@ -81,11 +81,11 @@ where
 {
     type InputHandoffs = <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended;
 
-    fn build<'slf, 'hof>(
+    fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &Context<'_>,
-        input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
-    ) -> Self::Build<'slf, 'hof> {
+        context: &'ctx Context<'ctx>,
+        input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
+    ) -> Self::Build<'slf, 'ctx> {
         let (input_a, input_b) = <Self::InputHandoffs as PortListSplit<_, _>>::split_ctx(input);
         let iter_a = self.prev_a.build(context, input_a);
         let iter_b = self.prev_b.build(context, input_b);

--- a/hydroflow/src/builder/build/pull_chain.rs
+++ b/hydroflow/src/builder/build/pull_chain.rs
@@ -42,7 +42,7 @@ where
         PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     type ItemOut = PrevA::ItemOut;
-    type Build<'slf, 'hof> = std::iter::Chain<PrevA::Build<'slf, 'hof>, PrevB::Build<'slf, 'hof>>;
+    type Build<'slf, 'ctx> = std::iter::Chain<PrevA::Build<'slf, 'ctx>, PrevB::Build<'slf, 'ctx>>;
 }
 
 impl<PrevA, PrevB> PullBuild for ChainPullBuild<PrevA, PrevB>
@@ -56,11 +56,11 @@ where
 {
     type InputHandoffs = <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended;
 
-    fn build<'slf, 'hof>(
+    fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &Context<'_>,
-        input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
-    ) -> Self::Build<'slf, 'hof> {
+        context: &'ctx Context<'ctx>,
+        input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
+    ) -> Self::Build<'slf, 'ctx> {
         let (input_a, input_b) = <Self::InputHandoffs as PortListSplit<_, _>>::split_ctx(input);
         let iter_a = self.prev_a.build(context, input_a);
         let iter_b = self.prev_b.build(context, input_b);

--- a/hydroflow/src/builder/build/pull_cross_join.rs
+++ b/hydroflow/src/builder/build/pull_cross_join.rs
@@ -53,11 +53,11 @@ where
         PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     type ItemOut = (PrevA::ItemOut, PrevB::ItemOut);
-    type Build<'slf, 'hof> = CrossJoin<
+    type Build<'slf, 'ctx> = CrossJoin<
         'slf,
-        PrevA::Build<'slf, 'hof>,
+        PrevA::Build<'slf, 'ctx>,
         PrevA::ItemOut,
-        PrevB::Build<'slf, 'hof>,
+        PrevB::Build<'slf, 'ctx>,
         PrevB::ItemOut,
     >;
 }
@@ -75,11 +75,11 @@ where
 {
     type InputHandoffs = <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended;
 
-    fn build<'slf, 'hof>(
+    fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &Context<'_>,
-        input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
-    ) -> Self::Build<'slf, 'hof> {
+        context: &'ctx Context<'ctx>,
+        input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
+    ) -> Self::Build<'slf, 'ctx> {
         let (input_a, input_b) = <Self::InputHandoffs as PortListSplit<_, _>>::split_ctx(input);
         let iter_a = self.prev_a.build(context, input_a);
         let iter_b = self.prev_b.build(context, input_b);

--- a/hydroflow/src/builder/build/pull_filter.rs
+++ b/hydroflow/src/builder/build/pull_filter.rs
@@ -20,10 +20,10 @@ where
 }
 
 #[allow(type_alias_bounds)]
-type PullBuildImpl<'slf, 'hof, Prev, Func>
+type PullBuildImpl<'slf, 'ctx, Prev, Func>
 where
     Prev: PullBuild,
-= std::iter::Filter<Prev::Build<'slf, 'hof>, impl FnMut(&Prev::ItemOut) -> bool>;
+= std::iter::Filter<Prev::Build<'slf, 'ctx>, impl FnMut(&Prev::ItemOut) -> bool>;
 
 impl<Prev, Func> PullBuildBase for FilterPullBuild<Prev, Func>
 where
@@ -31,7 +31,7 @@ where
     Func: FnMut(&Prev::ItemOut) -> bool,
 {
     type ItemOut = Prev::ItemOut;
-    type Build<'slf, 'hof> = PullBuildImpl<'slf, 'hof, Prev, Func>;
+    type Build<'slf, 'ctx> = PullBuildImpl<'slf, 'ctx, Prev, Func>;
 }
 
 impl<Prev, Func> PullBuild for FilterPullBuild<Prev, Func>
@@ -41,11 +41,11 @@ where
 {
     type InputHandoffs = Prev::InputHandoffs;
 
-    fn build<'slf, 'hof>(
+    fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &Context<'_>,
-        handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
-    ) -> Self::Build<'slf, 'hof> {
+        context: &'ctx Context<'ctx>,
+        handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
+    ) -> Self::Build<'slf, 'ctx> {
         self.prev
             .build(context, handoffs)
             .filter(|x| (self.func)(x))

--- a/hydroflow/src/builder/build/pull_filter_map.rs
+++ b/hydroflow/src/builder/build/pull_filter_map.rs
@@ -20,10 +20,10 @@ where
 }
 
 #[allow(type_alias_bounds)]
-type PullBuildImpl<'slf, 'hof, Prev, Func, Out>
+type PullBuildImpl<'slf, 'ctx, Prev, Func, Out>
 where
     Prev: PullBuild,
-= std::iter::FilterMap<Prev::Build<'slf, 'hof>, impl FnMut(Prev::ItemOut) -> Option<Out>>;
+= std::iter::FilterMap<Prev::Build<'slf, 'ctx>, impl FnMut(Prev::ItemOut) -> Option<Out>>;
 
 impl<Prev, Func, Out> PullBuildBase for FilterMapPullBuild<Prev, Func>
 where
@@ -31,7 +31,7 @@ where
     Func: FnMut(Prev::ItemOut) -> Option<Out>,
 {
     type ItemOut = Out;
-    type Build<'slf, 'hof> = PullBuildImpl<'slf, 'hof, Prev, Func, Out>;
+    type Build<'slf, 'ctx> = PullBuildImpl<'slf, 'ctx, Prev, Func, Out>;
 }
 
 impl<Prev, Func, Out> PullBuild for FilterMapPullBuild<Prev, Func>
@@ -41,11 +41,11 @@ where
 {
     type InputHandoffs = Prev::InputHandoffs;
 
-    fn build<'slf, 'hof>(
+    fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &Context<'_>,
-        handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
-    ) -> Self::Build<'slf, 'hof> {
+        context: &'ctx Context<'ctx>,
+        handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
+    ) -> Self::Build<'slf, 'ctx> {
         self.prev
             .build(context, handoffs)
             .filter_map(|x| (self.func)(x))

--- a/hydroflow/src/builder/build/pull_flatten.rs
+++ b/hydroflow/src/builder/build/pull_flatten.rs
@@ -24,7 +24,7 @@ where
     Prev::ItemOut: IntoIterator,
 {
     type ItemOut = <Prev::ItemOut as IntoIterator>::Item;
-    type Build<'slf, 'hof> = std::iter::Flatten<Prev::Build<'slf, 'hof>>;
+    type Build<'slf, 'ctx> = std::iter::Flatten<Prev::Build<'slf, 'ctx>>;
 }
 
 impl<Prev> PullBuild for FlattenPullBuild<Prev>
@@ -34,11 +34,11 @@ where
 {
     type InputHandoffs = Prev::InputHandoffs;
 
-    fn build<'slf, 'hof>(
+    fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &Context<'_>,
-        handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
-    ) -> Self::Build<'slf, 'hof> {
+        context: &'ctx Context<'ctx>,
+        handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
+    ) -> Self::Build<'slf, 'ctx> {
         self.prev.build(context, handoffs).flatten()
     }
 }

--- a/hydroflow/src/builder/build/pull_half_hash_join.rs
+++ b/hydroflow/src/builder/build/pull_half_hash_join.rs
@@ -68,13 +68,13 @@ where
         + PortListSplit<RECV, PrevBuf::InputHandoffs, Suffix = PrevStream::InputHandoffs>,
 {
     type ItemOut = (Key, StreamVal, L::Repr);
-    type Build<'slf, 'hof> = HalfHashJoin<
+    type Build<'slf, 'ctx> = HalfHashJoin<
         'slf,
         Key,
-        PrevBuf::Build<'slf, 'hof>,
+        PrevBuf::Build<'slf, 'ctx>,
         L,
         Update,
-        PrevStream::Build<'slf, 'hof>,
+        PrevStream::Build<'slf, 'ctx>,
         StreamVal,
     >;
 }
@@ -96,11 +96,11 @@ where
 {
     type InputHandoffs = <PrevBuf::InputHandoffs as Extend<PrevStream::InputHandoffs>>::Extended;
 
-    fn build<'slf, 'hof>(
+    fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &Context<'_>,
-        input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
-    ) -> Self::Build<'slf, 'hof> {
+        context: &'ctx Context<'ctx>,
+        input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
+    ) -> Self::Build<'slf, 'ctx> {
         let (input_a, input_b) = <Self::InputHandoffs as PortListSplit<_, _>>::split_ctx(input);
         let iter_a = self.prev_a.build(context, input_a);
         let iter_b = self.prev_b.build(context, input_b);

--- a/hydroflow/src/builder/build/pull_handoff.rs
+++ b/hydroflow/src/builder/build/pull_handoff.rs
@@ -40,7 +40,7 @@ where
     Hof: Handoff,
 {
     type ItemOut = Hof::Inner;
-    type Build<'slf, 'hof> = std::array::IntoIter<Hof::Inner, 1>;
+    type Build<'slf, 'ctx> = std::array::IntoIter<Hof::Inner, 1>;
 }
 
 impl<Hof> PullBuild for HandoffPullBuild<Hof>
@@ -49,11 +49,11 @@ where
 {
     type InputHandoffs = tt!(RecvPort<Hof>);
 
-    fn build<'slf, 'hof>(
+    fn build<'slf, 'ctx>(
         &'slf mut self,
-        _context: &Context<'_>,
-        handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
-    ) -> Self::Build<'slf, 'hof> {
+        _context: &'ctx Context<'ctx>,
+        handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
+    ) -> Self::Build<'slf, 'ctx> {
         let tl!(handoff) = handoffs;
         [handoff.take_inner()].into_iter()
     }

--- a/hydroflow/src/builder/build/pull_iter.rs
+++ b/hydroflow/src/builder/build/pull_iter.rs
@@ -22,7 +22,7 @@ where
     I: 'static + Iterator,
 {
     type ItemOut = I::Item;
-    type Build<'slf, 'hof> = &'slf mut I;
+    type Build<'slf, 'ctx> = &'slf mut I;
 }
 
 impl<I> PullBuild for IterPullBuild<I>
@@ -31,11 +31,11 @@ where
 {
     type InputHandoffs = ();
 
-    fn build<'slf, 'hof>(
+    fn build<'slf, 'ctx>(
         &'slf mut self,
-        _context: &Context<'_>,
-        _handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
-    ) -> Self::Build<'slf, 'hof> {
+        _context: &'ctx Context<'ctx>,
+        _handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
+    ) -> Self::Build<'slf, 'ctx> {
         &mut self.it
     }
 }

--- a/hydroflow/src/builder/build/pull_join.rs
+++ b/hydroflow/src/builder/build/pull_join.rs
@@ -58,12 +58,12 @@ where
         PortList<RECV> + PortListSplit<RECV, PrevA::InputHandoffs, Suffix = PrevB::InputHandoffs>,
 {
     type ItemOut = (Key, ValA, ValB);
-    type Build<'slf, 'hof> = SymmetricHashJoin<
+    type Build<'slf, 'ctx> = SymmetricHashJoin<
         'slf,
         Key,
-        PrevA::Build<'slf, 'hof>,
+        PrevA::Build<'slf, 'ctx>,
         ValA,
-        PrevB::Build<'slf, 'hof>,
+        PrevB::Build<'slf, 'ctx>,
         ValB,
     >;
 }
@@ -82,11 +82,11 @@ where
 {
     type InputHandoffs = <PrevA::InputHandoffs as Extend<PrevB::InputHandoffs>>::Extended;
 
-    fn build<'slf, 'hof>(
+    fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &Context<'_>,
-        input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
-    ) -> Self::Build<'slf, 'hof> {
+        context: &'ctx Context<'ctx>,
+        input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
+    ) -> Self::Build<'slf, 'ctx> {
         let (input_a, input_b) = <Self::InputHandoffs as PortListSplit<_, _>>::split_ctx(input);
         let iter_a = self.prev_a.build(context, input_a);
         let iter_b = self.prev_b.build(context, input_b);

--- a/hydroflow/src/builder/build/pull_map.rs
+++ b/hydroflow/src/builder/build/pull_map.rs
@@ -20,10 +20,10 @@ where
 }
 
 #[allow(type_alias_bounds)]
-type PullBuildImpl<'slf, 'hof, Prev, Func, Out>
+type PullBuildImpl<'slf, 'ctx, Prev, Func, Out>
 where
     Prev: PullBuild,
-= std::iter::Map<Prev::Build<'slf, 'hof>, impl FnMut(Prev::ItemOut) -> Out>;
+= std::iter::Map<Prev::Build<'slf, 'ctx>, impl FnMut(Prev::ItemOut) -> Out>;
 
 impl<Prev, Func, Out> PullBuildBase for MapPullBuild<Prev, Func>
 where
@@ -31,7 +31,7 @@ where
     Func: FnMut(Prev::ItemOut) -> Out,
 {
     type ItemOut = Out;
-    type Build<'slf, 'hof> = PullBuildImpl<'slf, 'hof, Prev, Func, Out>;
+    type Build<'slf, 'ctx> = PullBuildImpl<'slf, 'ctx, Prev, Func, Out>;
 }
 
 impl<Prev, Func, Out> PullBuild for MapPullBuild<Prev, Func>
@@ -41,11 +41,11 @@ where
 {
     type InputHandoffs = Prev::InputHandoffs;
 
-    fn build<'slf, 'hof>(
+    fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &Context<'_>,
-        handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'hof>,
-    ) -> Self::Build<'slf, 'hof> {
+        context: &'ctx Context<'ctx>,
+        handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
+    ) -> Self::Build<'slf, 'ctx> {
         self.prev.build(context, handoffs).map(|x| (self.func)(x))
     }
 }

--- a/hydroflow/src/builder/build/push_filter.rs
+++ b/hydroflow/src/builder/build/push_filter.rs
@@ -24,10 +24,10 @@ where
 }
 
 #[allow(type_alias_bounds)]
-type PushBuildImpl<'slf, 'hof, Next, Func>
+type PushBuildImpl<'slf, 'ctx, Next, Func>
 where
     Next: PushBuild,
-= Filter<Next::ItemIn, impl FnMut(&Next::ItemIn) -> bool, Next::Build<'slf, 'hof>>;
+= Filter<Next::ItemIn, impl FnMut(&Next::ItemIn) -> bool, Next::Build<'slf, 'ctx>>;
 
 impl<Next, Func> PushBuildBase for FilterPushBuild<Next, Func>
 where
@@ -35,7 +35,7 @@ where
     Func: FnMut(&Next::ItemIn) -> bool,
 {
     type ItemIn = Next::ItemIn;
-    type Build<'slf, 'hof> = PushBuildImpl<'slf, 'hof, Next, Func>;
+    type Build<'slf, 'ctx> = PushBuildImpl<'slf, 'ctx, Next, Func>;
 }
 
 impl<Next, Func> PushBuild for FilterPushBuild<Next, Func>
@@ -45,11 +45,11 @@ where
 {
     type OutputHandoffs = Next::OutputHandoffs;
 
-    fn build<'slf, 'hof>(
+    fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &Context<'_>,
-        handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
-    ) -> Self::Build<'slf, 'hof> {
+        context: &'ctx Context<'ctx>,
+        handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'ctx>,
+    ) -> Self::Build<'slf, 'ctx> {
         Filter::new(|x| (self.func)(x), self.next.build(context, handoffs))
     }
 }

--- a/hydroflow/src/builder/build/push_filter_map.rs
+++ b/hydroflow/src/builder/build/push_filter_map.rs
@@ -31,10 +31,10 @@ where
 }
 
 #[allow(type_alias_bounds)]
-type PushBuildImpl<'slf, 'hof, Next, Func, In>
+type PushBuildImpl<'slf, 'ctx, Next, Func, In>
 where
     Next: PushBuild,
-= FilterMap<Next::Build<'slf, 'hof>, impl FnMut(In) -> Option<Next::ItemIn>, In>;
+= FilterMap<Next::Build<'slf, 'ctx>, impl FnMut(In) -> Option<Next::ItemIn>, In>;
 
 impl<Next, Func, In> PushBuildBase for FilterMapPushBuild<Next, Func, In>
 where
@@ -42,7 +42,7 @@ where
     Func: FnMut(In) -> Option<Next::ItemIn>,
 {
     type ItemIn = In;
-    type Build<'slf, 'hof> = PushBuildImpl<'slf, 'hof, Next, Func, In>;
+    type Build<'slf, 'ctx> = PushBuildImpl<'slf, 'ctx, Next, Func, In>;
 }
 
 impl<Next, Func, In> PushBuild for FilterMapPushBuild<Next, Func, In>
@@ -52,11 +52,11 @@ where
 {
     type OutputHandoffs = Next::OutputHandoffs;
 
-    fn build<'slf, 'hof>(
+    fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &Context<'_>,
-        handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
-    ) -> Self::Build<'slf, 'hof> {
+        context: &'ctx Context<'ctx>,
+        handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'ctx>,
+    ) -> Self::Build<'slf, 'ctx> {
         FilterMap::new(|x| (self.func)(x), self.next.build(context, handoffs))
     }
 }

--- a/hydroflow/src/builder/build/push_flatten.rs
+++ b/hydroflow/src/builder/build/push_flatten.rs
@@ -34,7 +34,7 @@ where
     In: IntoIterator<Item = Next::ItemIn>,
 {
     type ItemIn = In;
-    type Build<'slf, 'hof> = Flatten<Next::Build<'slf, 'hof>, In>;
+    type Build<'slf, 'ctx> = Flatten<Next::Build<'slf, 'ctx>, In>;
 }
 
 impl<Next, In> PushBuild for FlattenPushBuild<Next, In>
@@ -44,11 +44,11 @@ where
 {
     type OutputHandoffs = Next::OutputHandoffs;
 
-    fn build<'slf, 'hof>(
+    fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &Context<'_>,
-        handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
-    ) -> Self::Build<'slf, 'hof> {
+        context: &'ctx Context<'ctx>,
+        handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'ctx>,
+    ) -> Self::Build<'slf, 'ctx> {
         Flatten::new(self.next.build(context, handoffs))
     }
 }

--- a/hydroflow/src/builder/build/push_for_each.rs
+++ b/hydroflow/src/builder/build/push_for_each.rs
@@ -28,14 +28,14 @@ where
 }
 
 #[allow(type_alias_bounds)]
-type PushBuildImpl<'slf, 'hof, Func, In> = ForEach<In, impl FnMut(In)>;
+type PushBuildImpl<'slf, 'ctx, Func, In> = ForEach<In, impl FnMut(In)>;
 
 impl<Func, In> PushBuildBase for ForEachPushBuild<Func, In>
 where
     Func: FnMut(In),
 {
     type ItemIn = In;
-    type Build<'slf, 'hof> = PushBuildImpl<'slf, 'hof, Func, In>;
+    type Build<'slf, 'ctx> = PushBuildImpl<'slf, 'ctx, Func, In>;
 }
 
 impl<Func, In> PushBuild for ForEachPushBuild<Func, In>
@@ -44,11 +44,11 @@ where
 {
     type OutputHandoffs = tt!();
 
-    fn build<'slf, 'hof>(
+    fn build<'slf, 'ctx>(
         &'slf mut self,
-        _context: &Context<'_>,
-        (): <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
-    ) -> Self::Build<'slf, 'hof> {
+        _context: &'ctx Context<'ctx>,
+        (): <Self::OutputHandoffs as PortList<SEND>>::Ctx<'ctx>,
+    ) -> Self::Build<'slf, 'ctx> {
         ForEach::new(|x| (self.func)(x))
     }
 }

--- a/hydroflow/src/builder/build/push_handoff.rs
+++ b/hydroflow/src/builder/build/push_handoff.rs
@@ -41,7 +41,7 @@ where
     Hof: Handoff + CanReceive<In>,
 {
     type ItemIn = In;
-    type Build<'slf, 'hof> = PushHandoff<'hof, Hof, In>;
+    type Build<'slf, 'ctx> = PushHandoff<'ctx, Hof, In>;
 }
 
 impl<Hof, In> PushBuild for HandoffPushBuild<Hof, In>
@@ -50,11 +50,11 @@ where
 {
     type OutputHandoffs = tt!(SendPort<Hof>);
 
-    fn build<'slf, 'hof>(
+    fn build<'slf, 'ctx>(
         &'slf mut self,
-        _context: &Context<'_>,
-        handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
-    ) -> Self::Build<'slf, 'hof> {
+        _context: &'ctx Context<'ctx>,
+        handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'ctx>,
+    ) -> Self::Build<'slf, 'ctx> {
         let tl!(handoff) = handoffs;
         PushHandoff::new(handoff)
     }

--- a/hydroflow/src/builder/build/push_map.rs
+++ b/hydroflow/src/builder/build/push_map.rs
@@ -31,10 +31,10 @@ where
 }
 
 #[allow(type_alias_bounds)]
-type PushBuildImpl<'slf, 'hof, Next, Func, In>
+type PushBuildImpl<'slf, 'ctx, Next, Func, In>
 where
     Next: PushBuild,
-= Map<In, Next::ItemIn, impl FnMut(In) -> Next::ItemIn, Next::Build<'slf, 'hof>>;
+= Map<In, Next::ItemIn, impl FnMut(In) -> Next::ItemIn, Next::Build<'slf, 'ctx>>;
 
 impl<Next, Func, In> PushBuildBase for MapPushBuild<Next, Func, In>
 where
@@ -42,7 +42,7 @@ where
     Func: FnMut(In) -> Next::ItemIn,
 {
     type ItemIn = In;
-    type Build<'slf, 'hof> = PushBuildImpl<'slf, 'hof, Next, Func, In>;
+    type Build<'slf, 'ctx> = PushBuildImpl<'slf, 'ctx, Next, Func, In>;
 }
 
 impl<Next, Func, In> PushBuild for MapPushBuild<Next, Func, In>
@@ -52,11 +52,11 @@ where
 {
     type OutputHandoffs = Next::OutputHandoffs;
 
-    fn build<'slf, 'hof>(
+    fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &Context<'_>,
-        handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
-    ) -> Self::Build<'slf, 'hof> {
+        context: &'ctx Context<'ctx>,
+        handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'ctx>,
+    ) -> Self::Build<'slf, 'ctx> {
         Map::new(|x| (self.func)(x), self.next.build(context, handoffs))
     }
 }

--- a/hydroflow/src/builder/build/push_tee.rs
+++ b/hydroflow/src/builder/build/push_tee.rs
@@ -45,7 +45,7 @@ where
         PortList<SEND> + PortListSplit<SEND, NextA::OutputHandoffs, Suffix = NextB::OutputHandoffs>,
 {
     type ItemIn = NextA::ItemIn;
-    type Build<'slf, 'hof> = Tee<Self::ItemIn, NextA::Build<'slf, 'hof>, NextB::Build<'slf, 'hof>>;
+    type Build<'slf, 'ctx> = Tee<Self::ItemIn, NextA::Build<'slf, 'ctx>, NextB::Build<'slf, 'ctx>>;
 }
 
 impl<NextA, NextB> PushBuild for TeePushBuild<NextA, NextB>
@@ -60,11 +60,11 @@ where
 {
     type OutputHandoffs = <NextA::OutputHandoffs as Extend<NextB::OutputHandoffs>>::Extended;
 
-    fn build<'slf, 'hof>(
+    fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &Context<'_>,
-        input: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'hof>,
-    ) -> Self::Build<'slf, 'hof> {
+        context: &'ctx Context<'ctx>,
+        input: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'ctx>,
+    ) -> Self::Build<'slf, 'ctx> {
         let (input_a, input_b) = <Self::OutputHandoffs as PortListSplit<_, _>>::split_ctx(input);
         let build_a = self.next_a.build(context, input_a);
         let build_b = self.next_b.build(context, input_b);

--- a/hydroflow/src/scheduled/graph.rs
+++ b/hydroflow/src/scheduled/graph.rs
@@ -223,7 +223,7 @@ impl Hydroflow {
         Name: Into<Cow<'static, str>>,
         R: 'static + PortList<RECV>,
         W: 'static + PortList<SEND>,
-        F: 'static + FnMut(&Context<'_>, R::Ctx<'_>, W::Ctx<'_>),
+        F: 'static + for<'ctx> FnMut(&'ctx Context<'ctx>, R::Ctx<'ctx>, W::Ctx<'ctx>),
     {
         self.add_subgraph_stratified(name, 0, recv_ports, send_ports, subgraph)
     }
@@ -243,7 +243,7 @@ impl Hydroflow {
         Name: Into<Cow<'static, str>>,
         R: 'static + PortList<RECV>,
         W: 'static + PortList<SEND>,
-        F: 'static + FnMut(&Context<'_>, R::Ctx<'_>, W::Ctx<'_>),
+        F: 'static + for<'ctx> FnMut(&'ctx Context<'ctx>, R::Ctx<'ctx>, W::Ctx<'ctx>),
     {
         let sg_id = self.subgraphs.len();
 
@@ -282,7 +282,8 @@ impl Hydroflow {
         Name: Into<Cow<'static, str>>,
         R: 'static + Handoff,
         W: 'static + Handoff,
-        F: 'static + FnMut(&Context<'_>, &[&RecvCtx<R>], &[&SendCtx<W>]),
+        F: 'static
+            + for<'ctx> FnMut(&'ctx Context<'ctx>, &'ctx [&'ctx RecvCtx<R>], &'ctx [&'ctx SendCtx<W>]),
     {
         self.add_subgraph_stratified_n_m(name, 0, recv_ports, send_ports, subgraph)
     }
@@ -300,7 +301,8 @@ impl Hydroflow {
         Name: Into<Cow<'static, str>>,
         R: 'static + Handoff,
         W: 'static + Handoff,
-        F: 'static + FnMut(&Context<'_>, &[&RecvCtx<R>], &[&SendCtx<W>]),
+        F: 'static
+            + for<'ctx> FnMut(&'ctx Context<'ctx>, &'ctx [&'ctx RecvCtx<R>], &'ctx [&'ctx SendCtx<W>]),
     {
         let sg_id = self.subgraphs.len();
 


### PR DESCRIPTION
Some find-replace refactoring, prerequisite for providing surface API with `Context`