### PR TITLE
explicit serde example, resolve #214

### DIFF
--- a/book/example_8_chat_server.md
+++ b/book/example_8_chat_server.md
@@ -14,7 +14,7 @@ The `main.rs` file here is very similar to that of the echo server, just with tw
 use clap::{ArgEnum, Parser};
 use client::run_client;
 use hydroflow::tokio;
-use hydroflow::util::{bind_udp_socket, ipv4_resolve};
+use hydroflow::util::{bind_udp_bytes, ipv4_resolve};
 use server::run_server;
 
 mod client;
@@ -76,7 +76,7 @@ async fn main() {
         }
         Role::Server => {
             println!("Listening on {}", server_str.clone());
-            let (outbound, inbound) = bind_udp_socket(server_str).await;
+            let (outbound, inbound) = bind_udp_bytes(server_str).await;
 
             run_server(outbound, inbound, opts.graph.clone()).await;
         }

--- a/hydroflow/Cargo.toml
+++ b/hydroflow/Cargo.toml
@@ -12,6 +12,9 @@ macros = [ "hydroflow_macro", "hydroflow_datalog" ]
 name = "echoserver"
 
 [[example]]
+name = "echo_serde_json"
+
+[[example]]
 name = "chat"
 
 [[example]]

--- a/hydroflow/examples/chat/main.rs
+++ b/hydroflow/examples/chat/main.rs
@@ -1,7 +1,7 @@
 use clap::{ArgEnum, Parser};
 use client::run_client;
 use hydroflow::tokio;
-use hydroflow::util::{bind_udp_socket, ipv4_resolve};
+use hydroflow::util::{bind_udp_bytes, ipv4_resolve};
 use server::run_server;
 
 mod client;
@@ -47,7 +47,8 @@ async fn main() {
                 client_str.clone(),
                 server_str.clone()
             );
-            let (outbound, inbound) = bind_udp_socket(client_str).await;
+            let client_addr = ipv4_resolve(client_str);
+            let (outbound, inbound) = bind_udp_bytes(client_addr).await;
             run_client(
                 outbound,
                 inbound,
@@ -59,7 +60,8 @@ async fn main() {
         }
         Role::Server => {
             println!("Listening on {}", server_str.clone());
-            let (outbound, inbound) = bind_udp_socket(server_str).await;
+            let server_addr = ipv4_resolve(server_str);
+            let (outbound, inbound) = bind_udp_bytes(server_addr).await;
 
             run_server(outbound, inbound, opts.graph.clone()).await;
         }

--- a/hydroflow/examples/echo_serde_json/README.md
+++ b/hydroflow/examples/echo_serde_json/README.md
@@ -1,0 +1,22 @@
+An example of explicit serialization and deserialization of data, in this case using a JSON encoder.
+
+Ordinarily it's simple and efficient to use `source_stream_serde` and `dest_sink_serde` for network I/O in Hydroflow programs. They automatically serialize and deserialize data on its way in and out of a UDP port. This example shows how to do the serialization and deserialization explicitly using a JSON encoder. This can be useful for debugging, or as a template for cases where you want to use a different serialization format.
+
+Note that in `main.rs` we use `udp_lines` in place of the usual `udp_bytes` that we use with `source_stream_serde` and `dest_sink_serde`. This is because `udp_lines` uses the `use tokio_util::codec::LinesCodec`, which is the right 
+codec for the JSON encoder. More details can be seen in `hydroflow/src/util/mod.rs`.
+
+To run the example, open 2 terminals.
+
+In one terminal run the server like so:
+```
+cargo run -p hydroflow --example echo_serde_json -- --role "server" --server-addr localhost:12347
+```
+
+In another terminal run a client:
+```
+cargo run -p hydroflow --example echo_serde_json -- --role client --client-addr localhost:9090 --server-addr localhost:12347
+```
+
+If you type in the client terminal the message will be sent to the server, echo'd back to the client and printed with a checksum and server timestamp.
+
+Adding the `--graph <graph_type>` flag to the end of the command lines above will print out a node-and-edge diagram of the program. Supported values for `<graph_type>` include [mermaid](https://mermaid-js.github.io/) and [dot](https://graphviz.org/doc/info/lang.html).

--- a/hydroflow/examples/echo_serde_json/client.rs
+++ b/hydroflow/examples/echo_serde_json/client.rs
@@ -1,0 +1,28 @@
+use crate::helpers::{deserialize_json, serialize_json};
+use crate::protocol::EchoMsg;
+use chrono::prelude::*;
+use hydroflow::hydroflow_syntax;
+use hydroflow::util::{UdpLinesSink, UdpLinesStream};
+use std::net::SocketAddr;
+
+pub(crate) async fn run_client(
+    outbound: UdpLinesSink,
+    inbound: UdpLinesStream,
+    server_addr: SocketAddr,
+) {
+    println!("Attempting to connect to server at {:?}", server_addr);
+    println!("Client live!");
+
+    let mut flow = hydroflow_syntax! {
+        // take stdin and send to server as an Echo::Message
+        source_stdin() -> map(|l| (EchoMsg{ payload: l.unwrap(), ts: Utc::now(), }, server_addr) )
+            -> map(|(msg, addr)| (serialize_json(msg), addr))
+            -> dest_sink(outbound);
+
+        // receive and print messages
+        source_stream(inbound) -> map(deserialize_json)
+            -> for_each(|(m, _a): (EchoMsg, SocketAddr) | println!("{:?}", m));
+    };
+
+    flow.run_async().await.unwrap();
+}

--- a/hydroflow/examples/echo_serde_json/helpers.rs
+++ b/hydroflow/examples/echo_serde_json/helpers.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::net::SocketAddr;
+use tokio_util::codec::LinesCodecError;
+
+pub fn serialize_json<T>(msg: T) -> String
+where
+    T: Serialize + for<'a> Deserialize<'a> + Clone,
+{
+    json!(msg).to_string()
+}
+
+pub fn deserialize_json<T>(msg: Result<(String, SocketAddr), LinesCodecError>) -> (T, SocketAddr)
+where
+    T: Serialize + for<'a> Deserialize<'a> + Clone,
+{
+    let (m, a) = msg.unwrap();
+    (serde_json::from_str(&(m)).unwrap(), a)
+}

--- a/hydroflow/examples/echo_serde_json/main.rs
+++ b/hydroflow/examples/echo_serde_json/main.rs
@@ -1,10 +1,11 @@
 use clap::{ArgEnum, Parser};
 use client::run_client;
 use hydroflow::tokio;
-use hydroflow::util::{bind_udp_bytes, ipv4_resolve};
+use hydroflow::util::{bind_udp_lines, ipv4_resolve};
 use server::run_server;
 
 mod client;
+mod helpers;
 mod protocol;
 mod server;
 
@@ -34,14 +35,14 @@ async fn main() {
     match opts.role {
         Role::Server => {
             // allocate `outbound` and `inbound` sockets
-            let (outbound, inbound) = bind_udp_bytes(server_addr).await;
+            let (outbound, inbound) = bind_udp_lines(server_addr).await;
             run_server(outbound, inbound).await;
         }
         Role::Client => {
             // resolve the server's IP address
             let client_addr = ipv4_resolve(opts.client_addr.clone().unwrap());
             // allocate `outbound` and `inbound` sockets
-            let (outbound, inbound) = bind_udp_bytes(client_addr).await;
+            let (outbound, inbound) = bind_udp_lines(client_addr).await;
             // run the client
             run_client(outbound, inbound, server_addr).await;
         }

--- a/hydroflow/examples/echo_serde_json/protocol.rs
+++ b/hydroflow/examples/echo_serde_json/protocol.rs
@@ -1,0 +1,8 @@
+use chrono::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(PartialEq, Clone, Serialize, Deserialize, Debug)]
+pub struct EchoMsg {
+    pub payload: String,
+    pub ts: DateTime<Utc>,
+}

--- a/hydroflow/examples/echo_serde_json/server.rs
+++ b/hydroflow/examples/echo_serde_json/server.rs
@@ -1,0 +1,25 @@
+use crate::helpers::{deserialize_json, serialize_json};
+use crate::protocol::EchoMsg;
+use chrono::prelude::*;
+use hydroflow::hydroflow_syntax;
+use hydroflow::scheduled::graph::Hydroflow;
+use hydroflow::util::{UdpLinesSink, UdpLinesStream};
+use std::net::SocketAddr;
+
+pub(crate) async fn run_server(outbound: UdpLinesSink, inbound: UdpLinesStream) {
+    println!("Server live!");
+
+    let mut flow: Hydroflow = hydroflow_syntax! {
+        // Inbound channel sharing
+        inbound_chan = source_stream(inbound) -> map(deserialize_json) -> tee();
+
+        // Logic
+        inbound_chan[0] -> for_each(|(m, a): (EchoMsg, SocketAddr)| println!("Got {:?} from {:?}", m, a));
+        inbound_chan[1] -> map(|(EchoMsg { payload, .. }, addr)| (EchoMsg { payload, ts: Utc::now() }, addr))
+            -> map(|(m, a)| (serialize_json(m), a))
+            -> dest_sink(outbound);
+    };
+
+    // run the server
+    flow.run_async().await;
+}

--- a/hydroflow/examples/kvs/main.rs
+++ b/hydroflow/examples/kvs/main.rs
@@ -1,7 +1,7 @@
 use clap::{ArgEnum, Parser};
 use client::run_client;
 use hydroflow::tokio;
-use hydroflow::util::{bind_udp_socket, ipv4_resolve};
+use hydroflow::util::{bind_udp_bytes, ipv4_resolve};
 use server::run_server;
 
 mod client;
@@ -36,10 +36,11 @@ struct Opts {
 #[tokio::main]
 async fn main() {
     let opts = Opts::parse();
+    let addr = ipv4_resolve(opts.addr.clone());
 
     match opts.role {
         Role::Client => {
-            let (outbound, inbound) = bind_udp_socket(opts.addr.clone()).await;
+            let (outbound, inbound) = bind_udp_bytes(addr).await;
             println!("Client is bound to {}", opts.addr.clone());
             println!(
                 "Attempting to connect to server at {}",
@@ -49,7 +50,7 @@ async fn main() {
             run_client(outbound, inbound, server_addr, opts.graph.clone()).await;
         }
         Role::Server => {
-            let (outbound, inbound) = bind_udp_socket(opts.addr.clone()).await;
+            let (outbound, inbound) = bind_udp_bytes(addr).await;
             println!("Listening on {}", opts.addr.clone());
             run_server(outbound, inbound, opts.graph.clone()).await;
         }

--- a/hydroflow/src/util/mod.rs
+++ b/hydroflow/src/util/mod.rs
@@ -22,6 +22,8 @@ pub type UdpFramedSink<Codec, Item> = SplitSink<UdpFramed<Codec>, (Item, SocketA
 pub type UdpFramedStream<Codec> = SplitStream<UdpFramed<Codec>>;
 pub type UdpSink = UdpFramedSink<LengthDelimitedCodec, Bytes>;
 pub type UdpStream = UdpFramedStream<LengthDelimitedCodec>;
+pub type UdpLinesSink = UdpFramedSink<LinesCodec, String>;
+pub type UdpLinesStream = UdpFramedStream<LinesCodec>;
 
 pub fn unbounded_channel<T>() -> (
     tokio::sync::mpsc::UnboundedSender<T>,
@@ -134,16 +136,12 @@ pub fn ipv4_resolve(addr: String) -> SocketAddr {
         .expect("Unable to resolve connection address")
 }
 
-pub async fn bind_udp_socket_addr(addr: SocketAddr) -> (UdpSink, UdpStream) {
+pub async fn bind_udp_bytes(addr: SocketAddr) -> (UdpSink, UdpStream) {
     let socket = tokio::net::UdpSocket::bind(addr).await.unwrap();
     udp_bytes(socket)
 }
 
-pub async fn bind_udp_socket(addr_string: String) -> (UdpSink, UdpStream) {
-    let addr = ipv4_resolve(addr_string);
-    bind_udp_socket_addr(addr).await
-}
-
-pub async fn bind_local_udp_socket(port: u16) -> (UdpSink, UdpStream) {
-    bind_udp_socket(format!("127.0.0.1:{}", port)).await
+pub async fn bind_udp_lines(addr: SocketAddr) -> (UdpLinesSink, UdpLinesStream) {
+    let socket = tokio::net::UdpSocket::bind(addr).await.unwrap();
+    udp_lines(socket)
 }

--- a/hydroflow_lang/src/graph/ops/dest_sink_serde.rs
+++ b/hydroflow_lang/src/graph/ops/dest_sink_serde.rs
@@ -11,7 +11,8 @@ use quote::quote_spanned;
 /// Note this operator must be used within a Tokio runtime.
 /// ```rustbook
 /// async fn serde_out() {
-///     let (outbound, inbound) = hydroflow::util::bind_udp_socket("localhost:9000".into()).await;
+///     let addr = hydroflow::util::ipv4_resolve("localhost:9000".into());
+///     let (outbound, inbound) = hydroflow::util::bind_udp_bytes(addr).await;
 ///     let remote = hydroflow::util::ipv4_resolve("localhost:9001".into());
 ///     let mut flow = hydroflow::hydroflow_syntax! {
 ///         source_iter(vec![("hello".to_string(), 1), ("world".to_string(), 2)])

--- a/hydroflow_lang/src/graph/ops/source_stream_serde.rs
+++ b/hydroflow_lang/src/graph/ops/source_stream_serde.rs
@@ -14,7 +14,8 @@ use quote::quote_spanned;
 ///
 /// ```rustbook
 /// async fn serde_in() {
-///     let (outbound, inbound) = hydroflow::util::bind_udp_socket("localhost:9000".into()).await;
+///     let addr = hydroflow::util::ipv4_resolve("localhost:9000".into());
+///     let (outbound, inbound) = hydroflow::util::bind_udp_bytes(addr).await;
 ///     let mut flow = hydroflow::hydroflow_syntax! {
 ///         source_stream_serde(inbound) -> map(|(x, a): (String, std::net::SocketAddr)| x.to_uppercase())
 ///             -> for_each(|x| println!("{}", x));


### PR DESCRIPTION
resolve #214. Since the time that issue was opened, the default is to use `udp_bytes` and a `bincode` encoder. So we switch to providing an explicit example, `echo_serde_json` that uses `udp_lines` and a JSON encoder. 