### PR TITLE
Use newtypes for Subgraph/Handoff/State IDs

### DIFF
--- a/hydroflow/src/scheduled/context.rs
+++ b/hydroflow/src/scheduled/context.rs
@@ -55,7 +55,7 @@ impl<'a> Context<'a> {
         T: Any,
     {
         self.states
-            .get(handle.state_id)
+            .get(handle.state_id.0)
             .expect("Failed to find state with given handle.")
             .state
             .downcast_ref()
@@ -67,7 +67,7 @@ impl<'a> Context<'a> {
         T: Any,
     {
         self.states
-            .get_mut(handle.state_id)
+            .get_mut(handle.state_id.0)
             .expect("Failed to find state with given handle.")
             .state
             .downcast_mut()

--- a/hydroflow/src/scheduled/handoff/handoff_list.rs
+++ b/hydroflow/src/scheduled/handoff/handoff_list.rs
@@ -43,7 +43,7 @@ where
 
         out_handoff_ids.push(this.handoff_id);
 
-        let handoff = handoffs.get_mut(this.handoff_id).unwrap();
+        let handoff = handoffs.get_mut(this.handoff_id.0).unwrap();
         if let Some(pred) = pred {
             handoff.preds.push(pred);
         }
@@ -57,7 +57,7 @@ where
     fn make_ctx<'a>(&self, handoffs: &'a [HandoffData]) -> Self::Ctx<'a> {
         let (this, rest) = self;
         let handoff = handoffs
-            .get(this.handoff_id)
+            .get(this.handoff_id.0)
             .unwrap()
             .handoff
             .any_ref()

--- a/hydroflow/src/scheduled/mod.rs
+++ b/hydroflow/src/scheduled/mod.rs
@@ -12,9 +12,23 @@ pub(crate) mod subgraph;
 pub mod type_list;
 pub mod util;
 
-pub type SubgraphId = usize;
-pub type HandoffId = usize;
-pub type StateId = usize;
+/// A subgraph's ID. Invalid if used in a different [`graph::Hydroflow`]
+/// instance than the original that created it.
+#[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct SubgraphId(pub(crate) usize);
+
+/// A handoff's ID. Invalid if used in a different [`graph::Hydroflow`]
+/// instance than the original that created it.
+#[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct HandoffId(pub(crate) usize);
+
+/// A staten handle's ID. Invalid if used in a different [`graph::Hydroflow`]
+/// instance than the original that created it.
+#[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct StateId(pub(crate) usize);
 
 #[cfg(test)]
 mod tests {

--- a/hydroflow/src/scheduled/reactor.rs
+++ b/hydroflow/src/scheduled/reactor.rs
@@ -16,7 +16,7 @@ impl Reactor {
         Self { event_queue_send }
     }
 
-    pub fn trigger(&self, sg_id: SubgraphId) -> Result<(), SendError<usize>> {
+    pub fn trigger(&self, sg_id: SubgraphId) -> Result<(), SendError<SubgraphId>> {
         self.event_queue_send.send(sg_id)
     }
 


### PR DESCRIPTION
To prevent them from being mixed up with each other.

Replaces #88