### PR TITLE
Add filtering expressions to Dedalus rules. #178

### DIFF
--- a/hydroflow_datalog_core/src/grammar.rs
+++ b/hydroflow_datalog_core/src/grammar.rs
@@ -16,29 +16,41 @@ pub mod datalog {
 
     #[derive(Debug, Clone)]
     pub struct Rule {
-        pub target: Atom,
+        pub target: RelationExpr,
+
         #[rust_sitter::leaf(text = ":-")]
         _from: (),
+
         #[rust_sitter::repeat(non_empty = true)]
         #[rust_sitter::delimited(
             #[rust_sitter::leaf(text = ",")]
             ()
         )]
         pub sources: Vec<Atom>,
+
         #[rust_sitter::leaf(text = ".")]
         _dot: Option<()>,
     }
 
     #[derive(Debug, Clone)]
-    pub struct Atom {
+    pub enum Atom {
+        Relation(RelationExpr),
+        Predicate(PredicateExpr),
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct RelationExpr {
         pub name: Ident,
+
         #[rust_sitter::leaf(text = "(")]
         _l_paren: (),
+
         #[rust_sitter::delimited(
             #[rust_sitter::leaf(text = ",")]
             ()
         )]
         pub fields: Vec<Ident>,
+
         #[rust_sitter::leaf(text = ")")]
         _r_paren: (),
     }
@@ -53,5 +65,27 @@ pub mod datalog {
     struct Whitespace {
         #[rust_sitter::leaf(pattern = r"\s")]
         _whitespace: (),
+    }
+
+    #[derive(Debug, Clone)]
+    pub enum BoolOp {
+        Lt(#[rust_sitter::leaf(text = "<")] ()),
+        LtEq(#[rust_sitter::leaf(text = "<=")] ()),
+        Gt(#[rust_sitter::leaf(text = ">")] ()),
+        GtEq(#[rust_sitter::leaf(text = ">=")] ()),
+        Eq(#[rust_sitter::leaf(text = "==")] ()),
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct PredicateExpr {
+        #[rust_sitter::leaf(text = "(")]
+        _l_brace: (),
+
+        pub left: Ident,
+        pub op: BoolOp,
+        pub right: Ident,
+
+        #[rust_sitter::leaf(text = ")")]
+        _r_brace: (),
     }
 }

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__simple_filter@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__simple_filter@datalog_program.snap
@@ -1,0 +1,157 @@
+---
+source: hydroflow_datalog_core/src/lib.rs
+expression: "prettyplease::unparse(&wrapped)"
+---
+fn main() {
+    {
+        {
+            use hydroflow::{var_expr, var_args};
+            let mut df = hydroflow::scheduled::graph::Hydroflow::new_with_graph(
+                "{\"nodes\":[{\"value\":null,\"version\":0},{\"value\":\"merge ()\",\"version\":1},{\"value\":\"tee ()\",\"version\":1},{\"value\":\"merge ()\",\"version\":1},{\"value\":\"tee ()\",\"version\":1},{\"value\":\"source_stream (input)\",\"version\":1},{\"value\":\"for_each (| v | out . send (v) . unwrap ())\",\"version\":1},{\"value\":\"filter (| & row : & (_ , _ ,) | row . 0 > row . 1 && row . 1 == row . 0)\",\"version\":1},{\"value\":\"map (| row : (_ , _ ,) | (row . 0 , row . 1 ,))\",\"version\":1}],\"node_color_map\":[{\"value\":null,\"version\":0},{\"value\":\"Pull\",\"version\":1},{\"value\":\"Pull\",\"version\":1},{\"value\":\"Push\",\"version\":1},{\"value\":\"Push\",\"version\":1},{\"value\":\"Pull\",\"version\":1},{\"value\":\"Push\",\"version\":1},{\"value\":\"Pull\",\"version\":1},{\"value\":\"Push\",\"version\":1}],\"edges\":[{\"value\":null,\"version\":0},{\"value\":[{\"src\":{\"idx\":1,\"version\":1},\"dst\":{\"idx\":2,\"version\":1},\"blocking\":false,\"label\":null}],\"version\":1},{\"value\":[{\"src\":{\"idx\":2,\"version\":1},\"dst\":{\"idx\":7,\"version\":1},\"blocking\":false,\"label\":null}],\"version\":1},{\"value\":[{\"src\":{\"idx\":3,\"version\":1},\"dst\":{\"idx\":4,\"version\":1},\"blocking\":false,\"label\":null}],\"version\":1},{\"value\":[{\"src\":{\"idx\":4,\"version\":1},\"dst\":{\"idx\":6,\"version\":1},\"blocking\":false,\"label\":\"0\"}],\"version\":1},{\"value\":[{\"src\":{\"idx\":5,\"version\":1},\"dst\":{\"idx\":1,\"version\":1},\"blocking\":false,\"label\":\"0\"}],\"version\":1},{\"value\":null,\"version\":0},{\"value\":[{\"src\":{\"idx\":7,\"version\":1},\"dst\":{\"idx\":8,\"version\":1},\"blocking\":false,\"label\":null}],\"version\":1},{\"value\":[{\"src\":{\"idx\":8,\"version\":1},\"dst\":{\"idx\":3,\"version\":1},\"blocking\":false,\"label\":\"0\"}],\"version\":1}],\"barrier_handoffs\":[{\"value\":null,\"version\":0}],\"subgraph_nodes\":[{\"value\":null,\"version\":0},{\"value\":[{\"idx\":5,\"version\":1},{\"idx\":1,\"version\":1},{\"idx\":2,\"version\":1},{\"idx\":7,\"version\":1},{\"idx\":8,\"version\":1},{\"idx\":3,\"version\":1},{\"idx\":4,\"version\":1},{\"idx\":6,\"version\":1}],\"version\":1}],\"subgraph_stratum\":[{\"value\":null,\"version\":0},{\"value\":0,\"version\":1}],\"subgraph_internal_handoffs\":[{\"value\":null,\"version\":0}],\"varname_nodes\":{\"input\":[{\"idx\":1,\"version\":1},{\"idx\":2,\"version\":1}],\"out\":[{\"idx\":3,\"version\":1},{\"idx\":4,\"version\":1}],\"predicate_0_filter\":[{\"idx\":7,\"version\":1}]}}\n",
+            );
+            let mut sg_1v1_node_5v1_stream = Box::pin(input);
+            df.add_subgraph_stratified(
+                "Subgraph GraphSubgraphId(1v1)",
+                0,
+                var_expr!(),
+                var_expr!(),
+                move |context, var_args!(), var_args!()| {
+                    let op_5v1 = std::iter::from_fn(|| {
+                        match hydroflow::futures::stream::Stream::poll_next(
+                            sg_1v1_node_5v1_stream.as_mut(),
+                            &mut std::task::Context::from_waker(&context.waker()),
+                        ) {
+                            std::task::Poll::Ready(maybe) => maybe,
+                            std::task::Poll::Pending => None,
+                        }
+                    });
+                    let op_5v1 = {
+                        #[inline(always)]
+                        pub fn check_op_5v1<
+                            Input: ::std::iter::Iterator<Item = Item>,
+                            Item,
+                        >(input: Input) -> impl ::std::iter::Iterator<Item = Item> {
+                            input
+                        }
+                        check_op_5v1(op_5v1)
+                    };
+                    let op_1v1 = {
+                        #[allow(unused)]
+                        #[inline(always)]
+                        fn check_inputs<
+                            A: ::std::iter::Iterator<Item = Item>,
+                            B: ::std::iter::Iterator<Item = Item>,
+                            Item,
+                        >(a: A, b: B) -> impl ::std::iter::Iterator<Item = Item> {
+                            a.chain(b)
+                        }
+                        op_5v1
+                    };
+                    let op_1v1 = {
+                        #[inline(always)]
+                        pub fn check_op_1v1<
+                            Input: ::std::iter::Iterator<Item = Item>,
+                            Item,
+                        >(input: Input) -> impl ::std::iter::Iterator<Item = Item> {
+                            input
+                        }
+                        check_op_1v1(op_1v1)
+                    };
+                    let op_2v1 = op_1v1;
+                    let op_2v1 = {
+                        #[inline(always)]
+                        pub fn check_op_2v1<
+                            Input: ::std::iter::Iterator<Item = Item>,
+                            Item,
+                        >(input: Input) -> impl ::std::iter::Iterator<Item = Item> {
+                            input
+                        }
+                        check_op_2v1(op_2v1)
+                    };
+                    let op_7v1 = op_2v1
+                        .filter(|&row: &(_, _)| row.0 > row.1 && row.1 == row.0);
+                    let op_7v1 = {
+                        #[inline(always)]
+                        pub fn check_op_7v1<
+                            Input: ::std::iter::Iterator<Item = Item>,
+                            Item,
+                        >(input: Input) -> impl ::std::iter::Iterator<Item = Item> {
+                            input
+                        }
+                        check_op_7v1(op_7v1)
+                    };
+                    let op_8v1 = op_7v1.map(|row: (_, _)| (row.0, row.1));
+                    let op_8v1 = {
+                        #[inline(always)]
+                        pub fn check_op_8v1<
+                            Input: ::std::iter::Iterator<Item = Item>,
+                            Item,
+                        >(input: Input) -> impl ::std::iter::Iterator<Item = Item> {
+                            input
+                        }
+                        check_op_8v1(op_8v1)
+                    };
+                    let op_3v1 = {
+                        #[allow(unused)]
+                        #[inline(always)]
+                        fn check_inputs<
+                            A: ::std::iter::Iterator<Item = Item>,
+                            B: ::std::iter::Iterator<Item = Item>,
+                            Item,
+                        >(a: A, b: B) -> impl ::std::iter::Iterator<Item = Item> {
+                            a.chain(b)
+                        }
+                        op_8v1
+                    };
+                    let op_3v1 = {
+                        #[inline(always)]
+                        pub fn check_op_3v1<
+                            Input: ::std::iter::Iterator<Item = Item>,
+                            Item,
+                        >(input: Input) -> impl ::std::iter::Iterator<Item = Item> {
+                            input
+                        }
+                        check_op_3v1(op_3v1)
+                    };
+                    let op_4v1 = op_3v1;
+                    let op_4v1 = {
+                        #[inline(always)]
+                        pub fn check_op_4v1<
+                            Input: ::std::iter::Iterator<Item = Item>,
+                            Item,
+                        >(input: Input) -> impl ::std::iter::Iterator<Item = Item> {
+                            input
+                        }
+                        check_op_4v1(op_4v1)
+                    };
+                    let op_6v1 = hydroflow::pusherator::for_each::ForEach::new(|v| {
+                        out.send(v).unwrap()
+                    });
+                    let op_6v1 = {
+                        #[inline(always)]
+                        pub fn check_op_6v1<
+                            Input: hydroflow::pusherator::Pusherator<Item = Item>,
+                            Item,
+                        >(
+                            input: Input,
+                        ) -> impl hydroflow::pusherator::Pusherator<Item = Item> {
+                            input
+                        }
+                        check_op_6v1(op_6v1)
+                    };
+                    #[inline(always)]
+                    fn check_pivot_run<
+                        Pull: ::std::iter::Iterator<Item = Item>,
+                        Push: hydroflow::pusherator::Pusherator<Item = Item>,
+                        Item,
+                    >(pull: Pull, push: Push) {
+                        hydroflow::pusherator::pivot::Pivot::new(pull, push).run();
+                    }
+                    check_pivot_run(op_4v1, op_6v1);
+                },
+            );
+            df
+        }
+    }
+}
+

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__simple_filter@surface_graph.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__simple_filter@surface_graph.snap
@@ -1,0 +1,21 @@
+---
+source: hydroflow_datalog_core/src/lib.rs
+expression: graph.surface_syntax_string()
+---
+1v1 = merge ();
+2v1 = tee ();
+3v1 = merge ();
+4v1 = tee ();
+5v1 = source_stream (input);
+6v1 = for_each (| v | out . send (v) . unwrap ());
+7v1 = filter (| & row : & (_ , _ ,) | row . 0 > row . 1 && row . 1 == row . 0);
+8v1 = map (| row : (_ , _ ,) | (row . 0 , row . 1 ,));
+
+(1v1-->2v1);
+(3v1-->4v1);
+(5v1-->1v1);
+(4v1-->6v1);
+(2v1-->7v1);
+(8v1-->3v1);
+(7v1-->8v1);
+


### PR DESCRIPTION
We only support expressions between identifiers currently. In the future we will add literal support and arithmetic expression support to both the LHS and RHS of the boolean expression.

We use | to denote the start of the filtering operator because using a comma introduces ambiguity with starting another Atom.

Filtering expressions also currently do not affect codegen.