### PR TITLE
Allow the chat example to bind and connect to DNS names

### DIFF
--- a/hydroflow/examples/chat/client.rs
+++ b/hydroflow/examples/chat/client.rs
@@ -1,15 +1,15 @@
 use chrono::prelude::*;
 use colored::Colorize;
 
-use crate::helpers::{deserialize_msg, is_chat_msg, is_connect_resp, serialize_msg};
+use crate::helpers::{deserialize_msg, is_chat_msg, is_connect_resp, resolve_ipv4_connection_addr, serialize_msg};
 use crate::protocol::Message;
 use crate::{GraphType, Opts};
 use chrono::Utc;
 use hydroflow::hydroflow_syntax;
-use std::net::SocketAddr;
 use tokio::io::AsyncBufReadExt;
 use tokio::net::UdpSocket;
 use tokio_stream::wrappers::LinesStream;
+
 
 pub(crate) async fn run_client(opts: Opts) {
     // set up network and I/O channels
@@ -20,12 +20,17 @@ pub(crate) async fn run_client(opts: Opts) {
         .server_port
         .expect("Clients must specify --server-port");
 
-    let server_addr: SocketAddr = format!("{}:{}", server_ip, server_port).parse().unwrap();
+    let server_addr = resolve_ipv4_connection_addr(server_ip, server_port).expect("Unable to resolve server address");
+    println!("Attempting to connect to server at {}", server_addr);
 
-    let client_socket = UdpSocket::bind(format!("{}:{}", opts.addr, opts.port))
+    let client_addr = resolve_ipv4_connection_addr(opts.addr, opts.port).expect("Unable to resolve client address");
+
+    let client_socket = UdpSocket::bind(client_addr)
         .await
         .unwrap();
-    let client_addr = client_socket.local_addr().unwrap();
+
+    println!("Client is bound to {}", client_addr);
+
     let (outbound, inbound) = hydroflow::util::udp_lines(client_socket);
 
     let reader = tokio::io::BufReader::new(tokio::io::stdin());

--- a/hydroflow/examples/chat/client.rs
+++ b/hydroflow/examples/chat/client.rs
@@ -1,7 +1,9 @@
 use chrono::prelude::*;
 use colored::Colorize;
 
-use crate::helpers::{deserialize_msg, is_chat_msg, is_connect_resp, resolve_ipv4_connection_addr, serialize_msg};
+use crate::helpers::{
+    deserialize_msg, is_chat_msg, is_connect_resp, resolve_ipv4_connection_addr, serialize_msg,
+};
 use crate::protocol::Message;
 use crate::{GraphType, Opts};
 use chrono::Utc;
@@ -9,7 +11,6 @@ use hydroflow::hydroflow_syntax;
 use tokio::io::AsyncBufReadExt;
 use tokio::net::UdpSocket;
 use tokio_stream::wrappers::LinesStream;
-
 
 pub(crate) async fn run_client(opts: Opts) {
     // set up network and I/O channels
@@ -20,14 +21,14 @@ pub(crate) async fn run_client(opts: Opts) {
         .server_port
         .expect("Clients must specify --server-port");
 
-    let server_addr = resolve_ipv4_connection_addr(server_ip, server_port).expect("Unable to resolve server address");
+    let server_addr = resolve_ipv4_connection_addr(server_ip, server_port)
+        .expect("Unable to resolve server address");
     println!("Attempting to connect to server at {}", server_addr);
 
-    let client_addr = resolve_ipv4_connection_addr(opts.addr, opts.port).expect("Unable to resolve client address");
+    let client_addr = resolve_ipv4_connection_addr(opts.addr, opts.port)
+        .expect("Unable to resolve client address");
 
-    let client_socket = UdpSocket::bind(client_addr)
-        .await
-        .unwrap();
+    let client_socket = UdpSocket::bind(client_addr).await.unwrap();
 
     println!("Client is bound to {}", client_addr);
 

--- a/hydroflow/examples/chat/helpers.rs
+++ b/hydroflow/examples/chat/helpers.rs
@@ -54,7 +54,7 @@ pub fn connect_get_addr(m: Message) -> Option<SocketAddr> {
 }
 
 pub fn resolve_ipv4_connection_addr(server_ip: String, server_port: u16) -> Option<SocketAddr> {
-    let addrs = format!("{}:{}", server_ip, server_port)
+    let mut addrs = format!("{}:{}", server_ip, server_port)
         .to_socket_addrs()
         .unwrap();
 

--- a/hydroflow/examples/chat/helpers.rs
+++ b/hydroflow/examples/chat/helpers.rs
@@ -1,7 +1,7 @@
 use crate::protocol::Message;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::net::{ToSocketAddrs, SocketAddr};
+use std::net::{SocketAddr, ToSocketAddrs};
 use tokio_util::codec::LinesCodecError;
 
 pub fn serialize_msg<T>(msg: T) -> String
@@ -54,7 +54,9 @@ pub fn connect_get_addr(m: Message) -> Option<SocketAddr> {
 }
 
 pub fn resolve_ipv4_connection_addr(server_ip: String, server_port: u16) -> Option<SocketAddr> {
-    let addrs = format!("{}:{}", server_ip, server_port).to_socket_addrs().unwrap();
+    let addrs = format!("{}:{}", server_ip, server_port)
+        .to_socket_addrs()
+        .unwrap();
 
     for addr in addrs {
         if addr.is_ipv4() {

--- a/hydroflow/examples/chat/helpers.rs
+++ b/hydroflow/examples/chat/helpers.rs
@@ -1,7 +1,7 @@
 use crate::protocol::Message;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::net::SocketAddr;
+use std::net::{ToSocketAddrs, SocketAddr};
 use tokio_util::codec::LinesCodecError;
 
 pub fn serialize_msg<T>(msg: T) -> String
@@ -51,4 +51,16 @@ pub fn connect_get_addr(m: Message) -> Option<SocketAddr> {
         Message::ConnectRequest { nickname: _, addr } => Some(addr),
         _ => None,
     }
+}
+
+pub fn resolve_ipv4_connection_addr(server_ip: String, server_port: u16) -> Option<SocketAddr> {
+    let addrs = format!("{}:{}", server_ip, server_port).to_socket_addrs().unwrap();
+
+    for addr in addrs {
+        if addr.is_ipv4() {
+            return Some(addr);
+        }
+    }
+
+    return None;
 }

--- a/hydroflow/examples/chat/helpers.rs
+++ b/hydroflow/examples/chat/helpers.rs
@@ -58,11 +58,5 @@ pub fn resolve_ipv4_connection_addr(server_ip: String, server_port: u16) -> Opti
         .to_socket_addrs()
         .unwrap();
 
-    for addr in addrs {
-        if addr.is_ipv4() {
-            return Some(addr);
-        }
-    }
-
-    return None;
+    return addrs.find(|addr| addr.is_ipv4());
 }

--- a/hydroflow/examples/chat/helpers.rs
+++ b/hydroflow/examples/chat/helpers.rs
@@ -58,5 +58,5 @@ pub fn resolve_ipv4_connection_addr(server_ip: String, server_port: u16) -> Opti
         .to_socket_addrs()
         .unwrap();
 
-    return addrs.find(|addr| addr.is_ipv4());
+    addrs.find(|addr| addr.is_ipv4())
 }

--- a/hydroflow/examples/chat/server.rs
+++ b/hydroflow/examples/chat/server.rs
@@ -13,7 +13,8 @@ use tokio::net::UdpSocket;
 pub(crate) async fn run_server(opts: Opts) {
     // First, set up the socket
 
-    let server_addr = resolve_ipv4_connection_addr(opts.addr, opts.port).expect("Unable to bind to provided IP and port");
+    let server_addr = resolve_ipv4_connection_addr(opts.addr, opts.port)
+        .expect("Unable to bind to provided IP and port");
     let server_socket = UdpSocket::bind(server_addr).await.unwrap();
     let (outbound, inbound) = hydroflow::util::udp_lines(server_socket);
     println!("Listening on {}", server_addr);

--- a/hydroflow/examples/chat/server.rs
+++ b/hydroflow/examples/chat/server.rs
@@ -1,7 +1,8 @@
 use crate::{GraphType, Opts};
 
 use crate::helpers::{
-    connect_get_addr, deserialize_msg, is_chat_msg, is_connect_req, serialize_msg,
+    connect_get_addr, deserialize_msg, is_chat_msg, is_connect_req, resolve_ipv4_connection_addr,
+    serialize_msg,
 };
 use crate::protocol::Message;
 
@@ -12,8 +13,10 @@ use tokio::net::UdpSocket;
 pub(crate) async fn run_server(opts: Opts) {
     // First, set up the socket
 
-    let server_socket = UdpSocket::bind((opts.addr, opts.port)).await.unwrap();
+    let server_addr = resolve_ipv4_connection_addr(opts.addr, opts.port).expect("Unable to bind to provided IP and port");
+    let server_socket = UdpSocket::bind(server_addr).await.unwrap();
     let (outbound, inbound) = hydroflow::util::udp_lines(server_socket);
+    println!("Listening on {}", server_addr);
     println!("Server live!");
 
     let mut df: Hydroflow = hydroflow_syntax! {


### PR DESCRIPTION
In many circumstances when testing chat in a distributed setting, we won't know the right IP address to either bind or connect to in advance. This diff allows the chat client and server to bind to DNS names, which (coupled with the distributed runtime's service discovery mechanism) should make it easier for clients and servers to find each other.