### PR TITLE
Remove lifetime from Context, avoid need to construct instances

### DIFF
--- a/hydroflow/src/builder/build/mod.rs
+++ b/hydroflow/src/builder/build/mod.rs
@@ -37,7 +37,7 @@ pub trait PullBuild: PullBuildBase {
     /// Builds the iterator for a single run of the subgraph.
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &'ctx Context<'ctx>,
+        context: &'ctx Context,
         handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx>;
 }
@@ -52,7 +52,7 @@ pub trait PushBuild: PushBuildBase {
     /// Builds the pusherator for a single run of the subgraph.
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &'ctx Context<'ctx>,
+        context: &'ctx Context,
         handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx>;
 }

--- a/hydroflow/src/builder/build/pull_batch.rs
+++ b/hydroflow/src/builder/build/pull_batch.rs
@@ -83,7 +83,7 @@ where
 
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &'ctx Context<'ctx>,
+        context: &'ctx Context,
         input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx> {
         let (input_a, input_b) = <Self::InputHandoffs as PortListSplit<_, _>>::split_ctx(input);

--- a/hydroflow/src/builder/build/pull_chain.rs
+++ b/hydroflow/src/builder/build/pull_chain.rs
@@ -58,7 +58,7 @@ where
 
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &'ctx Context<'ctx>,
+        context: &'ctx Context,
         input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx> {
         let (input_a, input_b) = <Self::InputHandoffs as PortListSplit<_, _>>::split_ctx(input);

--- a/hydroflow/src/builder/build/pull_cross_join.rs
+++ b/hydroflow/src/builder/build/pull_cross_join.rs
@@ -77,7 +77,7 @@ where
 
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &'ctx Context<'ctx>,
+        context: &'ctx Context,
         input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx> {
         let (input_a, input_b) = <Self::InputHandoffs as PortListSplit<_, _>>::split_ctx(input);

--- a/hydroflow/src/builder/build/pull_filter.rs
+++ b/hydroflow/src/builder/build/pull_filter.rs
@@ -12,7 +12,7 @@ where
 impl<Prev, Func> FilterPullBuild<Prev, Func>
 where
     Prev: PullBuild,
-    Func: FnMut(&Context<'_>, &Prev::ItemOut) -> bool,
+    Func: FnMut(&Context, &Prev::ItemOut) -> bool,
 {
     pub fn new(prev: Prev, func: Func) -> Self {
         Self { prev, func }
@@ -28,7 +28,7 @@ where
 impl<Prev, Func> PullBuildBase for FilterPullBuild<Prev, Func>
 where
     Prev: PullBuild,
-    Func: FnMut(&Context<'_>, &Prev::ItemOut) -> bool,
+    Func: FnMut(&Context, &Prev::ItemOut) -> bool,
 {
     type ItemOut = Prev::ItemOut;
     type Build<'slf, 'ctx> = PullBuildImpl<'slf, 'ctx, Prev, Func>;
@@ -37,13 +37,13 @@ where
 impl<Prev, Func> PullBuild for FilterPullBuild<Prev, Func>
 where
     Prev: PullBuild,
-    Func: FnMut(&Context<'_>, &Prev::ItemOut) -> bool,
+    Func: FnMut(&Context, &Prev::ItemOut) -> bool,
 {
     type InputHandoffs = Prev::InputHandoffs;
 
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &'ctx Context<'ctx>,
+        context: &'ctx Context,
         handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx> {
         self.prev

--- a/hydroflow/src/builder/build/pull_filter_map.rs
+++ b/hydroflow/src/builder/build/pull_filter_map.rs
@@ -12,7 +12,7 @@ where
 impl<Prev, Func, Out> FilterMapPullBuild<Prev, Func>
 where
     Prev: PullBuild,
-    Func: FnMut(&Context<'_>, Prev::ItemOut) -> Option<Out>,
+    Func: FnMut(&Context, Prev::ItemOut) -> Option<Out>,
 {
     pub fn new(prev: Prev, func: Func) -> Self {
         Self { prev, func }
@@ -28,7 +28,7 @@ where
 impl<Prev, Func, Out> PullBuildBase for FilterMapPullBuild<Prev, Func>
 where
     Prev: PullBuild,
-    Func: FnMut(&Context<'_>, Prev::ItemOut) -> Option<Out>,
+    Func: FnMut(&Context, Prev::ItemOut) -> Option<Out>,
 {
     type ItemOut = Out;
     type Build<'slf, 'ctx> = PullBuildImpl<'slf, 'ctx, Prev, Func, Out>;
@@ -37,13 +37,13 @@ where
 impl<Prev, Func, Out> PullBuild for FilterMapPullBuild<Prev, Func>
 where
     Prev: PullBuild,
-    Func: FnMut(&Context<'_>, Prev::ItemOut) -> Option<Out>,
+    Func: FnMut(&Context, Prev::ItemOut) -> Option<Out>,
 {
     type InputHandoffs = Prev::InputHandoffs;
 
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &'ctx Context<'ctx>,
+        context: &'ctx Context,
         handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx> {
         self.prev

--- a/hydroflow/src/builder/build/pull_flatten.rs
+++ b/hydroflow/src/builder/build/pull_flatten.rs
@@ -36,7 +36,7 @@ where
 
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &'ctx Context<'ctx>,
+        context: &'ctx Context,
         handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx> {
         self.prev.build(context, handoffs).flatten()

--- a/hydroflow/src/builder/build/pull_fold_epoch.rs
+++ b/hydroflow/src/builder/build/pull_fold_epoch.rs
@@ -13,8 +13,8 @@ where
 impl<Prev, Init, Func, Out> FoldEpochPullBuild<Prev, Init, Func>
 where
     Prev: PullBuild,
-    Init: FnMut(&Context<'_>) -> Out,
-    Func: FnMut(&Context<'_>, Out, Prev::ItemOut) -> Out,
+    Init: FnMut(&Context) -> Out,
+    Func: FnMut(&Context, Out, Prev::ItemOut) -> Out,
 {
     pub fn new(prev: Prev, init: Init, func: Func) -> Self {
         Self { prev, init, func }
@@ -30,8 +30,8 @@ where
 impl<Prev, Init, Func, Out> PullBuildBase for FoldEpochPullBuild<Prev, Init, Func>
 where
     Prev: PullBuild,
-    Init: FnMut(&Context<'_>) -> Out,
-    Func: FnMut(&Context<'_>, Out, Prev::ItemOut) -> Out,
+    Init: FnMut(&Context) -> Out,
+    Func: FnMut(&Context, Out, Prev::ItemOut) -> Out,
 {
     type ItemOut = Out;
     type Build<'slf, 'ctx> = PullBuildImpl<'slf, 'ctx, Prev, Init, Func, Out>;
@@ -40,14 +40,14 @@ where
 impl<Prev, Init, Func, Out> PullBuild for FoldEpochPullBuild<Prev, Init, Func>
 where
     Prev: PullBuild,
-    Init: FnMut(&Context<'_>) -> Out,
-    Func: FnMut(&Context<'_>, Out, Prev::ItemOut) -> Out,
+    Init: FnMut(&Context) -> Out,
+    Func: FnMut(&Context, Out, Prev::ItemOut) -> Out,
 {
     type InputHandoffs = Prev::InputHandoffs;
 
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &'ctx Context<'ctx>,
+        context: &'ctx Context,
         handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx> {
         std::iter::once_with(move || {

--- a/hydroflow/src/builder/build/pull_half_hash_join.rs
+++ b/hydroflow/src/builder/build/pull_half_hash_join.rs
@@ -98,7 +98,7 @@ where
 
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &'ctx Context<'ctx>,
+        context: &'ctx Context,
         input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx> {
         let (input_a, input_b) = <Self::InputHandoffs as PortListSplit<_, _>>::split_ctx(input);

--- a/hydroflow/src/builder/build/pull_handoff.rs
+++ b/hydroflow/src/builder/build/pull_handoff.rs
@@ -51,7 +51,7 @@ where
 
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        _context: &'ctx Context<'ctx>,
+        _context: &'ctx Context,
         handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx> {
         let tl!(handoff) = handoffs;

--- a/hydroflow/src/builder/build/pull_iter.rs
+++ b/hydroflow/src/builder/build/pull_iter.rs
@@ -33,7 +33,7 @@ where
 
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        _context: &'ctx Context<'ctx>,
+        _context: &'ctx Context,
         _handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx> {
         &mut self.it

--- a/hydroflow/src/builder/build/pull_join.rs
+++ b/hydroflow/src/builder/build/pull_join.rs
@@ -84,7 +84,7 @@ where
 
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &'ctx Context<'ctx>,
+        context: &'ctx Context,
         input: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx> {
         let (input_a, input_b) = <Self::InputHandoffs as PortListSplit<_, _>>::split_ctx(input);

--- a/hydroflow/src/builder/build/pull_map.rs
+++ b/hydroflow/src/builder/build/pull_map.rs
@@ -12,7 +12,7 @@ where
 impl<Prev, Func, Out> MapPullBuild<Prev, Func>
 where
     Prev: PullBuild,
-    Func: FnMut(&Context<'_>, Prev::ItemOut) -> Out,
+    Func: FnMut(&Context, Prev::ItemOut) -> Out,
 {
     pub fn new(prev: Prev, func: Func) -> Self {
         Self { prev, func }
@@ -28,7 +28,7 @@ where
 impl<Prev, Func, Out> PullBuildBase for MapPullBuild<Prev, Func>
 where
     Prev: PullBuild,
-    Func: FnMut(&Context<'_>, Prev::ItemOut) -> Out,
+    Func: FnMut(&Context, Prev::ItemOut) -> Out,
 {
     type ItemOut = Out;
     type Build<'slf, 'ctx> = PullBuildImpl<'slf, 'ctx, Prev, Func, Out>;
@@ -37,13 +37,13 @@ where
 impl<Prev, Func, Out> PullBuild for MapPullBuild<Prev, Func>
 where
     Prev: PullBuild,
-    Func: FnMut(&Context<'_>, Prev::ItemOut) -> Out,
+    Func: FnMut(&Context, Prev::ItemOut) -> Out,
 {
     type InputHandoffs = Prev::InputHandoffs;
 
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &'ctx Context<'ctx>,
+        context: &'ctx Context,
         handoffs: <Self::InputHandoffs as PortList<RECV>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx> {
         self.prev

--- a/hydroflow/src/builder/build/push_filter.rs
+++ b/hydroflow/src/builder/build/push_filter.rs
@@ -8,7 +8,7 @@ use crate::scheduled::port::SEND;
 pub struct FilterPushBuild<Next, Func>
 where
     Next: PushBuild,
-    Func: FnMut(&Context<'_>, &Next::ItemIn) -> bool,
+    Func: FnMut(&Context, &Next::ItemIn) -> bool,
 {
     next: Next,
     func: Func,
@@ -16,7 +16,7 @@ where
 impl<Next, Func> FilterPushBuild<Next, Func>
 where
     Next: PushBuild,
-    Func: FnMut(&Context<'_>, &Next::ItemIn) -> bool,
+    Func: FnMut(&Context, &Next::ItemIn) -> bool,
 {
     pub fn new(next: Next, func: Func) -> Self {
         Self { next, func }
@@ -32,7 +32,7 @@ where
 impl<Next, Func> PushBuildBase for FilterPushBuild<Next, Func>
 where
     Next: PushBuild,
-    Func: FnMut(&Context<'_>, &Next::ItemIn) -> bool,
+    Func: FnMut(&Context, &Next::ItemIn) -> bool,
 {
     type ItemIn = Next::ItemIn;
     type Build<'slf, 'ctx> = PushBuildImpl<'slf, 'ctx, Next, Func>;
@@ -41,13 +41,13 @@ where
 impl<Next, Func> PushBuild for FilterPushBuild<Next, Func>
 where
     Next: PushBuild,
-    Func: FnMut(&Context<'_>, &Next::ItemIn) -> bool,
+    Func: FnMut(&Context, &Next::ItemIn) -> bool,
 {
     type OutputHandoffs = Next::OutputHandoffs;
 
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &'ctx Context<'ctx>,
+        context: &'ctx Context,
         handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx> {
         Filter::new(

--- a/hydroflow/src/builder/build/push_filter_map.rs
+++ b/hydroflow/src/builder/build/push_filter_map.rs
@@ -10,7 +10,7 @@ use crate::scheduled::port::SEND;
 pub struct FilterMapPushBuild<Next, Func, In>
 where
     Next: PushBuild,
-    Func: FnMut(&Context<'_>, In) -> Option<Next::ItemIn>,
+    Func: FnMut(&Context, In) -> Option<Next::ItemIn>,
 {
     next: Next,
     func: Func,
@@ -19,7 +19,7 @@ where
 impl<Next, Func, In> FilterMapPushBuild<Next, Func, In>
 where
     Next: PushBuild,
-    Func: FnMut(&Context<'_>, In) -> Option<Next::ItemIn>,
+    Func: FnMut(&Context, In) -> Option<Next::ItemIn>,
 {
     pub fn new(next: Next, func: Func) -> Self {
         Self {
@@ -39,7 +39,7 @@ where
 impl<Next, Func, In> PushBuildBase for FilterMapPushBuild<Next, Func, In>
 where
     Next: PushBuild,
-    Func: FnMut(&Context<'_>, In) -> Option<Next::ItemIn>,
+    Func: FnMut(&Context, In) -> Option<Next::ItemIn>,
 {
     type ItemIn = In;
     type Build<'slf, 'ctx> = PushBuildImpl<'slf, 'ctx, Next, Func, In>;
@@ -48,13 +48,13 @@ where
 impl<Next, Func, In> PushBuild for FilterMapPushBuild<Next, Func, In>
 where
     Next: PushBuild,
-    Func: FnMut(&Context<'_>, In) -> Option<Next::ItemIn>,
+    Func: FnMut(&Context, In) -> Option<Next::ItemIn>,
 {
     type OutputHandoffs = Next::OutputHandoffs;
 
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &'ctx Context<'ctx>,
+        context: &'ctx Context,
         handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx> {
         FilterMap::new(

--- a/hydroflow/src/builder/build/push_flatten.rs
+++ b/hydroflow/src/builder/build/push_flatten.rs
@@ -46,7 +46,7 @@ where
 
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &'ctx Context<'ctx>,
+        context: &'ctx Context,
         handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx> {
         Flatten::new(self.next.build(context, handoffs))

--- a/hydroflow/src/builder/build/push_for_each.rs
+++ b/hydroflow/src/builder/build/push_for_each.rs
@@ -10,14 +10,14 @@ use crate::tt;
 
 pub struct ForEachPushBuild<Func, In>
 where
-    Func: FnMut(&Context<'_>, In),
+    Func: FnMut(&Context, In),
 {
     func: Func,
     _phantom: PhantomData<fn(In)>,
 }
 impl<Func, In> ForEachPushBuild<Func, In>
 where
-    Func: FnMut(&Context<'_>, In),
+    Func: FnMut(&Context, In),
 {
     pub fn new(func: Func) -> Self {
         Self {
@@ -32,7 +32,7 @@ type PushBuildImpl<'slf, 'ctx, Func, In> = ForEach<In, impl FnMut(In)>;
 
 impl<Func, In> PushBuildBase for ForEachPushBuild<Func, In>
 where
-    Func: FnMut(&Context<'_>, In),
+    Func: FnMut(&Context, In),
 {
     type ItemIn = In;
     type Build<'slf, 'ctx> = PushBuildImpl<'slf, 'ctx, Func, In>;
@@ -40,13 +40,13 @@ where
 
 impl<Func, In> PushBuild for ForEachPushBuild<Func, In>
 where
-    Func: FnMut(&Context<'_>, In),
+    Func: FnMut(&Context, In),
 {
     type OutputHandoffs = tt!();
 
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &'ctx Context<'ctx>,
+        context: &'ctx Context,
         (): <Self::OutputHandoffs as PortList<SEND>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx> {
         ForEach::new(|x| (self.func)(context, x))

--- a/hydroflow/src/builder/build/push_handoff.rs
+++ b/hydroflow/src/builder/build/push_handoff.rs
@@ -52,7 +52,7 @@ where
 
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        _context: &'ctx Context<'ctx>,
+        _context: &'ctx Context,
         handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx> {
         let tl!(handoff) = handoffs;

--- a/hydroflow/src/builder/build/push_map.rs
+++ b/hydroflow/src/builder/build/push_map.rs
@@ -10,7 +10,7 @@ use crate::scheduled::port::SEND;
 pub struct MapPushBuild<Next, Func, In>
 where
     Next: PushBuild,
-    Func: FnMut(&Context<'_>, In) -> Next::ItemIn,
+    Func: FnMut(&Context, In) -> Next::ItemIn,
 {
     next: Next,
     func: Func,
@@ -19,7 +19,7 @@ where
 impl<Next, Func, In> MapPushBuild<Next, Func, In>
 where
     Next: PushBuild,
-    Func: FnMut(&Context<'_>, In) -> Next::ItemIn,
+    Func: FnMut(&Context, In) -> Next::ItemIn,
 {
     pub fn new(next: Next, func: Func) -> Self {
         Self {
@@ -39,7 +39,7 @@ where
 impl<Next, Func, In> PushBuildBase for MapPushBuild<Next, Func, In>
 where
     Next: PushBuild,
-    Func: FnMut(&Context<'_>, In) -> Next::ItemIn,
+    Func: FnMut(&Context, In) -> Next::ItemIn,
 {
     type ItemIn = In;
     type Build<'slf, 'ctx> = PushBuildImpl<'slf, 'ctx, Next, Func, In>;
@@ -48,13 +48,13 @@ where
 impl<Next, Func, In> PushBuild for MapPushBuild<Next, Func, In>
 where
     Next: PushBuild,
-    Func: FnMut(&Context<'_>, In) -> Next::ItemIn,
+    Func: FnMut(&Context, In) -> Next::ItemIn,
 {
     type OutputHandoffs = Next::OutputHandoffs;
 
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &'ctx Context<'ctx>,
+        context: &'ctx Context,
         handoffs: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx> {
         Map::new(

--- a/hydroflow/src/builder/build/push_partition.rs
+++ b/hydroflow/src/builder/build/push_partition.rs
@@ -8,7 +8,7 @@ use crate::scheduled::type_list::Extend;
 
 pub struct PartitionPushBuild<NextA, NextB, Func>
 where
-    Func: FnMut(&Context<'_>, &NextA::ItemIn) -> bool,
+    Func: FnMut(&Context, &NextA::ItemIn) -> bool,
     NextA: PushBuild,
     NextB: PushBuild<ItemIn = NextA::ItemIn>,
 
@@ -22,7 +22,7 @@ where
 }
 impl<Func, NextA, NextB> PartitionPushBuild<NextA, NextB, Func>
 where
-    Func: FnMut(&Context<'_>, &NextA::ItemIn) -> bool,
+    Func: FnMut(&Context, &NextA::ItemIn) -> bool,
     NextA: PushBuild,
     NextB: PushBuild<ItemIn = NextA::ItemIn>,
 
@@ -53,7 +53,7 @@ where
 
 impl<NextA, NextB, Func> PushBuildBase for PartitionPushBuild<NextA, NextB, Func>
 where
-    Func: FnMut(&Context<'_>, &NextA::ItemIn) -> bool,
+    Func: FnMut(&Context, &NextA::ItemIn) -> bool,
     NextA: PushBuild,
     NextB: PushBuild<ItemIn = NextA::ItemIn>,
 
@@ -67,7 +67,7 @@ where
 
 impl<NextA, NextB, Func> PushBuild for PartitionPushBuild<NextA, NextB, Func>
 where
-    Func: FnMut(&Context<'_>, &NextA::ItemIn) -> bool,
+    Func: FnMut(&Context, &NextA::ItemIn) -> bool,
     NextA: PushBuild,
     NextB: PushBuild<ItemIn = NextA::ItemIn>,
 
@@ -79,7 +79,7 @@ where
 
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &'ctx Context<'ctx>,
+        context: &'ctx Context,
         input: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx> {
         let (input_a, input_b) = <Self::OutputHandoffs as PortListSplit<_, _>>::split_ctx(input);

--- a/hydroflow/src/builder/build/push_tee.rs
+++ b/hydroflow/src/builder/build/push_tee.rs
@@ -62,7 +62,7 @@ where
 
     fn build<'slf, 'ctx>(
         &'slf mut self,
-        context: &'ctx Context<'ctx>,
+        context: &'ctx Context,
         input: <Self::OutputHandoffs as PortList<SEND>>::Ctx<'ctx>,
     ) -> Self::Build<'slf, 'ctx> {
         let (input_a, input_b) = <Self::OutputHandoffs as PortListSplit<_, _>>::split_ctx(input);

--- a/hydroflow/src/builder/surface/filter.rs
+++ b/hydroflow/src/builder/surface/filter.rs
@@ -15,7 +15,7 @@ where
 impl<Prev, Func> FilterSurface<Prev, Func>
 where
     Prev: BaseSurface,
-    Func: FnMut(&Context<'_>, &Prev::ItemOut) -> bool,
+    Func: FnMut(&Context, &Prev::ItemOut) -> bool,
 {
     pub fn new(prev: Prev, func: Func) -> Self {
         Self { prev, func }
@@ -25,7 +25,7 @@ where
 impl<Prev, Func> BaseSurface for FilterSurface<Prev, Func>
 where
     Prev: BaseSurface,
-    Func: FnMut(&Context<'_>, &Prev::ItemOut) -> bool,
+    Func: FnMut(&Context, &Prev::ItemOut) -> bool,
 {
     type ItemOut = Prev::ItemOut;
 }
@@ -33,7 +33,7 @@ where
 impl<Prev, Func> PullSurface for FilterSurface<Prev, Func>
 where
     Prev: PullSurface,
-    Func: FnMut(&Context<'_>, &Prev::ItemOut) -> bool,
+    Func: FnMut(&Context, &Prev::ItemOut) -> bool,
 {
     type InputHandoffs = Prev::InputHandoffs;
     type Build = FilterPullBuild<Prev::Build, Func>;
@@ -47,7 +47,7 @@ where
 impl<Prev, Func> AssembleFlowGraph for FilterSurface<Prev, Func>
 where
     Prev: PullSurface + AssembleFlowGraph,
-    Func: FnMut(&Context<'_>, &Prev::ItemOut) -> bool,
+    Func: FnMut(&Context, &Prev::ItemOut) -> bool,
 {
     fn insert_dep(&self, e: &mut super::FlowGraph) -> NodeId {
         let my_id = e.add_node("Filter");
@@ -60,7 +60,7 @@ where
 impl<Prev, Func> PushSurface for FilterSurface<Prev, Func>
 where
     Prev: PushSurface,
-    Func: FnMut(&Context<'_>, &Prev::ItemOut) -> bool,
+    Func: FnMut(&Context, &Prev::ItemOut) -> bool,
 {
     type Output<Next> = Prev::Output<FilterPushSurfaceReversed<Next, Func>>
     where
@@ -85,7 +85,7 @@ where
 impl<Next, Func> FilterPushSurfaceReversed<Next, Func>
 where
     Next: PushSurfaceReversed,
-    Func: FnMut(&Context<'_>, &Next::ItemIn) -> bool,
+    Func: FnMut(&Context, &Next::ItemIn) -> bool,
 {
     pub fn new(next: Next, func: Func) -> Self {
         Self { next, func }
@@ -94,7 +94,7 @@ where
 impl<Next, Func> AssembleFlowGraph for FilterPushSurfaceReversed<Next, Func>
 where
     Next: PushSurfaceReversed + AssembleFlowGraph,
-    Func: FnMut(&Context<'_>, &Next::ItemIn) -> bool,
+    Func: FnMut(&Context, &Next::ItemIn) -> bool,
 {
     fn insert_dep(&self, e: &mut super::FlowGraph) -> NodeId {
         let my_id = e.add_node("Filter");
@@ -107,7 +107,7 @@ where
 impl<Next, Func> PushSurfaceReversed for FilterPushSurfaceReversed<Next, Func>
 where
     Next: PushSurfaceReversed,
-    Func: FnMut(&Context<'_>, &Next::ItemIn) -> bool,
+    Func: FnMut(&Context, &Next::ItemIn) -> bool,
 {
     type ItemIn = Next::ItemIn;
 

--- a/hydroflow/src/builder/surface/filter_map.rs
+++ b/hydroflow/src/builder/surface/filter_map.rs
@@ -17,7 +17,7 @@ where
 impl<Prev, Func, Out> FilterMapSurface<Prev, Func>
 where
     Prev: BaseSurface,
-    Func: FnMut(&Context<'_>, Prev::ItemOut) -> Option<Out>,
+    Func: FnMut(&Context, Prev::ItemOut) -> Option<Out>,
 {
     pub fn new(prev: Prev, func: Func) -> Self {
         Self { prev, func }
@@ -27,7 +27,7 @@ where
 impl<Prev, Func, Out> BaseSurface for FilterMapSurface<Prev, Func>
 where
     Prev: BaseSurface,
-    Func: FnMut(&Context<'_>, Prev::ItemOut) -> Option<Out>,
+    Func: FnMut(&Context, Prev::ItemOut) -> Option<Out>,
 {
     type ItemOut = Out;
 }
@@ -35,7 +35,7 @@ where
 impl<Prev, Func, Out> PullSurface for FilterMapSurface<Prev, Func>
 where
     Prev: PullSurface,
-    Func: FnMut(&Context<'_>, Prev::ItemOut) -> Option<Out>,
+    Func: FnMut(&Context, Prev::ItemOut) -> Option<Out>,
 {
     type InputHandoffs = Prev::InputHandoffs;
     type Build = FilterMapPullBuild<Prev::Build, Func>;
@@ -49,7 +49,7 @@ where
 impl<Prev, Func, Out> AssembleFlowGraph for FilterMapSurface<Prev, Func>
 where
     Prev: PullSurface + AssembleFlowGraph,
-    Func: FnMut(&Context<'_>, Prev::ItemOut) -> Option<Out>,
+    Func: FnMut(&Context, Prev::ItemOut) -> Option<Out>,
 {
     fn insert_dep(&self, e: &mut super::FlowGraph) -> NodeId {
         let my_id = e.add_node("FilterMap");
@@ -62,7 +62,7 @@ where
 impl<Prev, Func, Out> PushSurface for FilterMapSurface<Prev, Func>
 where
     Prev: PushSurface,
-    Func: FnMut(&Context<'_>, Prev::ItemOut) -> Option<Out>,
+    Func: FnMut(&Context, Prev::ItemOut) -> Option<Out>,
 {
     type Output<Next> = Prev::Output<FilterMapPushSurfaceReversed<Next, Func, Prev::ItemOut>>
     where
@@ -88,7 +88,7 @@ where
 impl<Next, Func, In> FilterMapPushSurfaceReversed<Next, Func, In>
 where
     Next: PushSurfaceReversed,
-    Func: FnMut(&Context<'_>, In) -> Option<Next::ItemIn>,
+    Func: FnMut(&Context, In) -> Option<Next::ItemIn>,
 {
     pub fn new(next: Next, func: Func) -> Self {
         Self {
@@ -102,7 +102,7 @@ where
 impl<Next, Func, In> PushSurfaceReversed for FilterMapPushSurfaceReversed<Next, Func, In>
 where
     Next: PushSurfaceReversed,
-    Func: FnMut(&Context<'_>, In) -> Option<Next::ItemIn>,
+    Func: FnMut(&Context, In) -> Option<Next::ItemIn>,
 {
     type ItemIn = In;
 

--- a/hydroflow/src/builder/surface/map.rs
+++ b/hydroflow/src/builder/surface/map.rs
@@ -17,7 +17,7 @@ where
 impl<Prev, Func, Out> MapSurface<Prev, Func>
 where
     Prev: BaseSurface,
-    Func: FnMut(&Context<'_>, Prev::ItemOut) -> Out,
+    Func: FnMut(&Context, Prev::ItemOut) -> Out,
 {
     pub fn new(prev: Prev, func: Func) -> Self {
         Self { prev, func }
@@ -27,7 +27,7 @@ where
 impl<Prev, Func, Out> BaseSurface for MapSurface<Prev, Func>
 where
     Prev: BaseSurface,
-    Func: FnMut(&Context<'_>, Prev::ItemOut) -> Out,
+    Func: FnMut(&Context, Prev::ItemOut) -> Out,
 {
     type ItemOut = Out;
 }
@@ -35,7 +35,7 @@ where
 impl<Prev, Func, Out> PullSurface for MapSurface<Prev, Func>
 where
     Prev: PullSurface,
-    Func: FnMut(&Context<'_>, Prev::ItemOut) -> Out,
+    Func: FnMut(&Context, Prev::ItemOut) -> Out,
 {
     type InputHandoffs = Prev::InputHandoffs;
     type Build = MapPullBuild<Prev::Build, Func>;
@@ -49,7 +49,7 @@ where
 impl<Prev, Func, Out> AssembleFlowGraph for MapSurface<Prev, Func>
 where
     Prev: PullSurface + AssembleFlowGraph,
-    Func: FnMut(&Context<'_>, Prev::ItemOut) -> Out,
+    Func: FnMut(&Context, Prev::ItemOut) -> Out,
 {
     fn insert_dep(&self, e: &mut super::FlowGraph) -> NodeId {
         let my_id = e.add_node("Map");
@@ -62,7 +62,7 @@ where
 impl<Prev, Func, Out> PushSurface for MapSurface<Prev, Func>
 where
     Prev: PushSurface,
-    Func: FnMut(&Context<'_>, Prev::ItemOut) -> Out,
+    Func: FnMut(&Context, Prev::ItemOut) -> Out,
 {
     type Output<Next> = Prev::Output<MapPushSurfaceReversed<Next, Func, Prev::ItemOut>>
     where
@@ -88,7 +88,7 @@ where
 impl<Next, Func, In> MapPushSurfaceReversed<Next, Func, In>
 where
     Next: PushSurfaceReversed,
-    Func: FnMut(&Context<'_>, In) -> Next::ItemIn,
+    Func: FnMut(&Context, In) -> Next::ItemIn,
 {
     pub fn new(next: Next, func: Func) -> Self {
         Self {
@@ -101,7 +101,7 @@ where
 impl<Next, Func, In> AssembleFlowGraph for MapPushSurfaceReversed<Next, Func, In>
 where
     Next: PushSurfaceReversed + AssembleFlowGraph,
-    Func: FnMut(&Context<'_>, In) -> Next::ItemIn,
+    Func: FnMut(&Context, In) -> Next::ItemIn,
 {
     fn insert_dep(&self, e: &mut super::FlowGraph) -> NodeId {
         let my_id = e.add_node("Map");
@@ -114,7 +114,7 @@ where
 impl<Next, Func, In> PushSurfaceReversed for MapPushSurfaceReversed<Next, Func, In>
 where
     Next: PushSurfaceReversed,
-    Func: FnMut(&Context<'_>, In) -> Next::ItemIn,
+    Func: FnMut(&Context, In) -> Next::ItemIn,
 {
     type ItemIn = In;
 

--- a/hydroflow/src/builder/surface/pull_fold_epoch.rs
+++ b/hydroflow/src/builder/surface/pull_fold_epoch.rs
@@ -16,8 +16,8 @@ where
 impl<Prev, Init, Func, Out> FoldEpochPullSurface<Prev, Init, Func>
 where
     Prev: BaseSurface,
-    Init: FnMut(&Context<'_>) -> Out,
-    Func: FnMut(&Context<'_>, Out, Prev::ItemOut) -> Out,
+    Init: FnMut(&Context) -> Out,
+    Func: FnMut(&Context, Out, Prev::ItemOut) -> Out,
 {
     pub fn new(prev: Prev, init: Init, func: Func) -> Self {
         Self { prev, init, func }
@@ -26,8 +26,8 @@ where
 impl<Prev, Init, Func, Out> AssembleFlowGraph for FoldEpochPullSurface<Prev, Init, Func>
 where
     Prev: BaseSurface + AssembleFlowGraph,
-    Init: FnMut(&Context<'_>) -> Out,
-    Func: FnMut(&Context<'_>, Out, Prev::ItemOut) -> Out,
+    Init: FnMut(&Context) -> Out,
+    Func: FnMut(&Context, Out, Prev::ItemOut) -> Out,
 {
     fn insert_dep(&self, e: &mut super::FlowGraph) -> NodeId {
         let my_id = e.add_node("FoldEpoch");
@@ -40,8 +40,8 @@ where
 impl<Prev, Init, Func, Out> BaseSurface for FoldEpochPullSurface<Prev, Init, Func>
 where
     Prev: BaseSurface,
-    Init: FnMut(&Context<'_>) -> Out,
-    Func: FnMut(&Context<'_>, Out, Prev::ItemOut) -> Out,
+    Init: FnMut(&Context) -> Out,
+    Func: FnMut(&Context, Out, Prev::ItemOut) -> Out,
 {
     type ItemOut = Out;
 }
@@ -49,8 +49,8 @@ where
 impl<Prev, Init, Func, Out> PullSurface for FoldEpochPullSurface<Prev, Init, Func>
 where
     Prev: PullSurface,
-    Init: FnMut(&Context<'_>) -> Out,
-    Func: FnMut(&Context<'_>, Out, Prev::ItemOut) -> Out,
+    Init: FnMut(&Context) -> Out,
+    Func: FnMut(&Context, Out, Prev::ItemOut) -> Out,
 {
     type InputHandoffs = Prev::InputHandoffs;
     type Build = FoldEpochPullBuild<Prev::Build, Init, Func>;

--- a/hydroflow/src/builder/surface/push_for_each.rs
+++ b/hydroflow/src/builder/surface/push_for_each.rs
@@ -8,14 +8,14 @@ use crate::scheduled::flow_graph::NodeId;
 
 pub struct ForEachPushSurfaceReversed<Func, In>
 where
-    Func: FnMut(&Context<'_>, In),
+    Func: FnMut(&Context, In),
 {
     func: Func,
     _phantom: PhantomData<fn(In)>,
 }
 impl<Func, In> ForEachPushSurfaceReversed<Func, In>
 where
-    Func: FnMut(&Context<'_>, In),
+    Func: FnMut(&Context, In),
 {
     pub fn new(func: Func) -> Self {
         Self {
@@ -26,7 +26,7 @@ where
 }
 impl<Func, In> AssembleFlowGraph for ForEachPushSurfaceReversed<Func, In>
 where
-    Func: FnMut(&Context<'_>, In),
+    Func: FnMut(&Context, In),
 {
     fn insert_dep(&self, e: &mut super::FlowGraph) -> NodeId {
         let my_id = e.add_node("ForEach");
@@ -36,7 +36,7 @@ where
 
 impl<Func, In> PushSurfaceReversed for ForEachPushSurfaceReversed<Func, In>
 where
-    Func: FnMut(&Context<'_>, In),
+    Func: FnMut(&Context, In),
 {
     type ItemIn = In;
 

--- a/hydroflow/src/builder/surface/push_partition.rs
+++ b/hydroflow/src/builder/surface/push_partition.rs
@@ -9,7 +9,7 @@ use crate::scheduled::type_list::Extend;
 
 pub struct PartitionPushSurfaceReversed<NextA, NextB, Func>
 where
-    Func: FnMut(&Context<'_>, &NextA::ItemIn) -> bool,
+    Func: FnMut(&Context, &NextA::ItemIn) -> bool,
     NextA: PushSurfaceReversed,
     NextB: PushSurfaceReversed<ItemIn = NextA::ItemIn>,
 
@@ -23,7 +23,7 @@ where
 }
 impl<NextA, NextB, Func> PartitionPushSurfaceReversed<NextA, NextB, Func>
 where
-    Func: FnMut(&Context<'_>, &NextA::ItemIn) -> bool,
+    Func: FnMut(&Context, &NextA::ItemIn) -> bool,
     NextA: PushSurfaceReversed,
     NextB: PushSurfaceReversed<ItemIn = NextA::ItemIn>,
 
@@ -41,7 +41,7 @@ where
 }
 impl<NextA, NextB, Func> AssembleFlowGraph for PartitionPushSurfaceReversed<NextA, NextB, Func>
 where
-    Func: FnMut(&Context<'_>, &NextA::ItemIn) -> bool,
+    Func: FnMut(&Context, &NextA::ItemIn) -> bool,
     NextA: PushSurfaceReversed + AssembleFlowGraph,
     NextB: PushSurfaceReversed<ItemIn = NextA::ItemIn> + AssembleFlowGraph,
 
@@ -61,7 +61,7 @@ where
 
 impl<NextA, NextB, Func> PushSurfaceReversed for PartitionPushSurfaceReversed<NextA, NextB, Func>
 where
-    Func: FnMut(&Context<'_>, &NextA::ItemIn) -> bool,
+    Func: FnMut(&Context, &NextA::ItemIn) -> bool,
     NextA: PushSurfaceReversed,
     NextB: PushSurfaceReversed<ItemIn = NextA::ItemIn>,
 

--- a/hydroflow/src/scheduled/flow_graph.rs
+++ b/hydroflow/src/scheduled/flow_graph.rs
@@ -19,7 +19,7 @@ impl Hydroflow {
             .handoff_ids
             .get(&node_id)
         {
-            let handoff = &self.handoffs[handoff_id.0];
+            let handoff = &self.context.handoffs[handoff_id.0];
             format!("Handoff_{}[\\{}/]", handoff_id.0, handoff.name)
         } else if &*name == "PullToPush" {
             format!("{}.{}[/{}\\]", sg_id.0, node_id.0, name)
@@ -141,7 +141,7 @@ impl Hydroflow {
                     subgraph.name.clone(),
                     subgraph.stratum,
                     subgraph.dependencies.clone(),
-                    &*self.handoffs,
+                    &*self.context.handoffs,
                 );
             }
         }

--- a/hydroflow/src/scheduled/graph_ext.rs
+++ b/hydroflow/src/scheduled/graph_ext.rs
@@ -26,7 +26,7 @@ macro_rules! subgraph_ext {
         ) -> SubgraphId
         where
             Name: Into<Cow<'static, str>>,
-            F: 'static + FnMut(&Context<'_>, $(&RecvCtx< $recv_generic >,)* $(&SendCtx< $send_generic >),*),
+            F: 'static + FnMut(&Context, $(&RecvCtx< $recv_generic >,)* $(&SendCtx< $send_generic >),*),
             $($recv_generic : 'static + Handoff,)*
             $($send_generic : 'static + Handoff,)*;
     };
@@ -44,7 +44,7 @@ macro_rules! subgraph_ext {
         ) -> SubgraphId
         where
             Name: Into<Cow<'static, str>>,
-            F: 'static + FnMut(&Context<'_>, $(&RecvCtx< $recv_generic >,)* $(&SendCtx< $send_generic >),*),
+            F: 'static + FnMut(&Context, $(&RecvCtx< $recv_generic >,)* $(&SendCtx< $send_generic >),*),
             $($recv_generic : 'static + Handoff,)*
             $($send_generic : 'static + Handoff,)*
         {

--- a/hydroflow/src/scheduled/query.rs
+++ b/hydroflow/src/scheduled/query.rs
@@ -24,7 +24,7 @@ impl Query {
     pub fn source<F, T>(&mut self, f: F) -> Operator<T>
     where
         T: 'static,
-        F: 'static + FnMut(&Context<'_>, &SendCtx<VecHandoff<T>>),
+        F: 'static + FnMut(&Context, &SendCtx<VecHandoff<T>>),
     {
         let mut df = self.df.borrow_mut();
 

--- a/hydroflow/src/scheduled/subgraph.rs
+++ b/hydroflow/src/scheduled/subgraph.rs
@@ -5,13 +5,13 @@ use super::context::Context;
  */
 pub(crate) trait Subgraph {
     // TODO: pass in some scheduling info?
-    fn run(&mut self, context: Context<'_>);
+    fn run(&mut self, context: &Context);
 }
 impl<F> Subgraph for F
 where
-    F: FnMut(Context<'_>),
+    F: FnMut(&Context),
 {
-    fn run(&mut self, context: Context<'_>) {
+    fn run(&mut self, context: &Context) {
         (self)(context);
     }
 }


### PR DESCRIPTION
Instead of creating the context each time a subgraph is scheduled, just keep a single context instance inside `Hydroflow` which stores the context state, and update it as needed before lending to each subgraph.