### PR TITLE
Surface syntax fixes

### DIFF
--- a/hydroflow_macro/src/lib.rs
+++ b/hydroflow_macro/src/lib.rs
@@ -41,11 +41,11 @@ pub fn hydroflow_parser(input: proc_macro::TokenStream) -> proc_macro::TokenStre
 
     let flat_mermaid = flat_graph.mermaid_string();
 
-    // let part_graph = flat_graph.into_partitioned_graph();
-    // let part_mermaid = part_graph.to_serde_graph();
+    let part_graph = flat_graph.into_partitioned_graph().unwrap();
+    let part_mermaid = part_graph.to_serde_graph().to_mermaid();
 
     let lit0 = Literal::string(&*flat_mermaid);
-    // let lit1 = Literal::string(&*part_mermaid);
+    let lit1 = Literal::string(&*part_mermaid);
 
-    quote! { println!("{}", #lit0); }.into()
+    quote! { println!("{}\n\n{}\n", #lit0, #lit1); }.into()
 }


### PR DESCRIPTION
```
commit 7603c5fa947f2b3c8899416b0532dcaa86e9b3a9 (HEAD -> surface-syntax-fixes, fork/surface-syntax-fixes)
Author: Mingwei Samuel <mingwei.samuel@gmail.com>
Date:   Mon Sep 26 17:47:17 2022 -0700

    Surface syntax fix handling of wildcard linear chains which might cause later pull-push conflicts    

commit c256d0f965c0862062757847ba856dad8ec40c3a
Author: Mingwei Samuel <mingwei.samuel@gmail.com>
Date:   Mon Sep 26 17:29:49 2022 -0700

    Add surface diamond tests

    To check subgraph partitioning bug in linear chains

commit 82e3076e6724b2159d2bb535873d741d78d75c2e
Author: Mingwei Samuel <mingwei.samuel@gmail.com>
Date:   Mon Sep 26 17:28:22 2022 -0700

    Enable partitioned output on hydroflow_parser!
```