### PR TITLE
Refactor `OpConstraints` fns, use lookup helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,6 +1439,7 @@ name = "hydroflow_lang"
 version = "0.1.0"
 dependencies = [
  "hydroflow_internalmacro",
+ "once_cell",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -1872,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "oorandom"

--- a/hydroflow_lang/Cargo.toml
+++ b/hydroflow_lang/Cargo.toml
@@ -9,6 +9,7 @@ diagnostics = []
 
 [dependencies]
 hydroflow_internalmacro = { path = "../hydroflow_internalmacro" }
+once_cell = "1.17"
 proc-macro2 = { version = "1.0.0", features = ["span-locations"] }
 quote = "1.0.0"
 regex = "1.7.0"

--- a/hydroflow_lang/src/graph/ops/anti_join.rs
+++ b/hydroflow_lang/src/graph/ops/anti_join.rs
@@ -33,22 +33,22 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    ports_inn: Some(&|| super::PortListSpec::Fixed(parse_quote! { pos, neg })),
+    ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { pos, neg })),
     ports_out: None,
-    input_delaytype_fn: &|idx| match idx {
+    input_delaytype_fn: |idx| match idx {
         PortIndexValue::Path(path) if "neg" == path.to_token_stream().to_string() => {
             Some(DelayType::Stratum)
         }
         _else => None,
     },
-    write_fn: &(|wc @ &WriteContextArgs {
-                     root,
-                     context,
-                     op_span,
-                     ..
-                 },
-                 &WriteIteratorArgs { ident, inputs, .. },
-                 _| {
+    write_fn: |wc @ &WriteContextArgs {
+                   root,
+                   context,
+                   op_span,
+                   ..
+               },
+               &WriteIteratorArgs { ident, inputs, .. },
+               _| {
         let handle_ident = wc.make_ident("diffdata_handle");
         let write_prologue = quote_spanned! {op_span=>
             let #handle_ident = df.add_state(std::cell::RefCell::new(
@@ -75,5 +75,5 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/cross_join.rs
+++ b/hydroflow_lang/src/graph/ops/cross_join.rs
@@ -44,12 +44,12 @@ pub const CROSS_JOIN: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=2),
     type_args: RANGE_0,
     is_external_input: false,
-    ports_inn: Some(&(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 }))),
+    ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|wc @ &WriteContextArgs { op_span, .. },
-                 wi @ &WriteIteratorArgs { ident, inputs, .. },
-                 diagnostics| {
+    input_delaytype_fn: |_| None,
+    write_fn: |wc @ &WriteContextArgs { op_span, .. },
+               wi @ &WriteIteratorArgs { ident, inputs, .. },
+               diagnostics| {
         let mut output = (super::join::JOIN.write_fn)(wc, wi, diagnostics)?;
 
         let lhs = &inputs[0];
@@ -63,5 +63,5 @@ pub const CROSS_JOIN: OperatorConstraints = OperatorConstraints {
         );
 
         Ok(output)
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/demux.rs
+++ b/hydroflow_lang/src/graph/ops/demux.rs
@@ -55,19 +55,19 @@ pub const DEMUX: OperatorConstraints = OperatorConstraints {
     type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
-    ports_out: Some(&(|| PortListSpec::Variadic)),
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|&WriteContextArgs { root, op_span, .. },
-                 &WriteIteratorArgs {
-                     ident,
-                     outputs,
-                     output_ports,
-                     arguments,
-                     op_name,
-                     is_pull,
-                     ..
-                 },
-                 diagnostics| {
+    ports_out: Some(|| PortListSpec::Variadic),
+    input_delaytype_fn: |_| None,
+    write_fn: |&WriteContextArgs { root, op_span, .. },
+               &WriteIteratorArgs {
+                   ident,
+                   outputs,
+                   output_ports,
+                   arguments,
+                   op_name,
+                   is_pull,
+                   ..
+               },
+               diagnostics| {
         assert!(!is_pull);
         let func = &arguments[0];
         let Expr::Closure(func) = func else {
@@ -175,7 +175,7 @@ pub const DEMUX: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };
 
 fn extract_closure_idents(arg2: &Pat) -> HashMap<Ident, usize> {

--- a/hydroflow_lang/src/graph/ops/dest_sink.rs
+++ b/hydroflow_lang/src/graph/ops/dest_sink.rs
@@ -93,12 +93,12 @@ pub const DEST_SINK: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|wc @ &WriteContextArgs { root, op_span, .. },
-                 &WriteIteratorArgs {
-                     ident, arguments, ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| None,
+    write_fn: |wc @ &WriteContextArgs { root, op_span, .. },
+               &WriteIteratorArgs {
+                   ident, arguments, ..
+               },
+               _| {
         let sink_arg = &arguments[0];
 
         let send_ident = wc.make_ident("item_send");
@@ -146,5 +146,5 @@ pub const DEST_SINK: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/dest_sink_serde.rs
+++ b/hydroflow_lang/src/graph/ops/dest_sink_serde.rs
@@ -34,12 +34,12 @@ pub const DEST_SINK_SERDE: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|wc @ &WriteContextArgs { root, op_span, .. },
-                 &WriteIteratorArgs {
-                     ident, arguments, ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| None,
+    write_fn: |wc @ &WriteContextArgs { root, op_span, .. },
+               &WriteIteratorArgs {
+                   ident, arguments, ..
+               },
+               _| {
         let sink_arg = &arguments[0];
 
         let send_ident = wc.make_ident("item_send");
@@ -78,5 +78,5 @@ pub const DEST_SINK_SERDE: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/difference.rs
+++ b/hydroflow_lang/src/graph/ops/difference.rs
@@ -31,22 +31,22 @@ pub const DIFFERENCE: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    ports_inn: Some(&|| super::PortListSpec::Fixed(parse_quote! { pos, neg })),
+    ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { pos, neg })),
     ports_out: None,
-    input_delaytype_fn: &|idx| match idx {
+    input_delaytype_fn: |idx| match idx {
         PortIndexValue::Path(path) if "neg" == path.to_token_stream().to_string() => {
             Some(DelayType::Stratum)
         }
         _else => None,
     },
-    write_fn: &(|wc @ &WriteContextArgs {
-                     root,
-                     context,
-                     op_span,
-                     ..
-                 },
-                 &WriteIteratorArgs { ident, inputs, .. },
-                 _| {
+    write_fn: |wc @ &WriteContextArgs {
+                   root,
+                   context,
+                   op_span,
+                   ..
+               },
+               &WriteIteratorArgs { ident, inputs, .. },
+               _| {
         let handle_ident = wc.make_ident("diffdata_handle");
         let write_prologue = quote_spanned! {op_span=>
             let #handle_ident = df.add_state(std::cell::RefCell::new(
@@ -73,5 +73,5 @@ pub const DIFFERENCE: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/filter.rs
+++ b/hydroflow_lang/src/graph/ops/filter.rs
@@ -30,17 +30,17 @@ pub const FILTER: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|&WriteContextArgs { root, op_span, .. },
-                 &WriteIteratorArgs {
-                     ident,
-                     inputs,
-                     outputs,
-                     arguments,
-                     is_pull,
-                     ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| None,
+    write_fn: |&WriteContextArgs { root, op_span, .. },
+               &WriteIteratorArgs {
+                   ident,
+                   inputs,
+                   outputs,
+                   arguments,
+                   is_pull,
+                   ..
+               },
+               _| {
         let write_iterator = if is_pull {
             let input = &inputs[0];
             quote_spanned! {op_span=>
@@ -56,5 +56,5 @@ pub const FILTER: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/filter_map.rs
+++ b/hydroflow_lang/src/graph/ops/filter_map.rs
@@ -27,17 +27,17 @@ pub const FILTER_MAP: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|&WriteContextArgs { root, op_span, .. },
-                 &WriteIteratorArgs {
-                     ident,
-                     inputs,
-                     outputs,
-                     arguments,
-                     is_pull,
-                     ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| None,
+    write_fn: |&WriteContextArgs { root, op_span, .. },
+               &WriteIteratorArgs {
+                   ident,
+                   inputs,
+                   outputs,
+                   arguments,
+                   is_pull,
+                   ..
+               },
+               _| {
         let write_iterator = if is_pull {
             let input = &inputs[0];
             quote_spanned! {op_span=>
@@ -53,5 +53,5 @@ pub const FILTER_MAP: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/flat_map.rs
+++ b/hydroflow_lang/src/graph/ops/flat_map.rs
@@ -31,17 +31,17 @@ pub const FLAT_MAP: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|&WriteContextArgs { root, op_span, .. },
-                 &WriteIteratorArgs {
-                     ident,
-                     inputs,
-                     outputs,
-                     arguments,
-                     is_pull,
-                     ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| None,
+    write_fn: |&WriteContextArgs { root, op_span, .. },
+               &WriteIteratorArgs {
+                   ident,
+                   inputs,
+                   outputs,
+                   arguments,
+                   is_pull,
+                   ..
+               },
+               _| {
         let write_iterator = if is_pull {
             let input = &inputs[0];
             quote_spanned! {op_span=>
@@ -60,5 +60,5 @@ pub const FLAT_MAP: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/flatten.rs
+++ b/hydroflow_lang/src/graph/ops/flatten.rs
@@ -27,16 +27,16 @@ pub const FLATTEN: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|&WriteContextArgs { root, op_span, .. },
-                 &WriteIteratorArgs {
-                     ident,
-                     inputs,
-                     outputs,
-                     is_pull,
-                     ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| None,
+    write_fn: |&WriteContextArgs { root, op_span, .. },
+               &WriteIteratorArgs {
+                   ident,
+                   inputs,
+                   outputs,
+                   is_pull,
+                   ..
+               },
+               _| {
         let write_iterator = if is_pull {
             let input = &inputs[0];
             quote_spanned! {op_span=>
@@ -52,5 +52,5 @@ pub const FLATTEN: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/fold.rs
+++ b/hydroflow_lang/src/graph/ops/fold.rs
@@ -43,19 +43,19 @@ pub const FOLD: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| Some(DelayType::Stratum),
-    write_fn: &(|wc @ &WriteContextArgs {
-                     context, op_span, ..
-                 },
-                 &WriteIteratorArgs {
-                     ident,
-                     inputs,
-                     persistence_args,
-                     arguments,
-                     is_pull,
-                     ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    write_fn: |wc @ &WriteContextArgs {
+                   context, op_span, ..
+               },
+               &WriteIteratorArgs {
+                   ident,
+                   inputs,
+                   persistence_args,
+                   arguments,
+                   is_pull,
+                   ..
+               },
+               _| {
         assert!(is_pull);
 
         let persistence = match *persistence_args {
@@ -108,5 +108,5 @@ pub const FOLD: OperatorConstraints = OperatorConstraints {
             write_iterator,
             write_iterator_after,
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/for_each.rs
+++ b/hydroflow_lang/src/graph/ops/for_each.rs
@@ -30,12 +30,12 @@ pub const FOR_EACH: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|&WriteContextArgs { root, op_span, .. },
-                 &WriteIteratorArgs {
-                     ident, arguments, ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| None,
+    write_fn: |&WriteContextArgs { root, op_span, .. },
+               &WriteIteratorArgs {
+                   ident, arguments, ..
+               },
+               _| {
         let write_iterator = quote_spanned! {op_span=>
             let #ident = #root::pusherator::for_each::ForEach::new(#arguments);
         };
@@ -43,5 +43,5 @@ pub const FOR_EACH: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/group_by.rs
+++ b/hydroflow_lang/src/graph/ops/group_by.rs
@@ -68,20 +68,20 @@ pub const GROUP_BY: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| Some(DelayType::Stratum),
-    write_fn: &(|wc @ &WriteContextArgs {
-                     context, op_span, ..
-                 },
-                 &WriteIteratorArgs {
-                     ident,
-                     inputs,
-                     persistence_args,
-                     type_args,
-                     arguments,
-                     is_pull,
-                     ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    write_fn: |wc @ &WriteContextArgs {
+                   context, op_span, ..
+               },
+               &WriteIteratorArgs {
+                   ident,
+                   inputs,
+                   persistence_args,
+                   type_args,
+                   arguments,
+                   is_pull,
+                   ..
+               },
+               _| {
         assert!(is_pull);
 
         let persistence = match *persistence_args {
@@ -155,5 +155,5 @@ pub const GROUP_BY: OperatorConstraints = OperatorConstraints {
             write_iterator,
             write_iterator_after,
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/identity.rs
+++ b/hydroflow_lang/src/graph/ops/identity.rs
@@ -22,6 +22,6 @@ pub const IDENTITY: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| None,
+    input_delaytype_fn: |_| None,
     write_fn: IDENTITY_WRITE_FN,
 };

--- a/hydroflow_lang/src/graph/ops/inspect.rs
+++ b/hydroflow_lang/src/graph/ops/inspect.rs
@@ -29,17 +29,17 @@ pub const INSPECT: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|&WriteContextArgs { root, op_span, .. },
-                 &WriteIteratorArgs {
-                     ident,
-                     inputs,
-                     outputs,
-                     arguments,
-                     is_pull,
-                     ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| None,
+    write_fn: |&WriteContextArgs { root, op_span, .. },
+               &WriteIteratorArgs {
+                   ident,
+                   inputs,
+                   outputs,
+                   arguments,
+                   is_pull,
+                   ..
+               },
+               _| {
         let write_iterator = if is_pull {
             let input = &inputs[0];
             quote_spanned! {op_span=>
@@ -55,5 +55,5 @@ pub const INSPECT: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/join.rs
+++ b/hydroflow_lang/src/graph/ops/join.rs
@@ -87,22 +87,22 @@ pub const JOIN: OperatorConstraints = OperatorConstraints {
     persistence_args: &(0..=2),
     type_args: RANGE_0,
     is_external_input: false,
-    ports_inn: Some(&(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 }))),
+    ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
     ports_out: None,
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|wc @ &WriteContextArgs {
-                     root,
-                     context,
-                     op_span,
-                     ..
-                 },
-                 &WriteIteratorArgs {
-                     ident,
-                     inputs,
-                     persistence_args,
-                     ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| None,
+    write_fn: |wc @ &WriteContextArgs {
+                   root,
+                   context,
+                   op_span,
+                   ..
+               },
+               &WriteIteratorArgs {
+                   ident,
+                   inputs,
+                   persistence_args,
+                   ..
+               },
+               _| {
         let persistences = match *persistence_args {
             [] => [Persistence::Static, Persistence::Static],
             [a] => [a, a],
@@ -183,5 +183,5 @@ pub const JOIN: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/map.rs
+++ b/hydroflow_lang/src/graph/ops/map.rs
@@ -31,17 +31,17 @@ pub const MAP: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|&WriteContextArgs { root, op_span, .. },
-                 &WriteIteratorArgs {
-                     ident,
-                     inputs,
-                     outputs,
-                     arguments,
-                     is_pull,
-                     ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| None,
+    write_fn: |&WriteContextArgs { root, op_span, .. },
+               &WriteIteratorArgs {
+                   ident,
+                   inputs,
+                   outputs,
+                   arguments,
+                   is_pull,
+                   ..
+               },
+               _| {
         let write_iterator = if is_pull {
             let input = &inputs[0];
             quote_spanned! {op_span=>
@@ -57,5 +57,5 @@ pub const MAP: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/merge.rs
+++ b/hydroflow_lang/src/graph/ops/merge.rs
@@ -32,16 +32,16 @@ pub const MERGE: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|&WriteContextArgs { op_span, .. },
-                 &WriteIteratorArgs {
-                     ident,
-                     inputs,
-                     outputs,
-                     is_pull,
-                     ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| None,
+    write_fn: |&WriteContextArgs { op_span, .. },
+               &WriteIteratorArgs {
+                   ident,
+                   inputs,
+                   outputs,
+                   is_pull,
+                   ..
+               },
+               _| {
         let write_iterator = if is_pull {
             let chains = inputs
                 .iter()
@@ -69,5 +69,5 @@ pub const MERGE: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/next_stratum.rs
+++ b/hydroflow_lang/src/graph/ops/next_stratum.rs
@@ -15,6 +15,6 @@ pub const NEXT_STRATUM: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| Some(DelayType::Stratum),
+    input_delaytype_fn: |_| Some(DelayType::Stratum),
     write_fn: IDENTITY_WRITE_FN,
 };

--- a/hydroflow_lang/src/graph/ops/next_tick.rs
+++ b/hydroflow_lang/src/graph/ops/next_tick.rs
@@ -45,6 +45,6 @@ pub const NEXT_TICK: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| Some(DelayType::Tick),
+    input_delaytype_fn: |_| Some(DelayType::Tick),
     write_fn: IDENTITY_WRITE_FN,
 };

--- a/hydroflow_lang/src/graph/ops/null.rs
+++ b/hydroflow_lang/src/graph/ops/null.rs
@@ -31,16 +31,16 @@ pub const NULL: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|&WriteContextArgs { root, op_span, .. },
-                 &WriteIteratorArgs {
-                     ident,
-                     inputs,
-                     outputs,
-                     is_pull,
-                     ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| None,
+    write_fn: |&WriteContextArgs { root, op_span, .. },
+               &WriteIteratorArgs {
+                   ident,
+                   inputs,
+                   outputs,
+                   is_pull,
+                   ..
+               },
+               _| {
         let write_iterator = if is_pull {
             quote_spanned! {op_span=>
                 (#(#inputs.for_each(std::mem::drop)),*);
@@ -57,5 +57,5 @@ pub const NULL: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/reduce.rs
+++ b/hydroflow_lang/src/graph/ops/reduce.rs
@@ -37,19 +37,19 @@ pub const REDUCE: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| Some(DelayType::Stratum),
-    write_fn: &(|wc @ &WriteContextArgs {
-                     context, op_span, ..
-                 },
-                 &WriteIteratorArgs {
-                     ident,
-                     inputs,
-                     persistence_args,
-                     arguments,
-                     is_pull,
-                     ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    write_fn: |wc @ &WriteContextArgs {
+                   context, op_span, ..
+               },
+               &WriteIteratorArgs {
+                   ident,
+                   inputs,
+                   persistence_args,
+                   arguments,
+                   is_pull,
+                   ..
+               },
+               _| {
         assert!(is_pull);
 
         let persistence = match *persistence_args {
@@ -98,5 +98,5 @@ pub const REDUCE: OperatorConstraints = OperatorConstraints {
             write_iterator,
             write_iterator_after,
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/repeat_iter.rs
+++ b/hydroflow_lang/src/graph/ops/repeat_iter.rs
@@ -17,14 +17,14 @@ pub const REPEAT_ITER: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|&WriteContextArgs {
-                     context, op_span, ..
-                 },
-                 &WriteIteratorArgs {
-                     ident, arguments, ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| None,
+    write_fn: |&WriteContextArgs {
+                   context, op_span, ..
+               },
+               &WriteIteratorArgs {
+                   ident, arguments, ..
+               },
+               _| {
         let write_iterator = quote_spanned! {op_span=>
             let #ident = {
                 #[inline(always)]
@@ -42,5 +42,5 @@ pub const REPEAT_ITER: OperatorConstraints = OperatorConstraints {
             write_iterator_after,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/sort.rs
+++ b/hydroflow_lang/src/graph/ops/sort.rs
@@ -52,18 +52,18 @@ pub const SORT: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| Some(DelayType::Stratum),
-    write_fn: &(|wc @ &WriteContextArgs {
-                     context, op_span, ..
-                 },
-                 &WriteIteratorArgs {
-                     ident,
-                     inputs,
-                     is_pull,
-                     persistence_args,
-                     ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    write_fn: |wc @ &WriteContextArgs {
+                   context, op_span, ..
+               },
+               &WriteIteratorArgs {
+                   ident,
+                   inputs,
+                   is_pull,
+                   persistence_args,
+                   ..
+               },
+               _| {
         assert!(is_pull);
 
         let persistence = match *persistence_args {
@@ -111,5 +111,5 @@ pub const SORT: OperatorConstraints = OperatorConstraints {
                 })
             }
         }
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/sort_by.rs
+++ b/hydroflow_lang/src/graph/ops/sort_by.rs
@@ -29,16 +29,16 @@ pub const SORT_BY: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| Some(DelayType::Stratum),
-    write_fn: &(|&WriteContextArgs { root, op_span, .. },
-                 &WriteIteratorArgs {
-                     ident,
-                     inputs,
-                     arguments,
-                     is_pull,
-                     ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    write_fn: |&WriteContextArgs { root, op_span, .. },
+               &WriteIteratorArgs {
+                   ident,
+                   inputs,
+                   arguments,
+                   is_pull,
+                   ..
+               },
+               _| {
         assert!(is_pull);
         let input = &inputs[0];
         let write_iterator = quote_spanned! {op_span=>
@@ -50,5 +50,5 @@ pub const SORT_BY: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/source_iter.rs
+++ b/hydroflow_lang/src/graph/ops/source_iter.rs
@@ -29,12 +29,12 @@ pub const SOURCE_ITER: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|wc @ &WriteContextArgs { op_span, .. },
-                 &WriteIteratorArgs {
-                     ident, arguments, ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| None,
+    write_fn: |wc @ &WriteContextArgs { op_span, .. },
+               &WriteIteratorArgs {
+                   ident, arguments, ..
+               },
+               _| {
         let iter_ident = wc.make_ident("iter");
         let write_prologue = quote_spanned! {op_span=>
             let mut #iter_ident = {
@@ -53,5 +53,5 @@ pub const SOURCE_ITER: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/source_stdin.rs
+++ b/hydroflow_lang/src/graph/ops/source_stdin.rs
@@ -31,15 +31,15 @@ pub const SOURCE_STDIN: OperatorConstraints = OperatorConstraints {
     is_external_input: true,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|wc @ &WriteContextArgs {
-                     root,
-                     context,
-                     op_span,
-                     ..
-                 },
-                 &WriteIteratorArgs { ident, .. },
-                 _| {
+    input_delaytype_fn: |_| None,
+    write_fn: |wc @ &WriteContextArgs {
+                   root,
+                   context,
+                   op_span,
+                   ..
+               },
+               &WriteIteratorArgs { ident, .. },
+               _| {
         let stream_ident = wc.make_ident("stream");
         let write_prologue = quote_spanned! {op_span=>
             let mut #stream_ident = {
@@ -62,5 +62,5 @@ pub const SOURCE_STDIN: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/source_stream.rs
+++ b/hydroflow_lang/src/graph/ops/source_stream.rs
@@ -36,17 +36,17 @@ pub const SOURCE_STREAM: OperatorConstraints = OperatorConstraints {
     is_external_input: true,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|wc @ &WriteContextArgs {
-                     root,
-                     context,
-                     op_span,
-                     ..
-                 },
-                 &WriteIteratorArgs {
-                     ident, arguments, ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| None,
+    write_fn: |wc @ &WriteContextArgs {
+                   root,
+                   context,
+                   op_span,
+                   ..
+               },
+               &WriteIteratorArgs {
+                   ident, arguments, ..
+               },
+               _| {
         let receiver = &arguments[0];
         let stream_ident = wc.make_ident("stream");
         let write_prologue = quote_spanned! {op_span=>
@@ -65,5 +65,5 @@ pub const SOURCE_STREAM: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/source_stream_serde.rs
+++ b/hydroflow_lang/src/graph/ops/source_stream_serde.rs
@@ -36,17 +36,17 @@ pub const SOURCE_STREAM_SERDE: OperatorConstraints = OperatorConstraints {
     is_external_input: true,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|wc @ &WriteContextArgs {
-                     root,
-                     context,
-                     op_span,
-                     ..
-                 },
-                 &WriteIteratorArgs {
-                     ident, arguments, ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| None,
+    write_fn: |wc @ &WriteContextArgs {
+                   root,
+                   context,
+                   op_span,
+                   ..
+               },
+               &WriteIteratorArgs {
+                   ident, arguments, ..
+               },
+               _| {
         let receiver = &arguments[0];
         let stream_ident = wc.make_ident("stream");
         let write_prologue = quote_spanned! {op_span=>
@@ -67,5 +67,5 @@ pub const SOURCE_STREAM_SERDE: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/tee.rs
+++ b/hydroflow_lang/src/graph/ops/tee.rs
@@ -31,16 +31,16 @@ pub const TEE: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|&WriteContextArgs { root, op_span, .. },
-                 &WriteIteratorArgs {
-                     ident,
-                     inputs,
-                     outputs,
-                     is_pull,
-                     ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| None,
+    write_fn: |&WriteContextArgs { root, op_span, .. },
+               &WriteIteratorArgs {
+                   ident,
+                   inputs,
+                   outputs,
+                   is_pull,
+                   ..
+               },
+               _| {
         let write_iterator = if !is_pull {
             let tees = outputs
                 .iter()
@@ -64,5 +64,5 @@ pub const TEE: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/unique.rs
+++ b/hydroflow_lang/src/graph/ops/unique.rs
@@ -55,18 +55,18 @@ pub const UNIQUE: OperatorConstraints = OperatorConstraints {
     is_external_input: false,
     ports_inn: None,
     ports_out: None,
-    input_delaytype_fn: &|_| Some(DelayType::Stratum),
-    write_fn: &(|wc @ &WriteContextArgs {
-                     op_span, context, ..
-                 },
-                 &WriteIteratorArgs {
-                     ident,
-                     inputs,
-                     is_pull,
-                     persistence_args,
-                     ..
-                 },
-                 _| {
+    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    write_fn: |wc @ &WriteContextArgs {
+                   op_span, context, ..
+               },
+               &WriteIteratorArgs {
+                   ident,
+                   inputs,
+                   is_pull,
+                   persistence_args,
+                   ..
+               },
+               _| {
         assert!(is_pull);
 
         let persistence = match *persistence_args {
@@ -112,5 +112,5 @@ pub const UNIQUE: OperatorConstraints = OperatorConstraints {
                 })
             }
         }
-    }),
+    },
 };

--- a/hydroflow_lang/src/graph/ops/unzip.rs
+++ b/hydroflow_lang/src/graph/ops/unzip.rs
@@ -27,16 +27,16 @@ pub const UNZIP: OperatorConstraints = OperatorConstraints {
     type_args: RANGE_0,
     is_external_input: false,
     ports_inn: None,
-    ports_out: Some(&|| super::PortListSpec::Fixed(parse_quote!(0, 1))),
-    input_delaytype_fn: &|_| None,
-    write_fn: &(|&WriteContextArgs { root, op_span, .. },
-                 &WriteIteratorArgs {
-                     ident,
-                     outputs,
-                     is_pull,
-                     ..
-                 },
-                 _| {
+    ports_out: Some(|| super::PortListSpec::Fixed(parse_quote!(0, 1))),
+    input_delaytype_fn: |_| None,
+    write_fn: |&WriteContextArgs { root, op_span, .. },
+               &WriteIteratorArgs {
+                   ident,
+                   outputs,
+                   is_pull,
+                   ..
+               },
+               _| {
         assert!(!is_pull);
         let output0 = &outputs[0];
         let output1 = &outputs[1];
@@ -47,5 +47,5 @@ pub const UNZIP: OperatorConstraints = OperatorConstraints {
             write_iterator,
             ..Default::default()
         })
-    }),
+    },
 };


### PR DESCRIPTION
Replaces `dyn Fn()` (dynamic dispatch trait) with `fn()` (fn pointer).
The main difference is that `dyn Fn()` has a notion of `&self` while
`fn()` is a pure function pointer. We don't use `&self` in any of the op
fns so `fn` makes more sense (and is `Send + Sync`).

Also use lookup helpers to avoid `.find()`ing the `OPERATORS` slice.