### PR TITLE
Limit `null()` to up to one input and/or output.

### DIFF
--- a/hydroflow/tests/compile-fail/surface_degenerate_null.rs
+++ b/hydroflow/tests/compile-fail/surface_degenerate_null.rs
@@ -1,6 +1,6 @@
 use hydroflow::hydroflow_syntax;
 
-/// I suppose technically this should/could compile, but it is a completely useless edge case.
+/// Technically this should/could compile, but it is a completely useless edge case.
 fn main() {
     let mut df = hydroflow_syntax! {
         null();

--- a/hydroflow_lang/src/graph/ops/null.rs
+++ b/hydroflow_lang/src/graph/ops/null.rs
@@ -1,10 +1,8 @@
-use super::{
-    OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs, RANGE_ANY,
-};
+use super::{OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs};
 
 use quote::quote_spanned;
 
-/// > unbounded number of input streams of any types, unbounded number of output streams of type `()`
+/// > unbounded number of input streams of any type, unbounded number of output streams of any type.
 ///
 /// As a source, generates nothing. As a sink, absorbs anything with no effect.
 ///
@@ -21,10 +19,10 @@ use quote::quote_spanned;
 #[hydroflow_internalmacro::operator_docgen]
 pub const NULL: OperatorConstraints = OperatorConstraints {
     name: "null",
-    hard_range_inn: RANGE_ANY,
-    soft_range_inn: RANGE_ANY,
-    hard_range_out: RANGE_ANY,
-    soft_range_out: RANGE_ANY,
+    hard_range_inn: &(0..=1),
+    soft_range_inn: &(0..=1),
+    hard_range_out: &(0..=1),
+    soft_range_out: &(0..=1),
     ports_inn: None,
     ports_out: None,
     num_args: 0,


### PR DESCRIPTION
In principle `null()` should be able to handle any combination of inputs and outputs, but in reality this makes it a huge edge case and causes lots of problems.... For now it is easier to limit null to [0,1] inputs and outputs (3 non-degenerate combos).

* Fixes #243
* Fixes #244