### PR TITLE
Allow alias name assignment without any arrow in surface syntax, closes #266

### DIFF
--- a/hydroflow/examples/rga/datalog_agg.rs
+++ b/hydroflow/examples/rga/datalog_agg.rs
@@ -21,7 +21,7 @@ pub(crate) fn rga_datalog_agg(
 
         // firstLastChild(Parent, max<Child>, min<Child) :- insertAfter(Child, Parent)
         firstLastChild = insertAfter[firstLastChild]
-            -> map(|(c, p)| (p, c))[firstLastChild]
+            -> map(|(c, p)| (p, c))
             -> group_by::<'static, Timestamp, (Timestamp, Timestamp)>(|| (Timestamp{node_ts: 0, node_id: 0}, Timestamp{node_ts: std::usize::MAX, node_id: std::usize::MAX}),
                                                                       |(first, last): &mut (Timestamp, Timestamp), s2: Timestamp| {
                                                                         if s2 > *first {*first = s2};

--- a/hydroflow/tests/compile-fail/surface_demux_port_elided.stderr
+++ b/hydroflow/tests/compile-fail/surface_demux_port_elided.stderr
@@ -1,8 +1,8 @@
 error: Output port from `demux(..)` must be specified and must be a valid identifier.
-  --> tests/compile-fail/surface_demux_port_elided.rs:15:18
+  --> tests/compile-fail/surface_demux_port_elided.rs:15:9
    |
 15 |         my_demux -> for_each(std::mem::drop);
-   |                  ^^
+   |         ^^^^^^^^
 
 error: `demux(..)` closure argument `odds` missing corresponding output port.
  --> tests/compile-fail/surface_demux_port_elided.rs:6:72

--- a/hydroflow/tests/compile-fail/surface_port_join.stderr
+++ b/hydroflow/tests/compile-fail/surface_port_join.stderr
@@ -1,14 +1,14 @@
 error: Unexpected input port. Expected one of: `0`, `1`
- --> tests/compile-fail/surface_port_join.rs:6:39
+ --> tests/compile-fail/surface_port_join.rs:6:42
   |
 6 |         source_iter([(1, 1), (2, 2)]) -> j;
-  |                                       ^^
+  |                                          ^
 
 error: Unexpected input port. Expected one of: `0`, `1`
- --> tests/compile-fail/surface_port_join.rs:7:39
+ --> tests/compile-fail/surface_port_join.rs:7:42
   |
 7 |         source_iter([(3, 3), (4, 4)]) -> j;
-  |                                       ^^
+  |                                          ^
 
 error: Missing expected input port(s): `0`, `1`.
  --> tests/compile-fail/surface_port_join.rs:5:13

--- a/hydroflow/tests/compile-fail/surface_port_naked_overwrite_knot_a.rs
+++ b/hydroflow/tests/compile-fail/surface_port_naked_overwrite_knot_a.rs
@@ -1,0 +1,17 @@
+use hydroflow::hydroflow_syntax;
+
+fn main() {
+    let mut df = hydroflow_syntax! {
+        pivot = merge() -> tee();
+
+        inn_0 = [0]pivot;
+        inn_1 = [1]pivot;
+
+        out_0 = pivot[0];
+        out_1 = pivot[1];
+
+        out_0[0] -> inn_0; // Error: `pivot[0][0]`
+        out_1 -> inn_1;
+    };
+    df.run_available();
+}

--- a/hydroflow/tests/compile-fail/surface_port_naked_overwrite_knot_a.stderr
+++ b/hydroflow/tests/compile-fail/surface_port_naked_overwrite_knot_a.stderr
@@ -1,0 +1,11 @@
+error: Indexing on output is overwritten below ($DIR/tests/compile-fail/surface_port_naked_overwrite_knot_a.rs:13:15) (1/2)
+  --> tests/compile-fail/surface_port_naked_overwrite_knot_a.rs:10:23
+   |
+10 |         out_0 = pivot[0];
+   |                       ^
+
+error: Cannot index on already-indexed output, previously indexed above ($DIR/tests/compile-fail/surface_port_naked_overwrite_knot_a.rs:10:23) (2/2)
+  --> tests/compile-fail/surface_port_naked_overwrite_knot_a.rs:13:15
+   |
+13 |         out_0[0] -> inn_0; // Error: `pivot[0][0]`
+   |               ^

--- a/hydroflow/tests/compile-fail/surface_port_naked_overwrite_knot_b_inn.rs
+++ b/hydroflow/tests/compile-fail/surface_port_naked_overwrite_knot_b_inn.rs
@@ -1,0 +1,14 @@
+use hydroflow::hydroflow_syntax;
+
+fn main() {
+    let mut df = hydroflow_syntax! {
+        pivot = merge() -> tee();
+
+        x_0 = [0]pivot;
+        x_1 = [1]pivot;
+
+        x_0 -> [0]x_0;
+        x_1[0] -> [1]x_1; // Error: `[1][1]pivot`
+    };
+    df.run_available();
+}

--- a/hydroflow/tests/compile-fail/surface_port_naked_overwrite_knot_b_inn.stderr
+++ b/hydroflow/tests/compile-fail/surface_port_naked_overwrite_knot_b_inn.stderr
@@ -1,0 +1,23 @@
+error: Indexing on input is overwritten below ($DIR/tests/compile-fail/surface_port_naked_overwrite_knot_b_inn.rs:10:17) (1/2)
+ --> tests/compile-fail/surface_port_naked_overwrite_knot_b_inn.rs:7:16
+  |
+7 |         x_0 = [0]pivot;
+  |                ^
+
+error: Cannot index on already-indexed input, previously indexed above ($DIR/tests/compile-fail/surface_port_naked_overwrite_knot_b_inn.rs:7:16) (2/2)
+  --> tests/compile-fail/surface_port_naked_overwrite_knot_b_inn.rs:10:17
+   |
+10 |         x_0 -> [0]x_0;
+   |                 ^
+
+error: Indexing on input is overwritten below ($DIR/tests/compile-fail/surface_port_naked_overwrite_knot_b_inn.rs:11:20) (1/2)
+ --> tests/compile-fail/surface_port_naked_overwrite_knot_b_inn.rs:8:16
+  |
+8 |         x_1 = [1]pivot;
+  |                ^
+
+error: Cannot index on already-indexed input, previously indexed above ($DIR/tests/compile-fail/surface_port_naked_overwrite_knot_b_inn.rs:8:16) (2/2)
+  --> tests/compile-fail/surface_port_naked_overwrite_knot_b_inn.rs:11:20
+   |
+11 |         x_1[0] -> [1]x_1; // Error: `[1][1]pivot`
+   |                    ^

--- a/hydroflow/tests/compile-fail/surface_port_naked_overwrite_knot_b_out.rs
+++ b/hydroflow/tests/compile-fail/surface_port_naked_overwrite_knot_b_out.rs
@@ -1,0 +1,14 @@
+use hydroflow::hydroflow_syntax;
+
+fn main() {
+    let mut df = hydroflow_syntax! {
+        pivot = merge() -> tee();
+
+        x_0 = pivot[0];
+        x_1 = pivot[1];
+
+        x_0 -> [0]x_0;
+        x_1[0] -> [1]x_1; // Error: `pivot[1][0]`
+    };
+    df.run_available();
+}

--- a/hydroflow/tests/compile-fail/surface_port_naked_overwrite_knot_b_out.stderr
+++ b/hydroflow/tests/compile-fail/surface_port_naked_overwrite_knot_b_out.stderr
@@ -1,0 +1,11 @@
+error: Indexing on output is overwritten below ($DIR/tests/compile-fail/surface_port_naked_overwrite_knot_b_out.rs:11:13) (1/2)
+ --> tests/compile-fail/surface_port_naked_overwrite_knot_b_out.rs:8:21
+  |
+8 |         x_1 = pivot[1];
+  |                     ^
+
+error: Cannot index on already-indexed output, previously indexed above ($DIR/tests/compile-fail/surface_port_naked_overwrite_knot_b_out.rs:8:21) (2/2)
+  --> tests/compile-fail/surface_port_naked_overwrite_knot_b_out.rs:11:13
+   |
+11 |         x_1[0] -> [1]x_1; // Error: `pivot[1][0]`
+   |             ^

--- a/hydroflow/tests/compile-fail/surface_port_naked_overwrite_simple.rs
+++ b/hydroflow/tests/compile-fail/surface_port_naked_overwrite_simple.rs
@@ -1,0 +1,11 @@
+use hydroflow::hydroflow_syntax;
+
+fn main() {
+    let mut df = hydroflow_syntax! {
+        id = identity();
+        inn = [0]id;
+        out = id[0];
+        out[0] -> [0]inn; // Error, equivalent to: `[0][0]id[0][0]`
+    };
+    df.run_available();
+}

--- a/hydroflow/tests/compile-fail/surface_port_naked_overwrite_simple.stderr
+++ b/hydroflow/tests/compile-fail/surface_port_naked_overwrite_simple.stderr
@@ -1,0 +1,23 @@
+error: Indexing on output is overwritten below ($DIR/tests/compile-fail/surface_port_naked_overwrite_simple.rs:8:13) (1/2)
+ --> tests/compile-fail/surface_port_naked_overwrite_simple.rs:7:18
+  |
+7 |         out = id[0];
+  |                  ^
+
+error: Cannot index on already-indexed output, previously indexed above ($DIR/tests/compile-fail/surface_port_naked_overwrite_simple.rs:7:18) (2/2)
+ --> tests/compile-fail/surface_port_naked_overwrite_simple.rs:8:13
+  |
+8 |         out[0] -> [0]inn; // Error, equivalent to: `[0][0]id[0][0]`
+  |             ^
+
+error: Indexing on input is overwritten below ($DIR/tests/compile-fail/surface_port_naked_overwrite_simple.rs:8:20) (1/2)
+ --> tests/compile-fail/surface_port_naked_overwrite_simple.rs:6:16
+  |
+6 |         inn = [0]id;
+  |                ^
+
+error: Cannot index on already-indexed input, previously indexed above ($DIR/tests/compile-fail/surface_port_naked_overwrite_simple.rs:6:16) (2/2)
+ --> tests/compile-fail/surface_port_naked_overwrite_simple.rs:8:20
+  |
+8 |         out[0] -> [0]inn; // Error, equivalent to: `[0][0]id[0][0]`
+  |                    ^

--- a/hydroflow/tests/surface_parser.rs
+++ b/hydroflow/tests/surface_parser.rs
@@ -60,3 +60,83 @@ pub fn test_parser_basic() {
         (h[2] -> [1]g);
     }
 }
+
+#[test]
+pub fn test_parser_port_reassign() {
+    hydroflow_parser! {
+        id = identity();
+        inn = id;
+        out = id;
+        out -> inn;
+    };
+
+    hydroflow_parser! {
+        id = identity();
+        inn = id;
+        out = id;
+        out[0] -> [0]inn;
+    };
+
+    hydroflow_parser! {
+        id = identity();
+        inn = id;
+        out = id;
+        [0]out[0] -> [0]inn[0]; // ?
+    };
+}
+
+#[test]
+pub fn test_parser_port_naked_basic() {
+    hydroflow_parser! {
+        id = identity();
+        inn = [0]id;
+        out = id[0];
+        out -> inn;
+    };
+}
+
+#[test]
+pub fn test_parser_port_naked_knot() {
+    hydroflow_parser! {
+        pivot = merge() -> tee();
+
+        inn_0 = [0]pivot;
+        inn_1 = [1]pivot;
+
+        out_0 = pivot[0];
+        out_1 = pivot[1];
+
+        out_0 -> inn_0;
+        out_1 -> inn_1;
+    };
+
+    hydroflow_parser! {
+        pivot = merge() -> tee();
+
+        x_0 = [0]pivot[0];
+        x_1 = [1]pivot[1];
+
+        x_0 -> x_0;
+        x_1 -> x_1;
+    };
+
+    hydroflow_parser! {
+        pivot = merge() -> tee();
+
+        x_0 = pivot[0];
+        x_1 = pivot[1];
+
+        x_0 -> [0]x_0;
+        x_1 -> [1]x_1;
+    };
+
+    hydroflow_parser! {
+        pivot = merge() -> tee();
+
+        x_0 = pivot;
+        x_1 = pivot;
+
+        x_0[0] -> [0]x_0;
+        x_1[1] -> [1]x_1;
+    };
+}


### PR DESCRIPTION
Port indexing (`[0]my_var` or `my_var[2]`) is now associated with the
pipeline (variable name or operator[s]) rather than the arrow connector.
Handled as such in parsing and graph assembly.

Limitation: variable names that are only (naked) aliases of other names
will not show up in visualization graphs for the sake of #327. This is
because only operators and not edges are associated with variable names.

closes #266