### PR TITLE
Fix `run_async()` not yielding with replay (stateful) operators

### DIFF
--- a/hydroflow_lang/src/graph/ops/dest_sink.rs
+++ b/hydroflow_lang/src/graph/ops/dest_sink.rs
@@ -36,7 +36,7 @@ use quote::quote_spanned;
 /// // Only 5 elements received due to buffer size.
 /// // (Note that if we were using a multi-threaded executor instead of `current_thread` it would
 /// // be possible for more items to be added as they're removed, resulting in >5 collected.)
-/// let out: Vec<_> = hydroflow::util::collect_ready(&mut recv);
+/// let out: Vec<_> = hydroflow::util::ready_iter(&mut recv).collect();
 /// assert_eq!(&[0, 1, 2, 3, 4], &*out);
 /// # }
 /// ```


### PR DESCRIPTION
Also adds `hydroflow::util::collect_ready_async` due to 128-batching issue with `collect_ready` while in a tokio runtime.