### PR TITLE
Remove diagnostics from default features

### DIFF
--- a/hydroflow/Cargo.toml
+++ b/hydroflow/Cargo.toml
@@ -60,6 +60,10 @@ tokio-util = { version = "0.7.4", features = [ "net", "codec" ] }
 variadics = { path = "../variadics" }
 rustc-hash = "1.1.0"
 
+# Diagnostics feature does not work on wasm32.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+hydroflow_macro = { optional = true, path = "../hydroflow_macro", features = ["diagnostics"] }
+
 [dev-dependencies]
 chrono = { version = "0.4.20", features = [ "serde" ], default-features = false }
 clap = { version = "4.0.29", features = [ "derive" ] }

--- a/hydroflow_datalog/Cargo.toml
+++ b/hydroflow_datalog/Cargo.toml
@@ -13,3 +13,7 @@ syn = { version = "1.0.0", features = [ "parsing", "extra-traits" ] }
 proc-macro2 = "1.0.27"
 proc-macro-crate = "1.1.0"
 hydroflow_datalog_core = { path = "../hydroflow_datalog_core" }
+
+# Diagnostics feature does not work on wasm32.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+hydroflow_datalog_core = { path = "../hydroflow_datalog_core", features = ["diagnostics" ] }

--- a/hydroflow_datalog_core/Cargo.toml
+++ b/hydroflow_datalog_core/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 path = "src/lib.rs"
 
 [features]
-default = [ "diagnostics" ]
+default = []
 diagnostics = [ "hydroflow_lang/diagnostics" ]
 
 [dependencies]
@@ -17,7 +17,7 @@ syn = { version = "1.0.0", features = [ "parsing", "extra-traits" ] }
 proc-macro2 = "1.0.27"
 proc-macro-crate = "1.1.0"
 rust-sitter = "0.2.1"
-hydroflow_lang = { path = "../hydroflow_lang", default-features = false }
+hydroflow_lang = { path = "../hydroflow_lang" }
 
 [build-dependencies]
 rust-sitter-tool = "0.2.1"

--- a/hydroflow_lang/Cargo.toml
+++ b/hydroflow_lang/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = [ "diagnostics" ]
+default = []
 diagnostics = []
 
 [dependencies]

--- a/hydroflow_macro/Cargo.toml
+++ b/hydroflow_macro/Cargo.toml
@@ -3,6 +3,10 @@ name = "hydroflow_macro"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = []
+diagnostics = [ "hydroflow_lang/diagnostics" ]
+
 [lib]
 proc-macro = true
 


### PR DESCRIPTION
Diagnostics is still enabled for hydroflow and hydroflow_data when building non-wasm32 targets.

PR for #329.