### PR TITLE
Receive events at tick start only, implement operator self-scheduling for replay #364

### DIFF
--- a/hydroflow/src/scheduled/context.rs
+++ b/hydroflow/src/scheduled/context.rs
@@ -45,6 +45,11 @@ impl Context {
         self.current_stratum
     }
 
+    /// Gets the ID of the current subgraph.
+    pub fn current_subgraph(&self) -> SubgraphId {
+        self.subgraph_id
+    }
+
     /// Schedules a subgraph.
     pub fn schedule_subgraph(&self, sg_id: SubgraphId) {
         self.event_queue_send.send(sg_id).unwrap()

--- a/hydroflow/src/scheduled/query.rs
+++ b/hydroflow/src/scheduled/query.rs
@@ -62,7 +62,7 @@ impl Query {
     }
 
     pub fn run_available(&mut self) {
-        (*self.df).borrow_mut().run_available()
+        (*self.df).borrow_mut().run_available();
     }
 }
 

--- a/hydroflow/tests/surface_fold.rs
+++ b/hydroflow/tests/surface_fold.rs
@@ -21,10 +21,13 @@ pub fn test_fold_tick() {
             .to_mermaid()
     );
 
+    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+
     items_send.send(vec![1, 2]).unwrap();
     items_send.send(vec![3, 4]).unwrap();
-    df.run_available();
+    df.run_tick();
 
+    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
     assert_eq!(
         &[vec![1, 2, 3, 4]],
         &*hydroflow::util::collect_ready::<Vec<_>, _>(&mut result_recv)
@@ -32,8 +35,9 @@ pub fn test_fold_tick() {
 
     items_send.send(vec![5, 6]).unwrap();
     items_send.send(vec![7, 8]).unwrap();
-    df.run_available();
+    df.run_tick();
 
+    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
     assert_eq!(
         &[vec![5, 6, 7, 8]],
         &*hydroflow::util::collect_ready::<Vec<_>, _>(&mut result_recv)
@@ -58,10 +62,13 @@ pub fn test_fold_static() {
             .to_mermaid()
     );
 
+    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+
     items_send.send(vec![1, 2]).unwrap();
     items_send.send(vec![3, 4]).unwrap();
-    df.run_available();
+    df.run_tick();
 
+    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
     assert_eq!(
         &[vec![1, 2, 3, 4]],
         &*hydroflow::util::collect_ready::<Vec<_>, _>(&mut result_recv)
@@ -69,8 +76,9 @@ pub fn test_fold_static() {
 
     items_send.send(vec![5, 6]).unwrap();
     items_send.send(vec![7, 8]).unwrap();
-    df.run_available();
+    df.run_tick();
 
+    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
     assert_eq!(
         &[vec![1, 2, 3, 4, 5, 6, 7, 8]],
         &*hydroflow::util::collect_ready::<Vec<_>, _>(&mut result_recv)
@@ -90,7 +98,9 @@ pub fn test_fold_flatten() {
             -> flatten()
             -> for_each(|(k,v)| out_send.send((k,v)).unwrap());
     };
-    df_pull.run_available();
+    assert_eq!((0, 0), (df_pull.current_tick(), df_pull.current_stratum()));
+    df_pull.run_tick();
+    assert_eq!((1, 0), (df_pull.current_tick(), df_pull.current_stratum()));
 
     let out: HashSet<_> = collect_ready(&mut out_recv);
     for pair in [(1, 3), (2, 7)] {
@@ -109,8 +119,9 @@ pub fn test_fold_flatten() {
             -> for_each(|(k,v)| out_send.send((k,v)).unwrap());
         datagen[1] -> null();
     };
-
-    df_push.run_available();
+    assert_eq!((0, 0), (df_push.current_tick(), df_push.current_stratum()));
+    df_push.run_tick();
+    assert_eq!((1, 0), (df_push.current_tick(), df_push.current_stratum()));
 
     let out: HashSet<_> = collect_ready(&mut out_recv);
     for pair in [(1, 4), (2, 8)] {
@@ -138,14 +149,17 @@ pub fn test_fold_sort() {
             .expect("No graph found, maybe failed to parse.")
             .to_mermaid()
     );
-    df.run_available();
+    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    df.run_tick();
+    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
 
     print!("\nA: ");
 
     items_send.send(9).unwrap();
     items_send.send(2).unwrap();
     items_send.send(5).unwrap();
-    df.run_available();
+    df.run_tick();
+    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
 
     print!("\nB: ");
 
@@ -154,7 +168,8 @@ pub fn test_fold_sort() {
     items_send.send(2).unwrap();
     items_send.send(0).unwrap();
     items_send.send(3).unwrap();
-    df.run_available();
+    df.run_tick();
+    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
 
     println!();
 }

--- a/hydroflow/tests/surface_group_by.rs
+++ b/hydroflow/tests/surface_group_by.rs
@@ -19,7 +19,9 @@ pub fn test_group_by_infer_basic() {
             -> group_by::<'static>(|| 0, |old: &mut u32, val: u32| *old += val)
             -> for_each(|(k, v)| println!("{}: {}", k, v));
     };
-    df.run_available();
+    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    df.run_tick();
+    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
 }
 
 #[test]
@@ -39,14 +41,17 @@ pub fn test_group_by_tick() {
             .expect("No graph found, maybe failed to parse.")
             .to_mermaid()
     );
-    df.run_available();
+    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    df.run_tick();
+    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
 
     items_send.send((0, vec![1, 2])).unwrap();
     items_send.send((0, vec![3, 4])).unwrap();
     items_send.send((1, vec![1])).unwrap();
     items_send.send((1, vec![1, 2])).unwrap();
-    df.run_available();
+    df.run_tick();
 
+    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
     assert_eq!(
         [(0, vec![1, 2, 3, 4]), (1, vec![1, 1, 2])]
             .into_iter()
@@ -58,8 +63,9 @@ pub fn test_group_by_tick() {
     items_send.send((0, vec![7, 8])).unwrap();
     items_send.send((1, vec![10])).unwrap();
     items_send.send((1, vec![11, 12])).unwrap();
-    df.run_available();
+    df.run_tick();
 
+    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
     assert_eq!(
         [(0, vec![5, 6, 7, 8]), (1, vec![10, 11, 12])]
             .into_iter()
@@ -85,14 +91,17 @@ pub fn test_group_by_static() {
             .expect("No graph found, maybe failed to parse.")
             .to_mermaid()
     );
-    df.run_available();
+    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    df.run_tick();
+    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
 
     items_send.send((0, vec![1, 2])).unwrap();
     items_send.send((0, vec![3, 4])).unwrap();
     items_send.send((1, vec![1])).unwrap();
     items_send.send((1, vec![1, 2])).unwrap();
-    df.run_available();
+    df.run_tick();
 
+    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
     assert_eq!(
         [(0, vec![1, 2, 3, 4]), (1, vec![1, 1, 2])]
             .into_iter()
@@ -104,8 +113,9 @@ pub fn test_group_by_static() {
     items_send.send((0, vec![7, 8])).unwrap();
     items_send.send((1, vec![10])).unwrap();
     items_send.send((1, vec![11, 12])).unwrap();
-    df.run_available();
+    df.run_tick();
 
+    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
     assert_eq!(
         [
             (0, vec![1, 2, 3, 4, 5, 6, 7, 8]),

--- a/hydroflow/tests/surface_reduce.rs
+++ b/hydroflow/tests/surface_reduce.rs
@@ -17,11 +17,13 @@ pub fn test_reduce_tick() {
             .expect("No graph found, maybe failed to parse.")
             .to_mermaid()
     );
+    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
 
     items_send.send(1).unwrap();
     items_send.send(2).unwrap();
-    df.run_available();
+    df.run_tick();
 
+    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
     assert_eq!(
         &[3],
         &*hydroflow::util::collect_ready::<Vec<_>, _>(&mut result_recv)
@@ -29,8 +31,9 @@ pub fn test_reduce_tick() {
 
     items_send.send(3).unwrap();
     items_send.send(4).unwrap();
-    df.run_available();
+    df.run_tick();
 
+    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
     assert_eq!(
         &[7],
         &*hydroflow::util::collect_ready::<Vec<_>, _>(&mut result_recv)
@@ -54,11 +57,13 @@ pub fn test_reduce_static() {
             .expect("No graph found, maybe failed to parse.")
             .to_mermaid()
     );
+    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
 
     items_send.send(1).unwrap();
     items_send.send(2).unwrap();
-    df.run_available();
+    df.run_tick();
 
+    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
     assert_eq!(
         &[3],
         &*hydroflow::util::collect_ready::<Vec<_>, _>(&mut result_recv)
@@ -66,8 +71,9 @@ pub fn test_reduce_static() {
 
     items_send.send(3).unwrap();
     items_send.send(4).unwrap();
-    df.run_available();
+    df.run_tick();
 
+    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
     assert_eq!(
         &[10],
         &*hydroflow::util::collect_ready::<Vec<_>, _>(&mut result_recv)
@@ -90,14 +96,17 @@ pub fn test_reduce_sum() {
             .expect("No graph found, maybe failed to parse.")
             .to_mermaid()
     );
-    df.run_available();
+    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    df.run_tick();
+    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
 
     print!("\nA: ");
 
     items_send.send(9).unwrap();
     items_send.send(2).unwrap();
     items_send.send(5).unwrap();
-    df.run_available();
+    df.run_tick();
+    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
 
     print!("\nB: ");
 
@@ -106,7 +115,8 @@ pub fn test_reduce_sum() {
     items_send.send(2).unwrap();
     items_send.send(0).unwrap();
     items_send.send(3).unwrap();
-    df.run_available();
+    df.run_tick();
+    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
 
     println!();
 }
@@ -136,7 +146,9 @@ pub fn test_reduce() {
             .expect("No graph found, maybe failed to parse.")
             .to_mermaid()
     );
-    df.run_available();
+    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    df.run_tick();
+    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
 
     println!("A");
 
@@ -144,11 +156,13 @@ pub fn test_reduce() {
     pairs_send.send((2, 4)).unwrap();
     pairs_send.send((3, 4)).unwrap();
     pairs_send.send((1, 2)).unwrap();
-    df.run_available();
+    df.run_tick();
+    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
 
     println!("B");
 
     pairs_send.send((0, 3)).unwrap();
     pairs_send.send((0, 3)).unwrap();
-    df.run_available();
+    df.run_tick();
+    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
 }

--- a/hydroflow/tests/surface_state_scheduling.rs
+++ b/hydroflow/tests/surface_state_scheduling.rs
@@ -1,0 +1,20 @@
+use hydroflow::hydroflow_syntax;
+use hydroflow::util::collect_ready;
+
+#[test]
+pub fn test_repeat_iter() {
+    let (out_send, mut out_recv) = hydroflow::util::unbounded_channel::<usize>();
+
+    let mut df = hydroflow_syntax! {
+        repeat_iter([1]) -> for_each(|v| out_send.send(v).unwrap());
+    };
+    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    df.run_tick();
+    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    df.run_tick();
+    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
+    df.run_tick();
+    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
+
+    assert_eq!(&[1, 1, 1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
+}

--- a/hydroflow/tests/surface_state_scheduling.rs
+++ b/hydroflow/tests/surface_state_scheduling.rs
@@ -54,3 +54,39 @@ pub fn test_fold_static() {
 
     assert_eq!(&[1, 1, 1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 }
+
+#[test]
+pub fn test_reduce_tick() {
+    let (out_send, mut out_recv) = hydroflow::util::unbounded_channel::<usize>();
+
+    let mut df = hydroflow_syntax! {
+        source_iter([1]) -> reduce::<'tick>(|a, b| a + b) -> for_each(|v| out_send.send(v).unwrap());
+    };
+    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    df.run_tick();
+    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    df.run_tick();
+    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
+    df.run_tick();
+    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
+
+    assert_eq!(&[1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
+}
+
+#[test]
+pub fn test_reduce_static() {
+    let (out_send, mut out_recv) = hydroflow::util::unbounded_channel::<usize>();
+
+    let mut df = hydroflow_syntax! {
+        source_iter([1]) -> reduce::<'static>(|a, b| a + b) -> for_each(|v| out_send.send(v).unwrap());
+    };
+    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    df.run_tick();
+    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    df.run_tick();
+    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
+    df.run_tick();
+    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
+
+    assert_eq!(&[1, 1, 1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
+}

--- a/hydroflow_internalmacro/src/lib.rs
+++ b/hydroflow_internalmacro/src/lib.rs
@@ -119,4 +119,9 @@ const DOCTEST_HYDROFLOW_PREFIX: &str = "\
 # let mut __hf = hydroflow::hydroflow_syntax! {";
 const DOCTEST_HYDROFLOW_SUFFIX: &str = "\
 # };
-# __hf.run_available();";
+# for _ in 0..100 {
+#     if !__hf.run_tick() {
+#         // No work done.
+#         break;
+#     }
+# }";

--- a/hydroflow_lang/src/graph/ops/reduce.rs
+++ b/hydroflow_lang/src/graph/ops/reduce.rs
@@ -62,12 +62,13 @@ pub const REDUCE: OperatorConstraints = OperatorConstraints {
         let func = &arguments[0];
         let reducedata_ident = wc.make_ident("reducedata_ident");
 
-        let (write_prologue, write_iterator) = match persistence {
+        let (write_prologue, write_iterator, write_iterator_after) = match persistence {
             Persistence::Tick => (
                 Default::default(),
                 quote_spanned! {op_span=>
                     let #ident = #input.reduce(#func).into_iter();
                 },
+                Default::default(),
             ),
             Persistence::Static => (
                 quote_spanned! {op_span=>
@@ -86,13 +87,16 @@ pub const REDUCE: OperatorConstraints = OperatorConstraints {
                         opt.into_iter()
                     };
                 },
+                quote_spanned! {op_span=>
+                    #context.schedule_subgraph(#context.current_subgraph());
+                },
             ),
         };
 
         Ok(OperatorWriteOutput {
             write_prologue,
             write_iterator,
-            ..Default::default()
+            write_iterator_after,
         })
     }),
 };

--- a/hydroflow_lang/src/graph/ops/repeat_iter.rs
+++ b/hydroflow_lang/src/graph/ops/repeat_iter.rs
@@ -24,7 +24,7 @@ pub const REPEAT_ITER: OperatorConstraints = OperatorConstraints {
                  },
                  _| {
         let write_iterator = quote_spanned! {op_span=>
-            let mut #ident = {
+            let #ident = {
                 #[inline(always)]
                 fn check_iter<IntoIter: ::std::iter::IntoIterator<Item = Item>, Item>(into_iter: IntoIter) -> impl ::std::iter::Iterator<Item = Item> {
                     ::std::iter::IntoIterator::into_iter(into_iter)

--- a/hydroflow_lang/src/graph/ops/repeat_iter.rs
+++ b/hydroflow_lang/src/graph/ops/repeat_iter.rs
@@ -18,7 +18,9 @@ pub const REPEAT_ITER: OperatorConstraints = OperatorConstraints {
     ports_inn: None,
     ports_out: None,
     input_delaytype_fn: &|_| None,
-    write_fn: &(|&WriteContextArgs { op_span, .. },
+    write_fn: &(|&WriteContextArgs {
+                     context, op_span, ..
+                 },
                  &WriteIteratorArgs {
                      ident, arguments, ..
                  },
@@ -32,8 +34,12 @@ pub const REPEAT_ITER: OperatorConstraints = OperatorConstraints {
                 check_iter(#arguments)
             };
         };
+        let write_iterator_after = quote_spanned! {op_span=>
+            #context.schedule_subgraph(#context.current_subgraph());
+        };
         Ok(OperatorWriteOutput {
             write_iterator,
+            write_iterator_after,
             ..Default::default()
         })
     }),


### PR DESCRIPTION
    commit 955167119249895e3cf1eb472c57f334abfb95e6
    Author: Mingwei Samuel <mingwei.samuel@gmail.com>
    Date:   Wed Feb 8 11:18:31 2023 -0800
    
        Only receive external events at the start of a tick, before stratum 0
    
        Start for #143 #364
    
        Supersedes #353
    
        Related #348 #357
    
    commit e0d243d9ab918d12d30f353372de4cab6260949d
    Author: Mingwei Samuel <mingwei.samuel@gmail.com>
    Date:   Wed Feb 8 11:19:49 2023 -0800
    
        Remove unnecessary `mut` from `repeat_iter`
    
    commit e4ef406c53d54cad9a2607b1cb89a39002ee202b
    Author: Mingwei Samuel <mingwei.samuel@gmail.com>
    Date:   Wed Feb 8 11:32:20 2023 -0800
    
        `repeat_iter` now repeats via self-scheduling #143 #364
    
    commit 95042015eb297071098ad9d220030a8cf3fc5878 (HEAD -> event-timing-2, fork/event-timing-2)
    Author: Mingwei Samuel <mingwei.samuel@gmail.com>
    Date:   Wed Feb 8 11:36:11 2023 -0800
    
        `fold` now self-schedules #143 #364