### PR TITLE
Fix example graph printing

### DIFF
--- a/hydroflow/examples/chat/client.rs
+++ b/hydroflow/examples/chat/client.rs
@@ -68,15 +68,19 @@ pub(crate) async fn run_client(opts: Opts) {
     };
 
     if let Some(graph) = opts.graph {
+        let serde_graph = hf
+            .serde_graph()
+            .expect("No graph found, maybe failed to parse.");
         match graph {
             GraphType::Mermaid => {
-                println!("{}", hf.generate_mermaid())
+                println!("{}", serde_graph.to_mermaid());
             }
             GraphType::Dot => {
-                println!("{}", hf.generate_dot())
+                println!("{}", serde_graph.to_dot())
             }
             GraphType::Json => {
-                println!("{}", hf.generate_json())
+                unimplemented!();
+                // println!("{}", serde_graph.to_json())
             }
         }
     }

--- a/hydroflow/examples/chat/server.rs
+++ b/hydroflow/examples/chat/server.rs
@@ -31,15 +31,19 @@ pub(crate) async fn run_server(opts: Opts) {
     };
 
     if let Some(graph) = opts.graph {
+        let serde_graph = df
+            .serde_graph()
+            .expect("No graph found, maybe failed to parse.");
         match graph {
             GraphType::Mermaid => {
-                println!("{}", df.generate_mermaid())
+                println!("{}", serde_graph.to_mermaid());
             }
             GraphType::Dot => {
-                println!("{}", df.generate_dot())
+                println!("{}", serde_graph.to_dot())
             }
             GraphType::Json => {
-                println!("{}", df.generate_json())
+                unimplemented!();
+                // println!("{}", serde_graph.to_json())
             }
         }
     }

--- a/hydroflow/examples/graph_reachability/main.rs
+++ b/hydroflow/examples/graph_reachability/main.rs
@@ -30,15 +30,19 @@ pub fn main() {
     };
 
     if let Some(graph) = opts.graph {
+        let serde_graph = df
+            .serde_graph()
+            .expect("No graph found, maybe failed to parse.");
         match graph {
             GraphType::Mermaid => {
-                println!("{}", df.generate_mermaid())
+                println!("{}", serde_graph.to_mermaid());
             }
             GraphType::Dot => {
-                println!("{}", df.generate_dot())
+                println!("{}", serde_graph.to_dot())
             }
             GraphType::Json => {
-                println!("{}", df.generate_json())
+                unimplemented!();
+                // println!("{}", serde_graph.to_json())
             }
         }
     }

--- a/hydroflow/examples/three_clique/main.rs
+++ b/hydroflow/examples/three_clique/main.rs
@@ -43,18 +43,23 @@ pub fn main() {
     };
 
     if let Some(graph) = opts.graph {
+        let serde_graph = df
+            .serde_graph()
+            .expect("No graph found, maybe failed to parse.");
         match graph {
             GraphType::Mermaid => {
-                println!("{}", df.generate_mermaid())
+                println!("{}", serde_graph.to_mermaid());
             }
             GraphType::Dot => {
-                println!("{}", df.generate_dot())
+                println!("{}", serde_graph.to_dot())
             }
             GraphType::Json => {
-                println!("{}", df.generate_json())
+                unimplemented!();
+                // println!("{}", serde_graph.to_json())
             }
         }
     }
+
     df.run_available();
 
     println!("A");

--- a/hydroflow/examples/two_pc/coordinator.rs
+++ b/hydroflow/examples/two_pc/coordinator.rs
@@ -90,15 +90,19 @@ pub(crate) async fn run_coordinator(opts: Opts, subordinates: Vec<String>) {
     };
 
     if let Some(graph) = opts.graph {
+        let serde_graph = df
+            .serde_graph()
+            .expect("No graph found, maybe failed to parse.");
         match graph {
             GraphType::Mermaid => {
-                println!("{}", df.generate_mermaid())
+                println!("{}", serde_graph.to_mermaid());
             }
             GraphType::Dot => {
-                println!("{}", df.generate_dot())
+                println!("{}", serde_graph.to_dot())
             }
             GraphType::Json => {
-                println!("{}", df.generate_json())
+                unimplemented!();
+                // println!("{}", serde_graph.to_json())
             }
         }
     }

--- a/hydroflow/examples/two_pc/subordinate.rs
+++ b/hydroflow/examples/two_pc/subordinate.rs
@@ -60,15 +60,19 @@ pub(crate) async fn run_subordinate(opts: Opts, coordinator: String) {
     };
 
     if let Some(graph) = opts.graph {
+        let serde_graph = df
+            .serde_graph()
+            .expect("No graph found, maybe failed to parse.");
         match graph {
             GraphType::Mermaid => {
-                println!("{}", df.generate_mermaid())
+                println!("{}", serde_graph.to_mermaid());
             }
             GraphType::Dot => {
-                println!("{}", df.generate_dot())
+                println!("{}", serde_graph.to_dot())
             }
             GraphType::Json => {
-                println!("{}", df.generate_json())
+                unimplemented!();
+                // println!("{}", serde_graph.to_json())
             }
         }
     }


### PR DESCRIPTION
Seems there are two code paths. For surface syntax:
```rust
hf.serde_graph().unwrap().to_mermaid()
```
For deprecated surface API. And core API, kinda
```rust
hf.generate_mermaid()
```
ref #219