### PR TITLE
Multiplatform example builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+book/
+target/
+hydroflow-examples-*.tar.gz

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
 book/
 target/
-hydroflow-examples-*.tar.gz

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ members = [
     "pusherator",
     "type_list",
 ]
+
+[profile.release]
+strip = true      # Strip symbols from the binary
+opt-level = "z"   # Optimize for size

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Compilation stage
+FROM --platform=$BUILDPLATFORM rust:slim-buster AS build
+
+ARG TARGETOS TARGETARCH
+
+RUN apt-get update
+
+RUN /bin/bash -c "if [ "${TARGETARCH}" == "arm64" ]; then apt-get install -y gcc-aarch64-linux-gnu ; else apt-get install -y gcc-x86-64-linux-gnu ; fi"
+
+WORKDIR /usr/src/myapp
+COPY . .
+
+RUN ./scripts/build_dist_release.sh ${TARGETOS} ${TARGETARCH}
+
+RUN mkdir -p xfer/examples
+RUN ls -dR target/*/examples/* | grep -vE '^.*/[a-z_]+\-.*$' | grep -vE '^.*\.d$' | xargs -I{} cp {} xfer/examples/
+
+# Runtime stage
+FROM rust:slim
+
+WORKDIR /usr/src/myapp
+COPY --from=build /usr/src/myapp/xfer/examples/* .

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ COPY . .
 RUN ./scripts/build_dist_release.sh ${TARGETOS} ${TARGETARCH}
 
 RUN mkdir -p xfer/examples
-RUN ls -dR target/*/examples/* | grep -vE '^.*/[a-z_]+\-.*$' | grep -vE '^.*\.d$' | xargs -I{} cp {} xfer/examples/
+RUN ls -dR target/*/release/examples/* | grep -vE '^.*/[a-z_]+\-.*$' | grep -vE '^.*\.d$' | xargs -I{} cp {} xfer/examples/
+RUN ls xfer/examples
 
 # Runtime stage
 FROM rust:slim

--- a/scripts/build_dist_release.sh
+++ b/scripts/build_dist_release.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [ "$#" -ne 2 ]; then
-    echo "Usage: build_dist_release <target OS> <target architecture>"
+    echo "Usage: build_dist_release.sh <target OS> <target architecture>"
     exit 1
 fi
 

--- a/scripts/build_dist_release.sh
+++ b/scripts/build_dist_release.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: build_dist_release <target OS> <target architecture>"
+    exit 1
+fi
+
+TARGET_OS=$1
+TARGET_ARCH=$2
+
+case $TARGET_ARCH in
+  arm64)
+    RUST_TARGET_ARCH=aarch64
+  ;;
+  amd64)
+    RUST_TARGET_ARCH=x86_64
+    ;;
+  *)
+    echo "Unsupported architecture '${TARGET_ARCH}'"
+    exit 1
+    ;;
+esac
+
+case $TARGET_OS in
+  linux)
+    RUST_TARGET_OS=unknown-linux
+    RUST_TARGET_LIBS=gnu
+  ;;
+  macos)
+    RUST_TARGET_OS=apple
+    RUST_TARGET_LIBS=darwin
+  ;;
+  *)
+    echo "Unsupported OS '${TARGET_OS}'"
+    exit 1
+  ;;
+esac
+
+RUST_TARGET="${RUST_TARGET_ARCH}-${RUST_TARGET_OS}-${RUST_TARGET_LIBS}"
+
+echo "Attempting to (cross-)compile to target '${RUST_TARGET}'"
+
+rustup target add ${RUST_TARGET}
+
+if [ "${TARGET_OS}" == "linux" ]
+then
+  export RUSTFLAGS="-C linker=${RUST_TARGET_ARCH}-linux-gnu-gcc"
+fi
+
+cargo build --release --all-targets --target ${RUST_TARGET}

--- a/scripts/multiplatform-docker-build.sh
+++ b/scripts/multiplatform-docker-build.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+if [ "$#" -ne 1 ]; then
+    echo "Usage: multiplatform-docker-build.sh <image name>"
+    exit 1
+fi
+
+IMAGE_NAME=$1
+
 docker buildx create --use --name hydroflow-multiplatform --node hydroflow-multiplatform
 
-docker buildx build --builder hydroflow-multiplatform --cache-to type=inline --platform linux/arm64,linux/amd64 -t hydro-project/hydroflow .
+docker buildx build --builder hydroflow-multiplatform --cache-to type=inline --platform linux/arm64,linux/amd64 -t ${IMAGE_NAME} --push .

--- a/scripts/multiplatform-docker-build.sh
+++ b/scripts/multiplatform-docker-build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker buildx create --use --name hydroflow-multiplatform --node hydroflow-multiplatform
+
+docker buildx build --builder hydroflow-multiplatform --cache-to type=inline --platform linux/arm64,linux/amd64 -t hydro-project/hydroflow .


### PR DESCRIPTION
This diff implements a script for building Hydroflow's examples for multiple platforms. At the moment, it supports macOS and Linux running on arm64 and x86_64 architectures. 

Subsequent diffs will incorporate this script into the repo's CI process. 