### PR TITLE
Make `DiMulGraph` fields private for encapsulation

### DIFF
--- a/hydroflow_lang/src/graph/di_mul_graph.rs
+++ b/hydroflow_lang/src/graph/di_mul_graph.rs
@@ -1,21 +1,31 @@
 use std::collections::BTreeSet;
+use std::fmt::Debug;
+use std::iter::FusedIterator;
 
 use slotmap::{Key, SecondaryMap, SlotMap};
 
 /// A directed multigraph where an vertex's inbound and outbound edges are indexed.
+///
+/// `DiMulGraph` does **not** allocate vertices `V`. The user shall use an external
+/// [`SlotMap<V, ...>`] for allocating vertices, which also allows the user to associate data `...`
+/// with each vertex.
+///
+/// `DiMulGraph` **does** allocate edges `E` as they are added. Additional data can be associated
+/// with edges via an external [`SlotMap<E, ...>`].
+/// [`SecondaryMap`]s.
 #[derive(Clone, Debug)]
 pub struct DiMulGraph<V, E>
 where
     V: Key,
     E: Key,
 {
-    /// Edges
-    pub(crate) edges: SlotMap<E, (V, V)>,
+    /// Edges (src, dst).
+    edges: SlotMap<E, (V, V)>,
 
     /// Successors for each vert.
-    pub(crate) succs: SecondaryMap<V, Vec<E>>,
+    succs: SecondaryMap<V, Vec<E>>,
     /// Predecessors for each vert.
-    pub(crate) preds: SecondaryMap<V, Vec<E>>,
+    preds: SecondaryMap<V, Vec<E>>,
 }
 impl<V, E> Default for DiMulGraph<V, E>
 where
@@ -36,10 +46,13 @@ where
     V: Key,
     E: Key,
 {
+    /// Creates an empty `DiMulGraph`.
     pub fn new() -> Self {
         Default::default()
     }
 
+    /// Creates a `DiMulGraph` with pre-allocated memory for `capacity` vertices and `capacity`
+    /// edges.
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             // Estimate 1 edge per vertex.
@@ -49,8 +62,8 @@ where
         }
     }
 
-    /// Assert that `self` is in a consistent state, for debugging.
-    /// This is computationally expensive for large graphs.
+    /// Assert that `self` is in a consistent state, for debugging. This is computationally
+    /// expensive for large graphs.
     pub fn assert_valid(&self) {
         // Ensure each edge exists in the adj lists.
         for (edge_id, &(src, dst)) in self.edges.iter() {
@@ -68,8 +81,8 @@ where
             assert_eq!(set.len(), pred_list.len());
         }
 
-        // Missing edges and duplicate edges could cancel each other out. But
-        // this would be caught by the above.
+        // Missing edges and duplicate edges could cancel each other out. But this would be caught
+        // by the above.
         assert_eq!(
             self.edges.len(),
             self.succs.values().map(|vec| vec.len()).sum::<usize>(),
@@ -82,6 +95,7 @@ where
         );
     }
 
+    /// HELPER, get the list out of the adj list `adj_list` for a particular vertex `v`.
     fn get_adj_edges(adj_list: &mut SecondaryMap<V, Vec<E>>, v: V) -> &mut Vec<E> {
         if !adj_list.contains_key(v) {
             adj_list.insert(v, Default::default());
@@ -89,6 +103,7 @@ where
         &mut adj_list[v]
     }
 
+    /// Creates an edge going from `src` to `dst` and returns the edge ID.
     pub fn insert_edge(&mut self, src: V, dst: V) -> E {
         let e = self.edges.insert((src, dst));
         Self::get_adj_edges(&mut self.succs, src).push(e);
@@ -96,20 +111,22 @@ where
         e
     }
 
-    /// For an edge E from A -> B, insert a new node NODE along that edge to
-    /// create A -> NODE -> B. Returns the edge ID into and out of NODE
-    /// respectively.
+    /// For an `edge` from `A --> B`, insert a new vertex `V` along that edge to create
+    /// `A --e0--> V --e1--> B`. Returns the pair of new edge IDs in and out of `V`, i.e.
+    /// `(e0, e1)`.
     ///
-    /// Returns None if the edge doesn't exist.
-    pub fn insert_intermediate_node(&mut self, new_node: V, edge: E) -> Option<(E, E)> {
+    /// Returns `None` if the edge doesn't exist.
+    ///
+    /// `edge` is removed from the graph, both returned edge IDs are new.
+    pub fn insert_intermediate_vertex(&mut self, new_vertex: V, edge: E) -> Option<(E, E)> {
         self.assert_valid();
 
         // Remove old edge from edges.
         let (src, dst) = self.edges.remove(edge)?;
 
         // Insert new edges into edges.
-        let e0 = self.edges.insert((src, new_node));
-        let e1 = self.edges.insert((new_node, dst));
+        let e0 = self.edges.insert((src, new_vertex));
+        let e1 = self.edges.insert((new_vertex, dst));
 
         // Remove old & add new edges in succs/preds.
         let succ_vec_idx = self.succs[src].iter().position(|&e| e == edge).unwrap();
@@ -123,59 +140,92 @@ where
             std::mem::replace(&mut self.preds[dst][pred_vec_idx], e1)
         );
 
-        // Insert new node succs/preds.
+        // Insert new vertex succs/preds.
         assert!(
-            self.preds.insert(new_node, vec![e0]).is_none(),
-            "Cannot insert intermediate node that already exists"
+            self.preds.insert(new_vertex, vec![e0]).is_none(),
+            "Cannot insert intermediate vertex that already exists"
         );
         assert!(
-            self.succs.insert(new_node, vec![e1]).is_none(),
-            "Cannot insert intermediate node that already exists"
+            self.succs.insert(new_vertex, vec![e1]).is_none(),
+            "Cannot insert intermediate vertex that already exists"
         );
 
         self.assert_valid();
         Some((e0, e1))
     }
 
+    /// Get the source and destination vertex IDs for the given edge ID.
     pub fn edge(&self, e: E) -> Option<(V, V)> {
         self.edges.get(e).copied()
     }
 
-    pub fn edges(&self) -> impl '_ + Iterator<Item = (E, (V, V))> {
+    /// Return an iterator over all edges in form `(E, (V, V))`.
+    pub fn edges(
+        &self,
+    ) -> impl '_ + Iterator<Item = (E, (V, V))> + ExactSizeIterator + FusedIterator + Clone + Debug
+    {
         self.edges.iter().map(|(e, &(src, dst))| (e, (src, dst)))
     }
 
-    pub fn successor_edges(&self, v: V) -> impl '_ + Iterator<Item = E> {
+    /// Return an iterator of all edge IDs coming out of `v`.
+    pub fn successor_edges(
+        &self,
+        v: V,
+    ) -> std::iter::Copied<std::iter::Flatten<std::option::IntoIter<&Vec<E>>>> {
         self.succs.get(v).into_iter().flatten().copied()
     }
 
-    pub fn predecessor_edges(&self, v: V) -> impl '_ + Iterator<Item = E> {
+    /// Return an iterator of all edge IDs going into `v`.
+    pub fn predecessor_edges(
+        &self,
+        v: V,
+    ) -> std::iter::Copied<std::iter::Flatten<std::option::IntoIter<&Vec<E>>>> {
         self.preds.get(v).into_iter().flatten().copied()
     }
 
-    pub fn successor_nodes(&self, v: V) -> impl '_ + Iterator<Item = V> {
+    /// Return an iterator of all successor vertex IDs of `v`.
+    pub fn successor_vertices(
+        &self,
+        v: V,
+    ) -> impl '_ + Iterator<Item = V> + DoubleEndedIterator + FusedIterator + Clone + Debug {
         self.successor_edges(v).map(|edge_id| self.edges[edge_id].1)
     }
 
-    pub fn predecessor_nodes(&self, v: V) -> impl '_ + Iterator<Item = V> {
+    /// Return an iterator of all predecessor vertex IDs of `v`.
+    pub fn predecessor_vertices(
+        &self,
+        v: V,
+    ) -> impl '_ + Iterator<Item = V> + DoubleEndedIterator + FusedIterator + Clone + Debug {
         self.predecessor_edges(v)
             .map(|edge_id| self.edges[edge_id].0)
     }
 
-    pub fn successors(&self, v: V) -> impl '_ + Iterator<Item = (E, V)> {
+    /// Return an iterator of all successor edge IDs _and_ vertex IDs of `v` in form `(E, V)`.
+    pub fn successors(
+        &self,
+        v: V,
+    ) -> impl '_ + Iterator<Item = (E, V)> + DoubleEndedIterator + FusedIterator + Clone + Debug
+    {
         self.successor_edges(v)
             .map(|edge_id| (edge_id, self.edges[edge_id].1))
     }
 
-    pub fn predecessors(&self, v: V) -> impl '_ + Iterator<Item = (E, V)> {
+    /// Return an iterator of all predecessor edge IDs _and_ vertex IDs of `v` in form `(E, V)`.
+    pub fn predecessors(
+        &self,
+        v: V,
+    ) -> impl '_ + Iterator<Item = (E, V)> + DoubleEndedIterator + FusedIterator + Clone + Debug
+    {
         self.predecessor_edges(v)
             .map(|edge_id| (edge_id, self.edges[edge_id].0))
     }
 
+    /// The degree (number of edges/vertices) coming out of `v`, i.e. the number of successors.
     pub fn degree_out(&self, v: V) -> usize {
         self.succs.get(v).map(Vec::len).unwrap_or_default()
     }
 
+    /// The degree (number of edges/vertices) going into `v`, i.e. the number of predecessors.
     pub fn degree_in(&self, v: V) -> usize {
         self.preds.get(v).map(Vec::len).unwrap_or_default()
     }

--- a/hydroflow_lang/src/graph/flat_to_partitioned.rs
+++ b/hydroflow_lang/src/graph/flat_to_partitioned.rs
@@ -108,7 +108,7 @@ fn make_subgraph_collect(
             .map(|(node_id, _)| node_id),
         |v| {
             graph
-                .predecessor_nodes(v)
+                .predecessor_vertices(v)
                 .filter(|&pred| !matches!(nodes[pred], Node::Handoff { .. }))
         },
     );
@@ -279,8 +279,8 @@ fn find_subgraph_strata(
                 continue;
             }
 
-            assert_eq!(1, graph.predecessor_nodes(node_id).count());
-            let pred = graph.predecessor_nodes(node_id).next().unwrap();
+            assert_eq!(1, graph.predecessor_vertices(node_id).count());
+            let pred = graph.predecessor_vertices(node_id).next().unwrap();
 
             let pred_sg = node_subgraph[pred];
             let succ_sg = node_subgraph[succ];
@@ -342,8 +342,8 @@ fn find_subgraph_strata(
     let max_stratum = subgraph_stratum.values().cloned().max().unwrap_or(0) + 1; // Used for `next_tick()` delayer subgraphs.
     for (edge_id, &delay_type) in barrier_crossers.iter() {
         let (hoff, dst) = graph.edge(edge_id).unwrap();
-        assert_eq!(1, graph.predecessor_nodes(hoff).count());
-        let src = graph.predecessor_nodes(hoff).next().unwrap();
+        assert_eq!(1, graph.predecessor_vertices(hoff).count());
+        let src = graph.predecessor_vertices(hoff).next().unwrap();
 
         let src_sg = node_subgraph[src];
         let dst_sg = node_subgraph[dst];
@@ -559,9 +559,9 @@ impl TryFrom<FlatGraph> for PartitionedGraph {
 
         // build a SecondaryMap from edges.dst to edges to find inbound edges of a node
         let mut dest_map = SecondaryMap::new();
-        graph.edges.iter().for_each(|e| {
+        graph.edges().for_each(|e| {
             let (_, (_src, dest)) = e;
-            dest_map.insert(*dest, e);
+            dest_map.insert(dest, e);
         });
         // iterate through edges, find internal handoffs and their inbound/outbound edges
         for e in graph.edges() {
@@ -619,7 +619,7 @@ fn insert_intermediate_node(
 ) -> (GraphNodeId, GraphEdgeId) {
     let span = Some(node.span());
     let node_id = nodes.insert(node);
-    let (e0, e1) = graph.insert_intermediate_node(node_id, edge_id).unwrap();
+    let (e0, e1) = graph.insert_intermediate_vertex(node_id, edge_id).unwrap();
 
     let (src_idx, dst_idx) = ports.remove(edge_id).unwrap();
     ports.insert(e0, (src_idx, PortIndexValue::Elided(span)));


### PR DESCRIPTION
Improve documentation and use consistent language, i.e. `vertex` instead
of `node`.

quick little refactor