### PR TITLE
Add surface versions of existing micro benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "lazy_static",
  "rand 0.8.5",
  "seq-macro",
+ "static_assertions",
  "timely",
  "tokio",
 ]

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -17,6 +17,7 @@ seq-macro = "0.2"
 timely = "*"
 differential-dataflow = "*"
 tokio = { version = "1.0", features = [ "rt-multi-thread" ] }
+static_assertions = "1.1.0"
 
 [[bench]]
 name = "arithmetic"

--- a/benches/benches/arithmetic.rs
+++ b/benches/benches/arithmetic.rs
@@ -1,4 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use hydroflow::hydroflow_syntax;
 use std::sync::mpsc::channel;
 use std::thread;
 use timely::dataflow::operators::{Inspect, Map, ToStream};
@@ -127,6 +128,86 @@ fn benchmark_hydroflow_compiled(c: &mut Criterion) {
     });
 }
 
+fn benchmark_hydroflow_compiled_no_cheating(c: &mut Criterion) {
+    use hydroflow::pusherator::{InputBuild, Pusherator, PusheratorBuild};
+
+    c.bench_function("arithmetic/hydroflow/compiled_no_cheating", |b| {
+        b.iter(|| {
+            let mut pusherator = InputBuild::<usize>::new()
+                .map(|x| black_box(x + 1))
+                .map(|x| black_box(x + 1))
+                .map(|x| black_box(x + 1))
+                .map(|x| black_box(x + 1))
+                .map(|x| black_box(x + 1))
+                .map(|x| black_box(x + 1))
+                .map(|x| black_box(x + 1))
+                .map(|x| black_box(x + 1))
+                .map(|x| black_box(x + 1))
+                .map(|x| black_box(x + 1))
+                .map(|x| black_box(x + 1))
+                .map(|x| black_box(x + 1))
+                .map(|x| black_box(x + 1))
+                .map(|x| black_box(x + 1))
+                .map(|x| black_box(x + 1))
+                .map(|x| black_box(x + 1))
+                .map(|x| black_box(x + 1))
+                .map(|x| black_box(x + 1))
+                .map(|x| black_box(x + 1))
+                .map(|x| black_box(x + 1))
+                .for_each(|x| {
+                    black_box(x);
+                });
+
+            for i in black_box(0..NUM_INTS) {
+                pusherator.give(i);
+            }
+        });
+    });
+}
+
+fn benchmark_hydroflow_surface(c: &mut Criterion) {
+    assert!(NUM_OPS == 20); // This benchmark is hardcoded for 20 ops, so assert that NUM_OPS is 20.
+    c.bench_function("arithmetic/hydroflow/surface", |b| {
+        b.iter_batched(
+            || {
+                hydroflow_syntax! {
+                    source_iter(black_box(0..NUM_INTS))
+
+                    -> map(|x| black_box(x + 1))
+                    -> map(|x| black_box(x + 1))
+                    -> map(|x| black_box(x + 1))
+                    -> map(|x| black_box(x + 1))
+                    -> map(|x| black_box(x + 1))
+
+                    -> map(|x| black_box(x + 1))
+                    -> map(|x| black_box(x + 1))
+                    -> map(|x| black_box(x + 1))
+                    -> map(|x| black_box(x + 1))
+                    -> map(|x| black_box(x + 1))
+
+                    -> map(|x| black_box(x + 1))
+                    -> map(|x| black_box(x + 1))
+                    -> map(|x| black_box(x + 1))
+                    -> map(|x| black_box(x + 1))
+                    -> map(|x| black_box(x + 1))
+
+                    -> map(|x| black_box(x + 1))
+                    -> map(|x| black_box(x + 1))
+                    -> map(|x| black_box(x + 1))
+                    -> map(|x| black_box(x + 1))
+                    -> map(|x| black_box(x + 1))
+
+                    -> for_each(|x| { black_box(x); });
+                }
+            },
+            |mut df| {
+                df.run_available();
+            },
+            criterion::BatchSize::SmallInput,
+        )
+    });
+}
+
 fn benchmark_timely(c: &mut Criterion) {
     c.bench_function("arithmetic/timely", |b| {
         b.iter(|| {
@@ -152,5 +233,7 @@ criterion_group!(
     benchmark_iter_collect,
     benchmark_raw_copy,
     benchmark_hydroflow_compiled,
+    benchmark_hydroflow_compiled_no_cheating,
+    benchmark_hydroflow_surface,
 );
 criterion_main!(identity_dataflow);

--- a/benches/benches/arithmetic.rs
+++ b/benches/benches/arithmetic.rs
@@ -1,5 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use hydroflow::hydroflow_syntax;
+use static_assertions::const_assert;
 use std::sync::mpsc::channel;
 use std::thread;
 use timely::dataflow::operators::{Inspect, Map, ToStream};
@@ -166,7 +167,7 @@ fn benchmark_hydroflow_compiled_no_cheating(c: &mut Criterion) {
 }
 
 fn benchmark_hydroflow_surface(c: &mut Criterion) {
-    assert!(NUM_OPS == 20); // This benchmark is hardcoded for 20 ops, so assert that NUM_OPS is 20.
+    const_assert!(NUM_OPS == 20); // This benchmark is hardcoded for 20 ops, so assert that NUM_OPS is 20.
     c.bench_function("arithmetic/hydroflow/surface", |b| {
         b.iter_batched(
             || {

--- a/benches/benches/fan_in.rs
+++ b/benches/benches/fan_in.rs
@@ -1,4 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use hydroflow::hydroflow_syntax;
 use hydroflow::lang::collections::Iter;
 use hydroflow::scheduled::query::Query as Q;
 use timely::dataflow::operators::{Concatenate, Inspect, ToStream};
@@ -30,6 +31,46 @@ fn benchmark_hydroflow(c: &mut Criterion) {
             });
 
             q.run_available();
+        })
+    });
+}
+
+fn benchmark_hydroflow_surface(c: &mut Criterion) {
+    assert!(NUM_OPS == 20); // This benchmark is hardcoded for 20 ops, so assert that NUM_OPS is 20.
+    c.bench_function("fan_in/hydroflow/surface", |b| {
+        b.iter(|| {
+            let mut df = hydroflow_syntax! {
+
+                my_merge = merge();
+
+                source_iter(0..NUM_INTS) -> my_merge;
+                source_iter(0..NUM_INTS) -> my_merge;
+                source_iter(0..NUM_INTS) -> my_merge;
+                source_iter(0..NUM_INTS) -> my_merge;
+                source_iter(0..NUM_INTS) -> my_merge;
+
+                source_iter(0..NUM_INTS) -> my_merge;
+                source_iter(0..NUM_INTS) -> my_merge;
+                source_iter(0..NUM_INTS) -> my_merge;
+                source_iter(0..NUM_INTS) -> my_merge;
+                source_iter(0..NUM_INTS) -> my_merge;
+
+                source_iter(0..NUM_INTS) -> my_merge;
+                source_iter(0..NUM_INTS) -> my_merge;
+                source_iter(0..NUM_INTS) -> my_merge;
+                source_iter(0..NUM_INTS) -> my_merge;
+                source_iter(0..NUM_INTS) -> my_merge;
+
+                source_iter(0..NUM_INTS) -> my_merge;
+                source_iter(0..NUM_INTS) -> my_merge;
+                source_iter(0..NUM_INTS) -> my_merge;
+                source_iter(0..NUM_INTS) -> my_merge;
+                source_iter(0..NUM_INTS) -> my_merge;
+
+                my_merge -> for_each(|x| { black_box(x); });
+            };
+
+            df.run_available();
         })
     });
 }
@@ -78,6 +119,7 @@ fn benchmark_for_loops(c: &mut Criterion) {
 criterion_group!(
     fan_in_dataflow,
     benchmark_hydroflow,
+    benchmark_hydroflow_surface,
     benchmark_timely,
     benchmark_iters,
     benchmark_for_loops,

--- a/benches/benches/fan_in.rs
+++ b/benches/benches/fan_in.rs
@@ -2,6 +2,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use hydroflow::hydroflow_syntax;
 use hydroflow::lang::collections::Iter;
 use hydroflow::scheduled::query::Query as Q;
+use static_assertions::const_assert;
 use timely::dataflow::operators::{Concatenate, Inspect, ToStream};
 
 const NUM_OPS: usize = 20;
@@ -36,7 +37,7 @@ fn benchmark_hydroflow(c: &mut Criterion) {
 }
 
 fn benchmark_hydroflow_surface(c: &mut Criterion) {
-    assert!(NUM_OPS == 20); // This benchmark is hardcoded for 20 ops, so assert that NUM_OPS is 20.
+    const_assert!(NUM_OPS == 20); // This benchmark is hardcoded for 20 ops, so assert that NUM_OPS is 20.
     c.bench_function("fan_in/hydroflow/surface", |b| {
         b.iter(|| {
             let mut df = hydroflow_syntax! {

--- a/benches/benches/fan_out.rs
+++ b/benches/benches/fan_out.rs
@@ -4,6 +4,7 @@ use hydroflow::lang::collections::Iter;
 // use hydroflow::scheduled::handoff::TeeingHandoff;
 use hydroflow::scheduled::query::Query as Q;
 // use hydroflow::scheduled::Hydroflow;
+use hydroflow::hydroflow_syntax;
 use timely::dataflow::operators::{Map, ToStream};
 
 const NUM_OPS: usize = 20;
@@ -25,6 +26,45 @@ fn benchmark_hydroflow_scheduled(c: &mut Criterion) {
             }
 
             q.run_available();
+        })
+    });
+}
+
+fn benchmark_hydroflow_surface(c: &mut Criterion) {
+    assert!(NUM_OPS == 20); // This benchmark is hardcoded for 20 ops, so assert that NUM_OPS is 20.
+    c.bench_function("fan_out/hydroflow/surface", |b| {
+        b.iter(|| {
+            let mut df = hydroflow_syntax! {
+                my_tee = tee();
+
+                source_iter(black_box(0..NUM_INTS)) -> my_tee;
+
+                my_tee -> for_each(|x| { black_box(x); });
+                my_tee -> for_each(|x| { black_box(x); });
+                my_tee -> for_each(|x| { black_box(x); });
+                my_tee -> for_each(|x| { black_box(x); });
+                my_tee -> for_each(|x| { black_box(x); });
+
+                my_tee -> for_each(|x| { black_box(x); });
+                my_tee -> for_each(|x| { black_box(x); });
+                my_tee -> for_each(|x| { black_box(x); });
+                my_tee -> for_each(|x| { black_box(x); });
+                my_tee -> for_each(|x| { black_box(x); });
+
+                my_tee -> for_each(|x| { black_box(x); });
+                my_tee -> for_each(|x| { black_box(x); });
+                my_tee -> for_each(|x| { black_box(x); });
+                my_tee -> for_each(|x| { black_box(x); });
+                my_tee -> for_each(|x| { black_box(x); });
+
+                my_tee -> for_each(|x| { black_box(x); });
+                my_tee -> for_each(|x| { black_box(x); });
+                my_tee -> for_each(|x| { black_box(x); });
+                my_tee -> for_each(|x| { black_box(x); });
+                my_tee -> for_each(|x| { black_box(x); });
+            };
+
+            df.run_available();
         })
     });
 }
@@ -89,6 +129,7 @@ fn benchmark_sol(c: &mut Criterion) {
 criterion_group!(
     fan_out_dataflow,
     benchmark_hydroflow_scheduled,
+    benchmark_hydroflow_surface,
     // benchmark_hydroflow_teer,
     benchmark_timely,
     benchmark_sol,

--- a/benches/benches/fan_out.rs
+++ b/benches/benches/fan_out.rs
@@ -5,6 +5,7 @@ use hydroflow::lang::collections::Iter;
 use hydroflow::scheduled::query::Query as Q;
 // use hydroflow::scheduled::Hydroflow;
 use hydroflow::hydroflow_syntax;
+use static_assertions::const_assert;
 use timely::dataflow::operators::{Map, ToStream};
 
 const NUM_OPS: usize = 20;
@@ -31,7 +32,7 @@ fn benchmark_hydroflow_scheduled(c: &mut Criterion) {
 }
 
 fn benchmark_hydroflow_surface(c: &mut Criterion) {
-    assert!(NUM_OPS == 20); // This benchmark is hardcoded for 20 ops, so assert that NUM_OPS is 20.
+    const_assert!(NUM_OPS == 20); // This benchmark is hardcoded for 20 ops, so assert that NUM_OPS is 20.
     c.bench_function("fan_out/hydroflow/surface", |b| {
         b.iter(|| {
             let mut df = hydroflow_syntax! {

--- a/benches/benches/identity.rs
+++ b/benches/benches/identity.rs
@@ -1,6 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use hydroflow::hydroflow_syntax;
 use hydroflow::scheduled::graph_ext::GraphExt;
+use static_assertions::const_assert;
 use std::sync::mpsc::channel;
 use std::thread;
 use timely::dataflow::operators::{Inspect, Map, ToStream};
@@ -186,33 +187,33 @@ fn benchmark_hydroflow(c: &mut Criterion) {
 }
 
 fn benchmark_hydroflow_surface(c: &mut Criterion) {
-    assert!(NUM_OPS == 20); // This benchmark is hardcoded for 20 ops, so assert that NUM_OPS is 20.
+    const_assert!(NUM_OPS == 20); // This benchmark is hardcoded for 20 ops, so assert that NUM_OPS is 20.
     c.bench_function("identity/hydroflow/surface", |b| {
         b.iter(|| {
             let mut df = hydroflow_syntax! {
                 source_iter(black_box(0..NUM_INTS))
 
-                -> map(|x| black_box(x))
-                -> map(|x| black_box(x))
-                -> map(|x| black_box(x))
-                -> map(|x| black_box(x))
-                -> map(|x| black_box(x))
-                -> map(|x| black_box(x))
-                -> map(|x| black_box(x))
-                -> map(|x| black_box(x))
-                -> map(|x| black_box(x))
-                -> map(|x| black_box(x))
+                -> map(black_box)
+                -> map(black_box)
+                -> map(black_box)
+                -> map(black_box)
+                -> map(black_box)
+                -> map(black_box)
+                -> map(black_box)
+                -> map(black_box)
+                -> map(black_box)
+                -> map(black_box)
 
-                -> map(|x| black_box(x))
-                -> map(|x| black_box(x))
-                -> map(|x| black_box(x))
-                -> map(|x| black_box(x))
-                -> map(|x| black_box(x))
-                -> map(|x| black_box(x))
-                -> map(|x| black_box(x))
-                -> map(|x| black_box(x))
-                -> map(|x| black_box(x))
-                -> map(|x| black_box(x))
+                -> map(black_box)
+                -> map(black_box)
+                -> map(black_box)
+                -> map(black_box)
+                -> map(black_box)
+                -> map(black_box)
+                -> map(black_box)
+                -> map(black_box)
+                -> map(black_box)
+                -> map(black_box)
 
                 -> for_each(|x| { black_box(x); });
             };

--- a/benches/benches/identity.rs
+++ b/benches/benches/identity.rs
@@ -1,4 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use hydroflow::hydroflow_syntax;
 use hydroflow::scheduled::graph_ext::GraphExt;
 use std::sync::mpsc::channel;
 use std::thread;
@@ -184,6 +185,43 @@ fn benchmark_hydroflow(c: &mut Criterion) {
     });
 }
 
+fn benchmark_hydroflow_surface(c: &mut Criterion) {
+    assert!(NUM_OPS == 20); // This benchmark is hardcoded for 20 ops, so assert that NUM_OPS is 20.
+    c.bench_function("identity/hydroflow/surface", |b| {
+        b.iter(|| {
+            let mut df = hydroflow_syntax! {
+                source_iter(black_box(0..NUM_INTS))
+
+                -> map(|x| black_box(x))
+                -> map(|x| black_box(x))
+                -> map(|x| black_box(x))
+                -> map(|x| black_box(x))
+                -> map(|x| black_box(x))
+                -> map(|x| black_box(x))
+                -> map(|x| black_box(x))
+                -> map(|x| black_box(x))
+                -> map(|x| black_box(x))
+                -> map(|x| black_box(x))
+
+                -> map(|x| black_box(x))
+                -> map(|x| black_box(x))
+                -> map(|x| black_box(x))
+                -> map(|x| black_box(x))
+                -> map(|x| black_box(x))
+                -> map(|x| black_box(x))
+                -> map(|x| black_box(x))
+                -> map(|x| black_box(x))
+                -> map(|x| black_box(x))
+                -> map(|x| black_box(x))
+
+                -> for_each(|x| { black_box(x); });
+            };
+
+            df.run_available();
+        })
+    });
+}
+
 criterion_group!(
     identity_dataflow,
     benchmark_timely,
@@ -193,5 +231,6 @@ criterion_group!(
     benchmark_raw_copy,
     benchmark_hydroflow,
     benchmark_hydroflow_compiled,
+    benchmark_hydroflow_surface,
 );
 criterion_main!(identity_dataflow);

--- a/benches/benches/reachability.rs
+++ b/benches/benches/reachability.rs
@@ -306,7 +306,6 @@ fn benchmark_hydroflow_surface_cheating(c: &mut Criterion) {
                         my_cheaty_join = reached_vertices -> filter_map(|v| EDGES.get(&v)) -> flatten() -> map(|&v| v);
                         my_cheaty_join -> filter(|&v| reachable_inner.borrow_mut().insert(v)) -> reached_vertices;
                     }
-                    
                 };
 
                 (df, reachable_verts)

--- a/benches/benches/reachability.rs
+++ b/benches/benches/reachability.rs
@@ -288,6 +288,7 @@ fn benchmark_hydroflow(c: &mut Criterion) {
     });
 }
 
+#[allow(clippy::map_clone)]
 fn benchmark_hydroflow_surface_cheating(c: &mut Criterion) {
     c.bench_function("reachability/hydroflow/surface_cheating", |b| {
         b.iter_batched(
@@ -305,6 +306,7 @@ fn benchmark_hydroflow_surface_cheating(c: &mut Criterion) {
                         my_cheaty_join = reached_vertices -> filter_map(|v| EDGES.get(&v)) -> flatten() -> map(|&v| v);
                         my_cheaty_join -> filter(|&v| reachable_inner.borrow_mut().insert(v)) -> reached_vertices;
                     }
+                    
                 };
 
                 (df, reachable_verts)
@@ -322,8 +324,7 @@ fn benchmark_hydroflow_surface(c: &mut Criterion) {
     c.bench_function("reachability/hydroflow/surface", |b| {
         let edges: Vec<_> = EDGES
             .iter()
-            .map(|(&k, v)| v.iter().map(move |v| (k, *v)))
-            .flatten()
+            .flat_map(|(&k, v)| v.iter().map(move |v| (k, *v)))
             .collect();
 
         b.iter_batched(


### PR DESCRIPTION
fork_join example still missing, not sure how to write it in surface.

```
test arithmetic/hydroflow/compiled ...              bench:      433822 ns/iter (+/- 2914)
test arithmetic/hydroflow/compiled_no_cheating ...  bench:     4008118 ns/iter (+/- 57048)
test arithmetic/hydroflow/surface ...               bench:     3565224 ns/iter (+/- 225604)

test fan_in/hydroflow ...                           bench:   139897374 ns/iter (+/- 1018220)
test fan_in/hydroflow/surface ...                   bench:   139589814 ns/iter (+/- 1242085)

test fan_out/hydroflow/scheduled ...                bench:    90996904 ns/iter (+/- 1011161)
test fan_out/hydroflow/surface ...                  bench:     4630026 ns/iter (+/- 11125)

test identity/hydroflow ...                         bench:    43572595 ns/iter (+/- 345472)
test identity/hydroflow/compiled ...                bench:     4105147 ns/iter (+/- 313148)
test identity/hydroflow/surface ...                 bench:     3985346 ns/iter (+/- 36528)

test reachability/hydroflow/scheduled ...           bench:     3115472 ns/iter (+/- 18418)
test reachability/hydroflow ...                     bench:     2928827 ns/iter (+/- 15196)
test reachability/hydroflow/surface ...             bench:    12368852 ns/iter (+/- 55141)
test reachability/hydroflow/surface_cheating ...    bench:     2340213 ns/iter (+/- 11036)
```