### PR TITLE
CI workflow for multiplatform example container builds

### DIFF
--- a/.github/workflows/examples-container.yml
+++ b/.github/workflows/examples-container.yml
@@ -1,9 +1,12 @@
 ---
 name: examples-container-build
 
-on:
-  push:
-    branches: [main]
+on: push
+
+# FIXME: replace on: block with this after it works on a branch
+# on:
+#   push:
+#     branches: [main]
 
 jobs:
   buildx:

--- a/.github/workflows/examples-container.yml
+++ b/.github/workflows/examples-container.yml
@@ -1,12 +1,9 @@
 ---
 name: examples-container-build
 
-on: push
-
-# FIXME: replace on: block with this after it works on a branch
-# on:
-#   push:
-#     branches: [main]
+on:
+  push:
+    branches: [main]
 
 jobs:
   buildx:

--- a/.github/workflows/examples-container.yml
+++ b/.github/workflows/examples-container.yml
@@ -37,5 +37,5 @@ jobs:
           secrets: |
             GIT_AUTH_TOKEN=${{ github.token }}
           tags: |
-            ${{ github.repository_owner }}/hydroflow-examples:${{ github.sha }}
-            ${{ github.repository_owner }}/hydroflow-examples:latest
+            ghcr.io/${{ github.repository_owner }}/hydroflow-examples:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/hydroflow-examples:latest

--- a/.github/workflows/examples-container.yml
+++ b/.github/workflows/examples-container.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - id: buildx
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -34,4 +36,6 @@ jobs:
           push: true
           secrets: |
             GIT_AUTH_TOKEN=${{ github.token }}
-          tags: ${{ github.repository_owner }}/hydroflow-examples:${{ github.sha }},${{ github.repository_owner }}/hydroflow-examples:latest
+          tags: |
+            ${{ github.repository_owner }}/hydroflow-examples:${{ github.sha }}
+            ${{ github.repository_owner }}/hydroflow-examples:latest

--- a/.github/workflows/examples-container.yml
+++ b/.github/workflows/examples-container.yml
@@ -1,0 +1,37 @@
+---
+name: examples-container-build
+
+on: push
+
+# FIXME: replace on: block with this after it works on a branch
+# on:
+#   push:
+#     branches: [main]
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - id: buildx
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          platforms: linux/amd64, linux/arm64
+          push: true
+          secrets: |
+            GIT_AUTH_TOKEN=${{ github.token }}
+          tags: ${{ github.repository_owner }}/hydroflow-examples:${{ github.sha }},${{ github.repository_owner }}/hydroflow-examples:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,6 @@ RUN /bin/bash -c "if [ "${TARGETARCH}" == "arm64" ]; then apt-get install -y gcc
 WORKDIR /usr/src/myapp
 COPY . .
 
-# Workaround to an issue similar to the one encountered by pytorch in
-# https://github.com/pytorch/pytorch/issues/82174
-ENV CARGO_NET_GIT_FETCH_WITH_CLI true
 RUN --mount=type=cache,target=/usr/src/myapp/target \
     --mount=type=cache,target=/usr/local/cargo/registry \
     ./scripts/build_dist_release.sh ${TARGETOS} ${TARGETARCH}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=$BUILDPLATFORM rust:slim-buster AS build
 
 ARG TARGETOS TARGETARCH
 
-RUN apt-get update && apt-get install git
+RUN apt-get update && apt-get install -y git
 
 RUN /bin/bash -c "if [ "${TARGETARCH}" == "arm64" ]; then apt-get install -y gcc-aarch64-linux-gnu ; else apt-get install -y gcc-x86-64-linux-gnu ; fi"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=$BUILDPLATFORM rust:slim-buster AS build
 
 ARG TARGETOS TARGETARCH
 
-RUN apt-get update
+RUN apt-get update && apt-get install git
 
 RUN /bin/bash -c "if [ "${TARGETARCH}" == "arm64" ]; then apt-get install -y gcc-aarch64-linux-gnu ; else apt-get install -y gcc-x86-64-linux-gnu ; fi"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN ls -dR target/*/release/examples/* | grep -vE '^.*/[a-z_]+\-.*$' | grep -vE 
 RUN mkdir -p xfer/example_utils && cp hydroflow/example_utils/* xfer/example_utils/.
 
 # Runtime stage
-FROM rust:slim
+FROM rust:slim-buster
 
 RUN apt-get update && apt-get install -y python3
 WORKDIR /usr/src/myapp

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN /bin/bash -c "if [ "${TARGETARCH}" == "arm64" ]; then apt-get install -y gcc
 WORKDIR /usr/src/myapp
 COPY . .
 
+# Workaround to an issue similar to the one encountered by pytorch in
+# https://github.com/pytorch/pytorch/issues/82174
+ENV CARGO_NET_GIT_FETCH_WITH_CLI true
 RUN --mount=type=cache,target=/usr/src/myapp/target \
     --mount=type=cache,target=/usr/local/cargo/registry \
     ./scripts/build_dist_release.sh ${TARGETOS} ${TARGETARCH}

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,5 @@ FROM rust:slim-buster
 
 RUN apt-get update && apt-get install -y python3
 WORKDIR /usr/src/myapp
-COPY --from=build /usr/src/myapp/xfer/examples/* .
 RUN mkdir -p example_utils
-COPY --from=build /usr/src/myapp/xfer/example_utils/* ./example_utils/.
+COPY --from=build /usr/src/myapp/xfer/examples/* /usr/src/myapp/xfer/example_utils .

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ RUN /bin/bash -c "if [ "${TARGETARCH}" == "arm64" ]; then apt-get install -y gcc
 WORKDIR /usr/src/myapp
 COPY . .
 
-RUN ./scripts/build_dist_release.sh ${TARGETOS} ${TARGETARCH}
+RUN --mount=type=cache,target=/usr/src/myapp/target \
+    --mount=type=cache,target=/usr/local/cargo/registry \
+    ./scripts/build_dist_release.sh ${TARGETOS} ${TARGETARCH}
 
 RUN mkdir -p xfer/examples
 RUN ls -dR target/*/release/examples/* | grep -vE '^.*/[a-z_]+\-.*$' | grep -vE '^.*\.d$' | xargs -I{} cp {} xfer/examples/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ RUN /bin/bash -c "if [ "${TARGETARCH}" == "arm64" ]; then apt-get install -y gcc
 WORKDIR /usr/src/myapp
 COPY . .
 
-RUN --mount=type=cache,target=/usr/src/myapp/target \
-    --mount=type=cache,target=/usr/local/cargo/registry \
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
     ./scripts/build_dist_release.sh ${TARGETOS} ${TARGETARCH}
 
 RUN mkdir -p xfer/examples
@@ -23,5 +22,6 @@ FROM rust:slim-buster
 
 RUN apt-get update && apt-get install -y python3
 WORKDIR /usr/src/myapp
+COPY --from=build /usr/src/myapp/xfer/examples/* .
 RUN mkdir -p example_utils
-COPY --from=build /usr/src/myapp/xfer/examples/* /usr/src/myapp/xfer/example_utils .
+COPY --from=build /usr/src/myapp/xfer/example_utils/* ./example_utils/.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ See the [setup section of the book](https://hydro-project.github.io/hydroflow/bo
 
 To make running Hydroflow's examples in the cloud easier, we've created a Docker image that contains compiled versions of those examples. The image is defined in the `Dockerfile` in the same directory as this README.
 
+If you want to build the examples container locally, you can run
+
+```
+docker build -t hydroflow-examples .
+```
+
+This will build an image suitable for your architecture.
+
 The `scripts/multiplatform-docker-build.sh <image name>` script will build both `arm64` and `amd64` versions of the image and push them to the image name specified. By default, this will push the image to DockerHub; if you want to push the image to another repository, you can pass an image URL as the argument to `multiplatform-docker-build.sh` instead.
 
 Example binaries are located in `/usr/src/myapp`.

--- a/scripts/build_dist_release.sh
+++ b/scripts/build_dist_release.sh
@@ -49,4 +49,7 @@ then
   export RUSTFLAGS="-C linker=${RUST_TARGET_ARCH}-linux-gnu-gcc"
 fi
 
-cargo build --release --all-targets --target ${RUST_TARGET}
+# The CARGO_NET_GIT_FETCH_WITH_CLI="true" environment variable is a Workaround to an issue similar
+# to the one encountered by pytorch in https://github.com/pytorch/pytorch/issues/82174
+
+CARGO_NET_GIT_FETCH_WITH_CLI="true" cargo build --release --all-targets --target ${RUST_TARGET}


### PR DESCRIPTION
This diff introduces a CI process that builds multi-platform example containers on every commit to `main`.