### PR TITLE
Provide `&mut Context` to subgraph closure, instead of just ref

### DIFF
--- a/hydroflow/src/scheduled/graph.rs
+++ b/hydroflow/src/scheduled/graph.rs
@@ -94,7 +94,7 @@ impl Hydroflow {
                 assert!(sg_data.is_scheduled.take());
 
                 self.context.subgraph_id = sg_id;
-                sg_data.subgraph.run(&self.context);
+                sg_data.subgraph.run(&mut self.context);
             }
 
             for &handoff_id in self.subgraphs[sg_id.0].succs.iter() {
@@ -257,7 +257,7 @@ impl Hydroflow {
             &mut subgraph_succs,
         );
 
-        let subgraph = move |context: &Context| {
+        let subgraph = move |context: &mut Context| {
             let recv = recv_ports.make_ctx(&*context.handoffs);
             let send = send_ports.make_ctx(&*context.handoffs);
             (subgraph)(context, recv, send);
@@ -327,7 +327,7 @@ impl Hydroflow {
                 .push(sg_id);
         }
 
-        let subgraph = move |context: &Context| {
+        let subgraph = move |context: &mut Context| {
             let recvs: Vec<&RecvCtx<R>> = recv_ports
                 .iter()
                 .map(|hid| hid.handoff_id)

--- a/hydroflow/src/scheduled/subgraph.rs
+++ b/hydroflow/src/scheduled/subgraph.rs
@@ -5,13 +5,13 @@ use super::context::Context;
  */
 pub(crate) trait Subgraph {
     // TODO: pass in some scheduling info?
-    fn run(&mut self, context: &Context);
+    fn run(&mut self, context: &mut Context);
 }
 impl<F> Subgraph for F
 where
-    F: FnMut(&Context),
+    F: FnMut(&mut Context),
 {
-    fn run(&mut self, context: &Context) {
+    fn run(&mut self, context: &mut Context) {
         (self)(context);
     }
 }


### PR DESCRIPTION
For now does not affect any external API, but is a preqrequisite for
`&mut Context` in the surface API