### PR TITLE
symmetric hash join improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,7 @@ dependencies = [
  "hydroflow",
  "lazy_static",
  "rand 0.8.5",
+ "rand_distr",
  "seq-macro",
  "static_assertions",
  "timely",
@@ -1028,6 +1029,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
 name = "link-cplusplus"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1142,6 +1149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1414,6 +1422,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom 0.2.6",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,6 +815,7 @@ dependencies = [
  "rand 0.8.5",
  "ref-cast",
  "regex",
+ "rustc-hash",
  "sealed",
  "serde",
  "serde_json",

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -13,6 +13,7 @@ hydroflow = { path = "../hydroflow" }
 lazy_static = "1.4.0"
 # pprof = { version = "0.6", features = [ "flamegraph", "criterion" ] }
 rand = "0.8.4"
+rand_distr = "0.4.3"
 seq-macro = "0.2"
 timely = "*"
 differential-dataflow = "*"
@@ -53,4 +54,8 @@ harness = false
 
 [[bench]]
 name = "micro_ops"
+harness = false
+
+[[bench]]
+name = "symmetric_hash_join"
 harness = false

--- a/benches/benches/symmetric_hash_join.rs
+++ b/benches/benches/symmetric_hash_join.rs
@@ -1,0 +1,123 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use hydroflow::compiled::pull::{JoinState, SymmetricHashJoin};
+use rand::distributions::Distribution;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use std::hint::black_box;
+
+fn ops(c: &mut Criterion) {
+    let mut rng = StdRng::from_entropy();
+
+    c.bench_function("symmetric_hash_join/no_match", |b| {
+        let lhs: Vec<_> = (0..3000).map(|v| (v, ())).collect();
+        let rhs: Vec<_> = (0..3000).map(|v| (v + 50000, ())).collect();
+
+        b.iter(|| {
+            let mut state = black_box(JoinState::default());
+            let join = SymmetricHashJoin::new(
+                black_box(lhs.iter().cloned()),
+                black_box(rhs.iter().cloned()),
+                &mut state,
+            );
+
+            for v in join {
+                black_box(v);
+            }
+        });
+    });
+
+    c.bench_function("symmetric_hash_join/match_keys_diff_values", |b| {
+        let lhs: Vec<_> = (0..3000).map(|v| (v, v)).collect();
+        let rhs: Vec<_> = (0..3000).map(|v| (v, v + 50000)).collect();
+
+        b.iter(|| {
+            let mut state = black_box(JoinState::default());
+            let join = SymmetricHashJoin::new(
+                black_box(lhs.iter().cloned()),
+                black_box(rhs.iter().cloned()),
+                &mut state,
+            );
+
+            for v in join {
+                black_box(v);
+            }
+        });
+    });
+
+    c.bench_function("symmetric_hash_join/match_keys_same_values", |b| {
+        let lhs: Vec<_> = (0..3000).map(|v| (v, v)).collect();
+        let rhs: Vec<_> = (0..3000).map(|v| (v, v)).collect();
+
+        b.iter(|| {
+            let mut state = black_box(JoinState::default());
+            let join = SymmetricHashJoin::new(
+                black_box(lhs.iter().cloned()),
+                black_box(rhs.iter().cloned()),
+                &mut state,
+            );
+
+            for v in join {
+                black_box(v);
+            }
+        });
+    });
+
+    c.bench_function(
+        "symmetric_hash_join/zipf_keys_low_contention_unique_values",
+        |b| {
+            let dist = rand_distr::Zipf::new(8000, 0.5).unwrap();
+
+            let lhs: Vec<_> = (0..2000)
+                .map(|v| (dist.sample(&mut rng) as usize, v))
+                .collect();
+
+            let rhs: Vec<_> = (0..2000)
+                .map(|v| (dist.sample(&mut rng) as usize, v + 8000))
+                .collect();
+
+            b.iter(|| {
+                let mut state = black_box(JoinState::default());
+                let join = SymmetricHashJoin::new(
+                    black_box(lhs.iter().cloned()),
+                    black_box(rhs.iter().cloned()),
+                    &mut state,
+                );
+
+                for v in join {
+                    black_box(v);
+                }
+            });
+        },
+    );
+
+    c.bench_function(
+        "symmetric_hash_join/zipf_keys_high_contention_unique_values",
+        |b| {
+            let dist = rand_distr::Zipf::new(8000, 4.0).unwrap();
+
+            let lhs: Vec<_> = (0..1000)
+                .map(|v| (dist.sample(&mut rng) as usize, v))
+                .collect();
+
+            let rhs: Vec<_> = (0..1000)
+                .map(|v| (dist.sample(&mut rng) as usize, v + 8000))
+                .collect();
+
+            b.iter(|| {
+                let mut state = black_box(JoinState::default());
+                let join = SymmetricHashJoin::new(
+                    black_box(lhs.iter().cloned()),
+                    black_box(rhs.iter().cloned()),
+                    &mut state,
+                );
+
+                for v in join {
+                    black_box(v);
+                }
+            });
+        },
+    );
+}
+
+criterion_group!(symmetric_hash_join, ops,);
+criterion_main!(symmetric_hash_join);

--- a/hydroflow/Cargo.toml
+++ b/hydroflow/Cargo.toml
@@ -55,6 +55,7 @@ tokio = { version = "1.16", features = [ "full" ] }
 tokio-stream = { version = "0.1.10", features = [ "io-util" ] }
 tokio-util = { version = "0.7.4", features = [ "net", "codec" ] }
 variadics = { path = "../variadics" }
+rustc-hash = "1.1.0"
 
 [dev-dependencies]
 chrono = { version = "0.4.20", features = [ "serde" ], default-features = false }

--- a/hydroflow/src/compiled/pull/symmetric_hash_join.rs
+++ b/hydroflow/src/compiled/pull/symmetric_hash_join.rs
@@ -45,7 +45,7 @@ where
     }
 
     fn probe(&mut self, k: &Key, v: &ValProbe) {
-        if let Some(entry) = self.table.get(&k) {
+        if let Some(entry) = self.table.get(k) {
             // TODO: Don't free/shrink the self.current_matches vecdeque to save time.
             // This mean it will grow to eventually become the largest number of matches in a single probe call.
             // Maybe we should clear this memory at the beginning of every tick/periodically?

--- a/hydroflow/src/compiled/pull/symmetric_hash_join.rs
+++ b/hydroflow/src/compiled/pull/symmetric_hash_join.rs
@@ -46,7 +46,7 @@ where
 
     fn probe(&mut self, k: &Key, v: &ValProbe) {
         if let Some(entry) = self.table.get(k) {
-            // TODO: We currently free/shrink the self.current_matches vecdeque to save time.
+            // TODO: We currently don't free/shrink the self.current_matches vecdeque to save time.
             // This mean it will grow to eventually become the largest number of matches in a single probe call.
             // Maybe we should clear this memory at the beginning of every tick/periodically?
             self.current_matches.extend(

--- a/hydroflow/src/compiled/pull/symmetric_hash_join.rs
+++ b/hydroflow/src/compiled/pull/symmetric_hash_join.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+type HashMap<K, V> = rustc_hash::FxHashMap<K, V>;
 
 #[derive(Debug)]
 pub struct HalfJoinState<Key, ValBuild, ValProbe> {
@@ -11,7 +11,7 @@ pub struct HalfJoinState<Key, ValBuild, ValProbe> {
 impl<Key, ValBuild, ValProbe> Default for HalfJoinState<Key, ValBuild, ValProbe> {
     fn default() -> Self {
         Self {
-            table: HashMap::new(),
+            table: HashMap::default(),
             current_matches: None,
         }
     }

--- a/hydroflow/src/compiled/pull/symmetric_hash_join.rs
+++ b/hydroflow/src/compiled/pull/symmetric_hash_join.rs
@@ -46,6 +46,9 @@ where
 
     fn probe(&mut self, k: &Key, v: &ValProbe) {
         if let Some(entry) = self.table.get(&k) {
+            // TODO: Don't free/shrink the self.current_matches vecdeque to save time.
+            // This mean it will grow to eventually become the largest number of matches in a single probe call.
+            // Maybe we should clear this memory at the beginning of every tick/periodically?
             self.current_matches.extend(
                 entry
                     .iter()

--- a/hydroflow/src/compiled/pull/symmetric_hash_join.rs
+++ b/hydroflow/src/compiled/pull/symmetric_hash_join.rs
@@ -46,7 +46,7 @@ where
 
     fn probe(&mut self, k: &Key, v: &ValProbe) {
         if let Some(entry) = self.table.get(k) {
-            // TODO: Don't free/shrink the self.current_matches vecdeque to save time.
+            // TODO: We currently free/shrink the self.current_matches vecdeque to save time.
             // This mean it will grow to eventually become the largest number of matches in a single probe call.
             // Maybe we should clear this memory at the beginning of every tick/periodically?
             self.current_matches.extend(


### PR DESCRIPTION
1. add microbenchmark for symmetric hash join.
2. change hash function to fxhash from siphash.
3. reduce redundant hash calculations in symmetric hash join code.

changing the hash function results in perf gains like this:
```
symmetric_hash_join/no_match
                        time:   [204.11 µs 204.71 µs 205.65 µs]
                        change: [-34.654% -34.157% -33.792%] (p = 0.00 < 0.05)

symmetric_hash_join/match_keys_diff_values
                        time:   [513.84 µs 514.51 µs 515.30 µs]
                        change: [-27.268% -26.017% -25.009%] (p = 0.00 < 0.05)

symmetric_hash_join/match_keys_same_values
                        time:   [567.36 µs 576.55 µs 587.08 µs]
                        change: [-20.294% -18.403% -16.310%] (p = 0.00 < 0.05)

symmetric_hash_join/zipf_keys_low_contention_unique_values
                        time:   [342.10 µs 347.09 µs 353.79 µs]
                        change: [-39.596% -38.597% -37.407%] (p = 0.00 < 0.05)

symmetric_hash_join/zipf_keys_high_contention_unique_values
                        time:   [14.296 ms 14.396 ms 14.515 ms]
                        change: [-57.789% -57.376% -56.921%] (p = 0.00 < 0.05)
```

Reducing redundant hash calculations results in perf gains like this (on top of hash function perf gains):
```
symmetric_hash_join/no_match
                        time:   [190.43 µs 190.82 µs 191.44 µs]
                        change: [-4.0796% -3.0662% -2.3169%] (p = 0.00 < 0.05)

symmetric_hash_join/match_keys_diff_values
                        time:   [447.14 µs 447.74 µs 448.41 µs]
                        change: [-10.886% -10.483% -10.213%] (p = 0.00 < 0.05)

symmetric_hash_join/match_keys_same_values
                        time:   [454.21 µs 454.51 µs 454.83 µs]
                        change: [-10.064% -9.7119% -9.4413%] (p = 0.00 < 0.05)

symmetric_hash_join/zipf_keys_low_contention_unique_values
                        time:   [302.46 µs 302.92 µs 303.38 µs]
                        change: [-5.9033% -5.6767% -5.4387%] (p = 0.00 < 0.05)

symmetric_hash_join/zipf_keys_high_contention_unique_values
                        time:   [10.580 ms 10.617 ms 10.664 ms]
                        change: [-20.644% -20.188% -19.704%] (p = 0.00 < 0.05)
```