### PR TITLE
Ops specify persistence/type arg counts, handle separately in `partitioned_graph`

### DIFF
--- a/hydroflow/tests/compile-fail/surface_badgeneric_both.rs
+++ b/hydroflow/tests/compile-fail/surface_badgeneric_both.rs
@@ -1,0 +1,8 @@
+use hydroflow::hydroflow_syntax;
+
+fn main() {
+    let mut df = hydroflow_syntax! {
+        source_iter(0..10) -> identity::<'static, usize>() -> for_each(std::mem::drop);
+    };
+    df.run_available();
+}

--- a/hydroflow/tests/compile-fail/surface_badgeneric_both.stderr
+++ b/hydroflow/tests/compile-fail/surface_badgeneric_both.stderr
@@ -1,0 +1,11 @@
+error: `identity` should have exactly 0 persistence lifetime arguments, actually has 1.
+ --> tests/compile-fail/surface_badgeneric_both.rs:5:42
+  |
+5 |         source_iter(0..10) -> identity::<'static, usize>() -> for_each(std::mem::drop);
+  |                                          ^^^^^^^^^^^^^^
+
+error: `identity` should have exactly 0 generic type arguments, actually has 1.
+ --> tests/compile-fail/surface_badgeneric_both.rs:5:42
+  |
+5 |         source_iter(0..10) -> identity::<'static, usize>() -> for_each(std::mem::drop);
+  |                                          ^^^^^^^^^^^^^^

--- a/hydroflow/tests/compile-fail/surface_badgeneric_extra.rs
+++ b/hydroflow/tests/compile-fail/surface_badgeneric_extra.rs
@@ -1,0 +1,9 @@
+use hydroflow::hydroflow_syntax;
+
+fn main() {
+    let mut df = hydroflow_syntax! {
+        // Due to the TODO the `usize` is not caught, but that is ok.
+        source_iter(0..10) -> identity::<'a, usize>() -> for_each(std::mem::drop);
+    };
+    df.run_available();
+}

--- a/hydroflow/tests/compile-fail/surface_badgeneric_extra.stderr
+++ b/hydroflow/tests/compile-fail/surface_badgeneric_extra.stderr
@@ -1,4 +1,4 @@
-error: Unknown lifetime generic argument `'a`, expected `'epoch` or `'static`.
+error: Unknown lifetime generic argument `'a`, expected `'tick` or `'static`.
  --> tests/compile-fail/surface_badgeneric_extra.rs:6:42
   |
 6 |         source_iter(0..10) -> identity::<'a, usize>() -> for_each(std::mem::drop);

--- a/hydroflow/tests/compile-fail/surface_badgeneric_extra.stderr
+++ b/hydroflow/tests/compile-fail/surface_badgeneric_extra.stderr
@@ -1,0 +1,5 @@
+error: Unknown lifetime generic argument `'a`, expected `'epoch` or `'static`.
+ --> tests/compile-fail/surface_badgeneric_extra.rs:6:42
+  |
+6 |         source_iter(0..10) -> identity::<'a, usize>() -> for_each(std::mem::drop);
+  |                                          ^^

--- a/hydroflow/tests/compile-fail/surface_badgeneric_lifetime.rs
+++ b/hydroflow/tests/compile-fail/surface_badgeneric_lifetime.rs
@@ -1,0 +1,8 @@
+use hydroflow::hydroflow_syntax;
+
+fn main() {
+    let mut df = hydroflow_syntax! {
+        source_iter(0..10) -> identity::<'static>() -> for_each(std::mem::drop);
+    };
+    df.run_available();
+}

--- a/hydroflow/tests/compile-fail/surface_badgeneric_lifetime.stderr
+++ b/hydroflow/tests/compile-fail/surface_badgeneric_lifetime.stderr
@@ -1,0 +1,5 @@
+error: `identity` should have exactly 0 persistence lifetime arguments, actually has 1.
+ --> tests/compile-fail/surface_badgeneric_lifetime.rs:5:42
+  |
+5 |         source_iter(0..10) -> identity::<'static>() -> for_each(std::mem::drop);
+  |                                          ^^^^^^^

--- a/hydroflow/tests/compile-fail/surface_badgeneric_type.rs
+++ b/hydroflow/tests/compile-fail/surface_badgeneric_type.rs
@@ -1,0 +1,10 @@
+use hydroflow::hydroflow_syntax;
+
+fn main() {
+    let mut df = hydroflow_syntax! {
+        // TODO(mingwei): this may make sense at some point in the future.
+        // Currently no generic arguments implemented for `identity` (or `map`, etc.).
+        source_iter(0..10) -> identity::<usize>() -> for_each(std::mem::drop);
+    };
+    df.run_available();
+}

--- a/hydroflow/tests/compile-fail/surface_badgeneric_type.stderr
+++ b/hydroflow/tests/compile-fail/surface_badgeneric_type.stderr
@@ -1,0 +1,5 @@
+error: `identity` should have exactly 0 generic type arguments, actually has 1.
+ --> tests/compile-fail/surface_badgeneric_type.rs:7:42
+  |
+7 |         source_iter(0..10) -> identity::<usize>() -> for_each(std::mem::drop);
+  |                                          ^^^^^

--- a/hydroflow/tests/compile-fail/surface_join_badpersistence.rs
+++ b/hydroflow/tests/compile-fail/surface_join_badpersistence.rs
@@ -1,0 +1,10 @@
+use hydroflow::hydroflow_syntax;
+
+fn main() {
+    let mut df = hydroflow_syntax! {
+        j = join::<'a>() -> for_each(std::mem::drop);
+        source_iter(0..10) -> map(|x| (x, x)) -> [0]j;
+        source_iter(0..10) -> map(|x| (x, x)) -> [1]j;
+    };
+    df.run_available();
+}

--- a/hydroflow/tests/compile-fail/surface_join_badpersistence.stderr
+++ b/hydroflow/tests/compile-fail/surface_join_badpersistence.stderr
@@ -1,0 +1,5 @@
+error: Unknown lifetime generic argument `'a`, expected `'epoch` or `'static`.
+ --> tests/compile-fail/surface_join_badpersistence.rs:5:20
+  |
+5 |         j = join::<'a>() -> for_each(std::mem::drop);
+  |                    ^^

--- a/hydroflow/tests/compile-fail/surface_join_badpersistence.stderr
+++ b/hydroflow/tests/compile-fail/surface_join_badpersistence.stderr
@@ -1,4 +1,4 @@
-error: Unknown lifetime generic argument `'a`, expected `'epoch` or `'static`.
+error: Unknown lifetime generic argument `'a`, expected `'tick` or `'static`.
  --> tests/compile-fail/surface_join_badpersistence.rs:5:20
   |
 5 |         j = join::<'a>() -> for_each(std::mem::drop);

--- a/hydroflow/tests/surface_difference.rs
+++ b/hydroflow/tests/surface_difference.rs
@@ -5,7 +5,7 @@ pub fn test_diff_timing() {
     let (neg_send, neg_recv) = hydroflow::util::unbounded_channel::<usize>();
 
     let mut df = hydroflow::hydroflow_syntax! {
-        diff = difference::<'static>() -> for_each(|x| println!("diff: {:?}", x));
+        diff = difference() -> for_each(|x| println!("diff: {:?}", x));
 
         poss = source_stream(pos_recv); //-> tee();
         poss -> [pos]diff;

--- a/hydroflow_lang/src/graph/ops/cross_join.rs
+++ b/hydroflow_lang/src/graph/ops/cross_join.rs
@@ -1,4 +1,4 @@
-use super::{OperatorConstraints, WriteContextArgs, WriteIteratorArgs, RANGE_1};
+use super::{OperatorConstraints, WriteContextArgs, WriteIteratorArgs, RANGE_0, RANGE_1};
 
 use quote::quote_spanned;
 use syn::parse_quote;
@@ -42,6 +42,8 @@ pub const CROSS_JOIN: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 0,
+    persistence_args: &(0..=2),
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: Some(&(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 }))),
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/demux.rs
+++ b/hydroflow_lang/src/graph/ops/demux.rs
@@ -6,7 +6,7 @@ use crate::pretty_span::PrettySpan;
 
 use super::{
     OperatorConstraints, OperatorWriteOutput, PortListSpec, WriteContextArgs, WriteIteratorArgs,
-    RANGE_1,
+    RANGE_0, RANGE_1,
 };
 
 use proc_macro2::{Ident, TokenTree};
@@ -49,6 +49,8 @@ pub const DEMUX: OperatorConstraints = OperatorConstraints {
     hard_range_out: &(2..),
     soft_range_out: &(2..),
     num_args: 1,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: Some(&(|| PortListSpec::Variadic)),

--- a/hydroflow_lang/src/graph/ops/dest_sink.rs
+++ b/hydroflow_lang/src/graph/ops/dest_sink.rs
@@ -88,6 +88,8 @@ pub const DEST_SINK: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_0,
     soft_range_out: RANGE_0,
     num_args: 1,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/dest_sink_serde.rs
+++ b/hydroflow_lang/src/graph/ops/dest_sink_serde.rs
@@ -29,6 +29,8 @@ pub const DEST_SINK_SERDE: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_0,
     soft_range_out: RANGE_0,
     num_args: 1,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/difference.rs
+++ b/hydroflow_lang/src/graph/ops/difference.rs
@@ -2,7 +2,7 @@ use crate::graph::PortIndexValue;
 
 use super::{
     DelayType, OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs,
-    RANGE_1,
+    RANGE_0, RANGE_1,
 };
 
 use quote::{quote_spanned, ToTokens};
@@ -29,6 +29,8 @@ pub const DIFFERENCE: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 0,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: Some(&|| super::PortListSpec::Fixed(parse_quote! { pos, neg })),
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/filter.rs
+++ b/hydroflow_lang/src/graph/ops/filter.rs
@@ -1,5 +1,5 @@
 use super::{
-    OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs, RANGE_1,
+    OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs, RANGE_0, RANGE_1,
 };
 
 use quote::quote_spanned;
@@ -21,6 +21,8 @@ pub const FILTER: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 1,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/filter_map.rs
+++ b/hydroflow_lang/src/graph/ops/filter_map.rs
@@ -1,5 +1,5 @@
 use super::{
-    OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs, RANGE_1,
+    OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs, RANGE_0, RANGE_1,
 };
 
 use quote::quote_spanned;
@@ -20,6 +20,8 @@ pub const FILTER_MAP: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 1,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/flat_map.rs
+++ b/hydroflow_lang/src/graph/ops/flat_map.rs
@@ -1,5 +1,5 @@
 use super::{
-    OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs, RANGE_1,
+    OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs, RANGE_0, RANGE_1,
 };
 
 use quote::quote_spanned;
@@ -24,6 +24,8 @@ pub const FLAT_MAP: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 1,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/flatten.rs
+++ b/hydroflow_lang/src/graph/ops/flatten.rs
@@ -1,5 +1,5 @@
 use super::{
-    OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs, RANGE_1,
+    OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs, RANGE_0, RANGE_1,
 };
 
 use quote::quote_spanned;
@@ -22,6 +22,8 @@ pub const FLATTEN: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 0,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/fold.rs
+++ b/hydroflow_lang/src/graph/ops/fold.rs
@@ -1,6 +1,6 @@
 use super::{
     DelayType, OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs,
-    RANGE_1,
+    RANGE_0, RANGE_1,
 };
 
 use quote::quote_spanned;
@@ -30,6 +30,8 @@ pub const FOLD: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 2,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/for_each.rs
+++ b/hydroflow_lang/src/graph/ops/for_each.rs
@@ -23,6 +23,8 @@ pub const FOR_EACH: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_0,
     soft_range_out: RANGE_0,
     num_args: 1,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/identity.rs
+++ b/hydroflow_lang/src/graph/ops/identity.rs
@@ -1,4 +1,4 @@
-use super::{OperatorConstraints, IDENTITY_WRITE_FN, RANGE_1};
+use super::{OperatorConstraints, IDENTITY_WRITE_FN, RANGE_0, RANGE_1};
 
 /// > 1 input stream of type T, 1 output stream of type T
 ///
@@ -17,6 +17,8 @@ pub const IDENTITY: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 0,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/inspect.rs
+++ b/hydroflow_lang/src/graph/ops/inspect.rs
@@ -1,5 +1,5 @@
 use super::{
-    OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs, RANGE_1,
+    OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs, RANGE_0, RANGE_1,
 };
 
 use quote::quote_spanned;
@@ -22,6 +22,8 @@ pub const INSPECT: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 1,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/join.rs
+++ b/hydroflow_lang/src/graph/ops/join.rs
@@ -34,11 +34,11 @@ use syn::parse_quote;
 /// join(); // Or
 /// join::<'static>();
 ///
-/// join::<'epoch>();
+/// join::<'tick>();
 ///
-/// join::<'static, 'epoch>();
+/// join::<'static, 'tick>();
 ///
-/// join::<'epoch, 'static>();
+/// join::<'tick, 'static>();
 /// // etc.
 /// ```
 ///

--- a/hydroflow_lang/src/graph/ops/map.rs
+++ b/hydroflow_lang/src/graph/ops/map.rs
@@ -1,5 +1,5 @@
 use super::{
-    OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs, RANGE_1,
+    OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs, RANGE_0, RANGE_1,
 };
 
 use quote::quote_spanned;
@@ -24,6 +24,8 @@ pub const MAP: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 1,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/merge.rs
+++ b/hydroflow_lang/src/graph/ops/merge.rs
@@ -1,6 +1,6 @@
 use super::{
-    OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs, RANGE_1,
-    RANGE_ANY,
+    OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs, RANGE_0,
+    RANGE_1, RANGE_ANY,
 };
 
 use quote::{quote_spanned, ToTokens};
@@ -28,6 +28,8 @@ pub const MERGE: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 0,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/next_stratum.rs
+++ b/hydroflow_lang/src/graph/ops/next_stratum.rs
@@ -1,4 +1,4 @@
-use super::{DelayType, OperatorConstraints, IDENTITY_WRITE_FN, RANGE_1};
+use super::{DelayType, OperatorConstraints, IDENTITY_WRITE_FN, RANGE_0, RANGE_1};
 
 /// Delays all elements which pass through to the next stratum (in the same
 /// tick).
@@ -10,6 +10,8 @@ pub const NEXT_STRATUM: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 0,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/next_tick.rs
+++ b/hydroflow_lang/src/graph/ops/next_tick.rs
@@ -1,4 +1,4 @@
-use super::{DelayType, OperatorConstraints, IDENTITY_WRITE_FN, RANGE_1};
+use super::{DelayType, OperatorConstraints, IDENTITY_WRITE_FN, RANGE_0, RANGE_1};
 
 /// Delays all elements which pass through to the next tick. In short,
 /// execution of a hydroflow graph runs as a sequence of distinct "ticks".
@@ -40,6 +40,8 @@ pub const NEXT_TICK: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 0,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/null.rs
+++ b/hydroflow_lang/src/graph/ops/null.rs
@@ -1,4 +1,6 @@
-use super::{OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs};
+use super::{
+    OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs, RANGE_0,
+};
 
 use quote::quote_spanned;
 
@@ -24,6 +26,8 @@ pub const NULL: OperatorConstraints = OperatorConstraints {
     hard_range_out: &(0..=1),
     soft_range_out: &(0..=1),
     num_args: 0,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/reduce.rs
+++ b/hydroflow_lang/src/graph/ops/reduce.rs
@@ -1,6 +1,6 @@
 use super::{
     DelayType, OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs,
-    RANGE_1,
+    RANGE_0, RANGE_1,
 };
 
 use quote::quote_spanned;
@@ -30,6 +30,8 @@ pub const REDUCE: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 1,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/repeat_iter.rs
+++ b/hydroflow_lang/src/graph/ops/repeat_iter.rs
@@ -12,6 +12,8 @@ pub const REPEAT_ITER: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 1,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/sort.rs
+++ b/hydroflow_lang/src/graph/ops/sort.rs
@@ -1,12 +1,9 @@
-use crate::diagnostic::{Diagnostic, Level};
-
 use super::{
-    parse_persistence_lifetimes, DelayType, OperatorConstraints, OperatorWriteOutput, Persistence,
-    WriteContextArgs, WriteIteratorArgs, RANGE_1,
+    DelayType, OperatorConstraints, OperatorWriteOutput, Persistence, WriteContextArgs,
+    WriteIteratorArgs, RANGE_0, RANGE_1,
 };
 
 use quote::quote_spanned;
-use syn::spanned::Spanned;
 
 /// Takes a stream as input and produces a sorted version of the stream as output.
 ///
@@ -50,39 +47,27 @@ pub const SORT: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 0,
+    persistence_args: &(0..=1),
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
     input_delaytype_fn: &|_| Some(DelayType::Stratum),
     write_fn: &(|wc @ &WriteContextArgs { op_span, .. },
-                 wi @ &WriteIteratorArgs {
+                 &WriteIteratorArgs {
                      ident,
                      inputs,
                      is_pull,
-                     generic_args,
-                     op_name,
+                     persistence_args,
                      ..
                  },
-                 diagnostics| {
+                 _| {
         assert!(is_pull);
 
-        let generics_span = generic_args.map(Spanned::span).unwrap_or(op_span);
-
-        let persistence = parse_persistence_lifetimes(wi, diagnostics);
-        let persistence = match *persistence {
+        let persistence = match *persistence_args {
             [] => Persistence::Tick,
             [a] => a,
-            _ => {
-                diagnostics.push(Diagnostic::spanned(
-                    generics_span,
-                    Level::Error,
-                    format!(
-                        "Operator `{}` expects zero or one persistence lifetime generic arguments",
-                        op_name
-                    ),
-                ));
-                Persistence::Static
-            }
+            _ => unreachable!(),
         };
 
         let input = &inputs[0];

--- a/hydroflow_lang/src/graph/ops/sort_by.rs
+++ b/hydroflow_lang/src/graph/ops/sort_by.rs
@@ -1,6 +1,6 @@
 use super::{
     DelayType, OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs,
-    RANGE_1,
+    RANGE_0, RANGE_1,
 };
 
 use quote::quote_spanned;
@@ -22,6 +22,8 @@ pub const SORT_BY: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 1,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/source_iter.rs
+++ b/hydroflow_lang/src/graph/ops/source_iter.rs
@@ -24,6 +24,8 @@ pub const SOURCE_ITER: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 1,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/source_stdin.rs
+++ b/hydroflow_lang/src/graph/ops/source_stdin.rs
@@ -26,6 +26,8 @@ pub const SOURCE_STDIN: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 0,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: true,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/source_stream.rs
+++ b/hydroflow_lang/src/graph/ops/source_stream.rs
@@ -31,6 +31,8 @@ pub const SOURCE_STREAM: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 1,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: true,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/source_stream_serde.rs
+++ b/hydroflow_lang/src/graph/ops/source_stream_serde.rs
@@ -31,6 +31,8 @@ pub const SOURCE_STREAM_SERDE: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_1,
     soft_range_out: RANGE_1,
     num_args: 1,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: true,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/tee.rs
+++ b/hydroflow_lang/src/graph/ops/tee.rs
@@ -1,6 +1,6 @@
 use super::{
-    OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs, RANGE_1,
-    RANGE_ANY,
+    OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs, RANGE_0,
+    RANGE_1, RANGE_ANY,
 };
 
 use quote::{quote_spanned, ToTokens};
@@ -26,6 +26,8 @@ pub const TEE: OperatorConstraints = OperatorConstraints {
     hard_range_out: RANGE_ANY,
     soft_range_out: &(2..),
     num_args: 0,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: None,

--- a/hydroflow_lang/src/graph/ops/unzip.rs
+++ b/hydroflow_lang/src/graph/ops/unzip.rs
@@ -1,5 +1,5 @@
 use super::{
-    OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs, RANGE_1,
+    OperatorConstraints, OperatorWriteOutput, WriteContextArgs, WriteIteratorArgs, RANGE_0, RANGE_1,
 };
 
 use quote::quote_spanned;
@@ -23,6 +23,8 @@ pub const UNZIP: OperatorConstraints = OperatorConstraints {
     hard_range_out: &(2..=2),
     soft_range_out: &(2..=2),
     num_args: 0,
+    persistence_args: RANGE_0,
+    type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
     ports_out: Some(&|| super::PortListSpec::Fixed(parse_quote!(0, 1))),

--- a/hydroflow_lang/src/graph/partitioned_graph.rs
+++ b/hydroflow_lang/src/graph/partitioned_graph.rs
@@ -209,7 +209,7 @@ impl PartitionedGraph {
                                             diagnostics.push(Diagnostic::spanned(
                                                 generic_arg.span(),
                                                 Level::Error,
-                                                format!("Unknown lifetime generic argument `'{}`, expected `'epoch` or `'static`.", lifetime.ident),
+                                                format!("Unknown lifetime generic argument `'{}`, expected `'tick` or `'static`.", lifetime.ident),
                                             ));
                                             // TODO(mingwei): should really keep going and not short circuit?
                                             None


### PR DESCRIPTION
TODO(mingwei): Should also check the arg counts in `flat_graph`

Part of #364