### PR TITLE
Add a driver for the chat example

### DIFF
--- a/hydroflow/examples/chat/README.md
+++ b/hydroflow/examples/chat/README.md
@@ -9,14 +9,20 @@ cargo run -p hydroflow --example chat -- --name "_" --role "server" --port 12347
 
 In another terminal run the first client:
 ```
-cargo run -p hydroflow --example chat -- --name "alice" --role client --port 12347 --addr 127.0.0.1
+cargo run -p hydroflow --example chat -- --name "alice" --role client --port 9090 --addr 127.0.0.1 --server-port 12347 --server-addr 127.0.0.1
 ```
 
 In the third terminal run the second client:
 ```
-cargo run -p hydroflow --example chat -- --name "bob" --role client --port 12347 --addr 127.0.0.1
+cargo run -p hydroflow --example chat -- --name "bob" --role client --port 9091 --addr 127.0.0.1 --server-port 12347 --server-addr 127.0.0.1
 ```
 
 If you type in the client terminals the messages should appear everywhere.
+
+If you want chat clients to send messages autonomously, you can feed those messages into the client's stdin. The included `chat_driver.py` is one way to do this. To use it:
+
+```
+hydroflow/examples/chat/chat_driver.py | cargo run -p hydroflow --example chat -- --name "alice" --role client --port 9090 --addr 127.0.0.1 --server-addr 127.0.0.1 --server-port 12347
+```
 
 Adding the `--graph <graph_type>` flag to the end of the command lines above will print out a node-and-edge diagram of the program. Supported values for `<graph_type>` include [mermaid](https://mermaid-js.github.io/) and [dot](https://graphviz.org/doc/info/lang.html).

--- a/hydroflow/examples/chat/chat_driver.py
+++ b/hydroflow/examples/chat/chat_driver.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+import argparse
+import random
+import time
+
+
+def chat_driver(
+        word_source: str,
+        delay_seconds: float,
+        jitter_millis: int,
+        phrase_length: int
+):
+    with open(word_source, 'r') as fp:
+        words = fp.readlines()
+
+    while True:
+        phrase = ' '.join([
+            x.strip()
+            for x in random.choices(words, k=phrase_length)
+        ])
+
+        print(phrase, flush=True)
+
+        sleep_time_seconds = delay_seconds + \
+            (random.randrange(-1 * jitter_millis, jitter_millis) / 1000.0)
+
+        time.sleep(sleep_time_seconds)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="A source of random phrases to pipe into chat "
+        "clients' stdin"
+    )
+
+    parser.add_argument(
+        '--word_source',
+        '-w',
+        help='where to get words from (default: %(default)s)',
+        default='/usr/share/dict/words'
+    )
+
+    parser.add_argument(
+        '--phrase_length',
+        '-l',
+        type=int,
+        help='phrase length in words',
+        default=5
+    )
+
+    parser.add_argument(
+        '--delay_seconds',
+        '-d',
+        type=float,
+        help='delay between phrases in seconds (default: %(default)s seconds)',
+        default=2.0
+    )
+
+    parser.add_argument(
+        '--jitter_millis',
+        '-j',
+        type=int,
+        help='maximum time jitter between phrases in milliseconds '
+        '(default: %(default)s milliseconds)',
+        default=50
+    )
+
+    args = parser.parse_args()
+
+    chat_driver(**vars(args))


### PR DESCRIPTION
Clients can take messages in on stdin from any process, but in order to drive them autonomously we need a reliable and continuous source of input that's less spammy than commands like 'yes'. This diff adds a chat driver that spits out a random phrase every few seconds to serve as this driver.