### PR TITLE
Add API for defining custom services in deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1997,6 +1997,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.25.0+1.1.1t"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3173cd3626c43e3854b1b727422a276e568d9ec5fe8cec197822cf52cfb743d6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2005,6 +2014,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/hydro_cli/Cargo.toml
+++ b/hydro_cli/Cargo.toml
@@ -18,7 +18,7 @@ async-channel = "1.8.0"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 tempfile = "3.3.0"
-async-ssh2-lite = { version = "0.4.2", features = [ "tokio" ] }
+async-ssh2-lite = { version = "0.4.2", features = [ "tokio", "vendored-openssl" ] }
 hydroflow = { path = "../hydroflow", features = ["cli_integration"] }
 
 [dev-dependencies]

--- a/hydro_cli/hydro/__init__.py
+++ b/hydro_cli/hydro/__init__.py
@@ -11,6 +11,9 @@ class Deployment(object):
     def GCPComputeEngineHost(self, project: str, machine_type: str, region: str) -> "GCPComputeEngineHost":
         return GCPComputeEngineHost(self, project, machine_type, region)
 
+    def CustomService(self, on: "Host", external_ports: List[int]) -> "CustomService":
+        return CustomService(self, on, external_ports)
+
     def HydroflowCrate(self, src: str, on: "Host", example: Optional[str] = None, features: Optional[List[str]] = None) -> "HydroflowCrate":
         return HydroflowCrate(self, src, on, example, features)
 
@@ -32,9 +35,21 @@ class GCPComputeEngineHost(Host):
     def __init__(self, deployment: Deployment, project: str, machine_type: str, region: str):
         super().__init__(hydro_cli_rust.PyGCPComputeEngineHost(deployment.underlying, project, machine_type, region))
 
+    @property
+    def internal_ip(self) -> str:
+        return self.underlying.internal_ip
+
+    @property
+    def external_ip(self) -> Optional[str]:
+        return self.underlying.external_ip
+
 class Service(object):
     def __init__(self, underlying) -> None:
         self.underlying = underlying
+
+class CustomService(Service):
+    def __init__(self, deployment: Deployment, on: Host, external_ports: List[int]) -> None:
+        super().__init__(hydro_cli_rust.PyCustomService(deployment.underlying, on.underlying, external_ports))
 
 class HydroflowPort(object):
     def __init__(self, underlying, name) -> None:

--- a/hydro_cli/hydro/__init__.py
+++ b/hydro_cli/hydro/__init__.py
@@ -43,6 +43,10 @@ class GCPComputeEngineHost(Host):
     def external_ip(self) -> Optional[str]:
         return self.underlying.external_ip
 
+    @property
+    def ssh_key_path(self) -> str:
+        return self.underlying.ssh_key_path
+
 class Service(object):
     def __init__(self, underlying) -> None:
         self.underlying = underlying

--- a/hydro_cli/hydro/__init__.py
+++ b/hydro_cli/hydro/__init__.py
@@ -8,8 +8,8 @@ class Deployment(object):
     def Localhost(self) -> "Localhost":
         return Localhost(self)
 
-    def GCPComputeEngineHost(self, project: str, machine_type: str, region: str) -> "GCPComputeEngineHost":
-        return GCPComputeEngineHost(self, project, machine_type, region)
+    def GCPComputeEngineHost(self, project: str, machine_type: str, image: str, region: str) -> "GCPComputeEngineHost":
+        return GCPComputeEngineHost(self, project, machine_type, image, region)
 
     def CustomService(self, on: "Host", external_ports: List[int]) -> "CustomService":
         return CustomService(self, on, external_ports)
@@ -32,8 +32,8 @@ class Localhost(Host):
         super().__init__(hydro_cli_rust.PyLocalhostHost(deployment.underlying))
 
 class GCPComputeEngineHost(Host):
-    def __init__(self, deployment: Deployment, project: str, machine_type: str, region: str):
-        super().__init__(hydro_cli_rust.PyGCPComputeEngineHost(deployment.underlying, project, machine_type, region))
+    def __init__(self, deployment: Deployment, project: str, machine_type: str, image: str, region: str):
+        super().__init__(hydro_cli_rust.PyGCPComputeEngineHost(deployment.underlying, project, machine_type, image, region))
 
     @property
     def internal_ip(self) -> str:

--- a/hydro_cli/src/async_wrapper.py
+++ b/hydro_cli/src/async_wrapper.py
@@ -11,20 +11,34 @@ def run(inner):
     event_loop = asyncio.get_event_loop()
     task = event_loop.create_task(wrap(inner))
     should_cancel = False
+
     try:
         res = event_loop.run_until_complete(task)
+    except KeyboardInterrupt:
+        should_cancel = True
+        # don't re-raise the exception, to give Rust a chance to gracefully shut down
+        res = (None, [Exception, Exception("Received keyboard interrupt"), None])
     except:
         should_cancel = True
+        cancel_reason = sys.exc_info()
+
+        # avoid leaking references to the coroutine
+        cancel_reason[1].__traceback__ = None
+        res = (None, [cancel_reason[0], cancel_reason[1], None])
+        del cancel_reason
 
     if should_cancel:
         task.cancel()
-        res = event_loop.run_until_complete(task)
+        event_loop.run_until_complete(task)
 
-    pending = asyncio.all_tasks(loop=event_loop)
-    group = asyncio.gather(*pending)
-    event_loop.run_until_complete(group)
+    event_loop.run_until_complete(
+        asyncio.gather(*asyncio.all_tasks(loop=event_loop))
+    )
 
     event_loop.close()
+
+    del task
+    del event_loop
 
     if res[1]:
         raise res[1][1].with_traceback(res[1][2])

--- a/hydro_cli/src/core/custom_service.rs
+++ b/hydro_cli/src/core/custom_service.rs
@@ -6,9 +6,13 @@ use tokio::sync::RwLock;
 
 use super::{BindType, Host, LaunchedHost, ResourceBatch, ResourceResult, Service};
 
+/// Represents an unknown, third-party service that is not part of the Hydroflow ecosystem.
 pub struct CustomService {
     on: Arc<RwLock<dyn Host>>,
+
+    /// The ports that the service wishes to expose to the public internet.
     external_ports: Vec<u16>,
+
     launched_host: Option<Arc<dyn LaunchedHost>>,
 }
 

--- a/hydro_cli/src/core/custom_service.rs
+++ b/hydro_cli/src/core/custom_service.rs
@@ -46,8 +46,4 @@ impl Service for CustomService {
     }
 
     async fn start(&mut self) {}
-
-    fn host(&self) -> Arc<RwLock<dyn Host>> {
-        self.on.clone()
-    }
 }

--- a/hydro_cli/src/core/custom_service.rs
+++ b/hydro_cli/src/core/custom_service.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+
+use super::{BindType, Host, LaunchedHost, ResourceBatch, ResourceResult, Service};
+
+pub struct CustomService {
+    on: Arc<RwLock<dyn Host>>,
+    external_ports: Vec<u16>,
+    launched_host: Option<Arc<dyn LaunchedHost>>,
+}
+
+impl CustomService {
+    pub fn new(on: Arc<RwLock<dyn Host>>, external_ports: Vec<u16>) -> Self {
+        Self {
+            on,
+            external_ports,
+            launched_host: None,
+        }
+    }
+}
+
+#[async_trait]
+impl Service for CustomService {
+    fn collect_resources(&mut self, _resource_batch: &mut ResourceBatch) {
+        let mut host = self
+            .on
+            .try_write()
+            .expect("No one should be reading/writing the host while resources are collected");
+
+        for port in self.external_ports.iter() {
+            host.request_port(&BindType::ExternalTcpPort(*port));
+        }
+    }
+
+    async fn deploy(&mut self, resource_result: &Arc<ResourceResult>) {
+        let mut host_write = self.on.write().await;
+        let launched = host_write.provision(resource_result);
+        self.launched_host = Some(launched.await);
+    }
+
+    async fn ready(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn start(&mut self) {}
+
+    fn host(&self) -> Arc<RwLock<dyn Host>> {
+        self.on.clone()
+    }
+}

--- a/hydro_cli/src/core/deployment.rs
+++ b/hydro_cli/src/core/deployment.rs
@@ -20,6 +20,10 @@ impl Deployment {
             service.write().await.collect_resources(&mut resource_pool);
         }
 
+        for host in self.hosts.iter_mut() {
+            host.write().await.collect_resources(&mut resource_pool);
+        }
+
         let result = Arc::new(resource_pool.provision().await);
 
         let services_future =

--- a/hydro_cli/src/core/gcp.rs
+++ b/hydro_cli/src/core/gcp.rs
@@ -67,6 +67,17 @@ pub struct LaunchedComputeEngine {
     binary_counter: RwLock<usize>,
 }
 
+impl LaunchedComputeEngine {
+    pub fn ssh_key_path(&self) -> PathBuf {
+        self.resource_result
+            .terraform
+            .deployment_folder
+            .path()
+            .join(".ssh")
+            .join("vm_instance_ssh_key_pem")
+    }
+}
+
 #[async_trait]
 impl LaunchedHost for LaunchedComputeEngine {
     fn get_bind_config(&self, bind_type: &BindType) -> BindConfig {
@@ -97,18 +108,7 @@ impl LaunchedHost for LaunchedComputeEngine {
                 session.handshake().await?;
 
                 session
-                    .userauth_pubkey_file(
-                        "hydro",
-                        None,
-                        self.resource_result
-                            .terraform
-                            .deployment_folder
-                            .path()
-                            .join(".ssh")
-                            .join("vm_instance_ssh_key_pem")
-                            .as_path(),
-                        None,
-                    )
+                    .userauth_pubkey_file("hydro", None, self.ssh_key_path().as_path(), None)
                     .await?;
 
                 Ok(session)

--- a/hydro_cli/src/core/gcp.rs
+++ b/hydro_cli/src/core/gcp.rs
@@ -169,17 +169,25 @@ pub struct GCPComputeEngineHost {
     pub id: usize,
     pub project: String,
     pub machine_type: String,
+    pub image: String,
     pub region: String,
     pub launched: Option<Arc<LaunchedComputeEngine>>,
     external_ports: Vec<u16>,
 }
 
 impl GCPComputeEngineHost {
-    pub fn new(id: usize, project: String, machine_type: String, region: String) -> Self {
+    pub fn new(
+        id: usize,
+        project: String,
+        machine_type: String,
+        image: String,
+        region: String,
+    ) -> Self {
         Self {
             id,
             project,
             machine_type,
+            image,
             region,
             launched: None,
             external_ports: vec![],
@@ -398,7 +406,7 @@ impl Host for GCPComputeEngineHost {
                         {
                             "initialize_params": [
                                 {
-                                    "image": "debian-cloud/debian-11"
+                                    "image": self.image
                                 }
                             ]
                         }

--- a/hydro_cli/src/core/gcp.rs
+++ b/hydro_cli/src/core/gcp.rs
@@ -5,13 +5,13 @@ use std::{
     time::Duration,
 };
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use async_channel::{Receiver, Sender};
 
 use async_ssh2_lite::{AsyncChannel, AsyncSession, SessionConfiguration};
 use async_trait::async_trait;
 use futures::{AsyncWriteExt, StreamExt};
-use hydroflow::util::connection::BindType;
+use hydroflow::util::connection::BindConfig;
 use serde_json::json;
 use tokio::{net::TcpStream, sync::RwLock};
 
@@ -19,7 +19,7 @@ use super::{
     localhost::create_broadcast,
     terraform::{TerraformOutput, TerraformProvider},
     util::async_retry,
-    ConnectionType, Host, LaunchedBinary, LaunchedHost, ResourceBatch, ResourceResult,
+    BindType, ConnectionType, Host, LaunchedBinary, LaunchedHost, ResourceBatch, ResourceResult,
 };
 
 struct LaunchedComputeEngineBinary {
@@ -60,25 +60,39 @@ impl LaunchedBinary for LaunchedComputeEngineBinary {
     }
 }
 
-struct LaunchedComputeEngine {
+pub struct LaunchedComputeEngine {
     resource_result: Arc<ResourceResult>,
-    external_ip: String,
+    pub internal_ip: String,
+    pub external_ip: Option<String>,
     binary_counter: RwLock<usize>,
 }
 
 #[async_trait]
 impl LaunchedHost for LaunchedComputeEngine {
+    fn get_bind_config(&self, bind_type: &BindType) -> BindConfig {
+        match bind_type {
+            BindType::UnixSocket => BindConfig::UnixSocket,
+            BindType::InternalTcpPort => BindConfig::TcpPort(self.internal_ip.clone()),
+            BindType::ExternalTcpPort(_) => todo!(),
+        }
+    }
+
     async fn launch_binary(&self, binary: &Path) -> Result<Arc<RwLock<dyn LaunchedBinary>>> {
+        let target_addr = SocketAddr::new(
+            self.external_ip
+                .as_ref()
+                .context("GCP host must be configured with an external IP to launch binaries")?
+                .parse()
+                .unwrap(),
+            22,
+        );
         let session = async_retry(
             || async {
                 let mut config = SessionConfiguration::new();
                 config.set_timeout(5000);
 
-                let mut session = AsyncSession::<TcpStream>::connect(
-                    SocketAddr::new(self.external_ip.parse().unwrap(), 22),
-                    Some(config),
-                )
-                .await?;
+                let mut session =
+                    AsyncSession::<TcpStream>::connect(target_addr, Some(config)).await?;
 
                 session.handshake().await?;
 
@@ -156,9 +170,8 @@ pub struct GCPComputeEngineHost {
     pub project: String,
     pub machine_type: String,
     pub region: String,
-    pub internal_ip: Option<String>,
-    pub external_ip: Option<String>,
-    pub launched: Option<Arc<dyn LaunchedHost>>,
+    pub launched: Option<Arc<LaunchedComputeEngine>>,
+    external_ports: Vec<u16>,
 }
 
 impl GCPComputeEngineHost {
@@ -168,15 +181,24 @@ impl GCPComputeEngineHost {
             project,
             machine_type,
             region,
-            internal_ip: None,
-            external_ip: None,
             launched: None,
+            external_ports: vec![],
         }
     }
 }
 
 #[async_trait]
 impl Host for GCPComputeEngineHost {
+    fn request_port(&mut self, bind_type: &BindType) {
+        match bind_type {
+            BindType::UnixSocket => {}
+            BindType::InternalTcpPort => {}
+            BindType::ExternalTcpPort(port) => {
+                self.external_ports.push(*port);
+            }
+        }
+    }
+
     fn collect_resources(&self, resource_batch: &mut ResourceBatch) {
         let project = self.project.as_str();
         let id = self.id;
@@ -308,57 +330,82 @@ impl Host for GCPComputeEngineHost {
             }),
         );
 
-        // allow SSH access to all VMs
-        let allow_ssh_rule = format!("{vpc_network}-allow-ssh");
-        firewall_entries.insert(
-            allow_ssh_rule.clone(),
-            json!({
-                "name": allow_ssh_rule,
-                "project": project,
-                "network": format!("${{google_compute_network.{vpc_network}.name}}"),
-                "target_tags": [allow_ssh_rule],
-                "source_ranges": ["0.0.0.0/0"],
-                "allow": [
-                    {
-                        "protocol": "tcp",
-                        "ports": ["22"]
-                    }
-                ]
-            }),
-        );
-
         let vm_instance = format!("vm-instance-{project}-{id}");
-        resource_batch.terraform.resource.entry("google_compute_instance".to_string())
-            .or_default()
-            .insert(vm_instance.clone(), json!({
-                "name": vm_instance,
-                "project": project,
-                "machine_type": self.machine_type,
-                "zone": self.region,
-                "tags": [ allow_ssh_rule ],
-                "metadata": {
-                "ssh-keys": "hydro:${tls_private_key.vm_instance_ssh_key.public_key_openssh}"
-                },
-                "boot_disk": [
+
+        let mut tags = vec![];
+        let mut external_interfaces = vec![];
+
+        if self.external_ports.is_empty() {
+            external_interfaces.push(json!({
+                "network": format!("${{google_compute_network.{vpc_network}.self_link}}")
+            }));
+        } else {
+            external_interfaces.push(json!({
+                "network": format!("${{google_compute_network.{vpc_network}.self_link}}"),
+                "access_config": [
                     {
-                        "initialize_params": [
-                            {
-                                "image": "debian-cloud/debian-11"
-                            }
-                        ]
-                    }
-                ],
-                "network_interface": [
-                    {
-                        "network": format!("${{google_compute_network.{vpc_network}.self_link}}"),
-                        "access_config": [
-                            {
-                                "network_tier": "STANDARD"
-                            }
-                        ]
+                        "network_tier": "STANDARD"
                     }
                 ]
             }));
+
+            // open the external ports that were requested
+            let open_external_ports_rule = format!("{vm_instance}-open-external-ports");
+            firewall_entries.insert(
+                open_external_ports_rule.clone(),
+                json!({
+                    "name": open_external_ports_rule,
+                    "project": project,
+                    "network": format!("${{google_compute_network.{vpc_network}.name}}"),
+                    "target_tags": [open_external_ports_rule],
+                    "source_ranges": ["0.0.0.0/0"],
+                    "allow": [
+                        {
+                            "protocol": "tcp",
+                            "ports": self.external_ports.iter().map(|p| p.to_string()).collect::<Vec<String>>()
+                        }
+                    ]
+                }),
+            );
+
+            tags.push(open_external_ports_rule);
+
+            resource_batch.terraform.output.insert(
+                format!("{vm_instance}-public-ip"),
+                TerraformOutput {
+                    value: format!("${{google_compute_instance.{vm_instance}.network_interface[0].access_config[0].nat_ip}}")
+                }
+            );
+        }
+
+        resource_batch
+            .terraform
+            .resource
+            .entry("google_compute_instance".to_string())
+            .or_default()
+            .insert(
+                vm_instance.clone(),
+                json!({
+                    "name": vm_instance,
+                    "project": project,
+                    "machine_type": self.machine_type,
+                    "zone": self.region,
+                    "tags": tags,
+                    "metadata": {
+                    "ssh-keys": "hydro:${tls_private_key.vm_instance_ssh_key.public_key_openssh}"
+                    },
+                    "boot_disk": [
+                        {
+                            "initialize_params": [
+                                {
+                                    "image": "debian-cloud/debian-11"
+                                }
+                            ]
+                        }
+                    ],
+                    "network_interface": external_interfaces
+                }),
+            );
 
         resource_batch.terraform.output.insert(
             format!("{vm_instance}-internal-ip"),
@@ -368,13 +415,6 @@ impl Host for GCPComputeEngineHost {
                 ),
             },
         );
-
-        resource_batch.terraform.output.insert(
-            format!("{vm_instance}-public-ip"),
-            TerraformOutput {
-                value: format!("${{google_compute_instance.{vm_instance}.network_interface[0].access_config[0].nat_ip}}")
-            }
-        );
     }
 
     async fn provision(&mut self, resource_result: &Arc<ResourceResult>) -> Arc<dyn LaunchedHost> {
@@ -382,25 +422,24 @@ impl Host for GCPComputeEngineHost {
             let project = self.project.as_str();
             let id = self.id;
 
-            let internal_ip = &resource_result
+            let internal_ip = resource_result
                 .terraform
                 .outputs
                 .get(&format!("vm-instance-{project}-{id}-internal-ip"))
                 .unwrap()
-                .value;
-            self.internal_ip = Some(internal_ip.clone());
+                .value
+                .clone();
 
-            let external_ip = &resource_result
+            let external_ip = resource_result
                 .terraform
                 .outputs
                 .get(&format!("vm-instance-{project}-{id}-public-ip"))
-                .unwrap()
-                .value;
-            self.external_ip = Some(external_ip.clone());
+                .map(|v| v.value.clone());
 
             self.launched = Some(Arc::new(LaunchedComputeEngine {
                 resource_result: resource_result.clone(),
-                external_ip: external_ip.clone(),
+                internal_ip,
+                external_ip,
                 binary_counter: RwLock::new(0),
             }))
         }
@@ -408,14 +447,13 @@ impl Host for GCPComputeEngineHost {
         self.launched.as_ref().unwrap().clone()
     }
 
-    fn find_bind_type(&self, connection_from: &dyn Host) -> BindType {
+    fn get_bind_type(&self, connection_from: &dyn Host) -> BindType {
         if connection_from.can_connect_to(ConnectionType::UnixSocket(self.id)) {
             BindType::UnixSocket
         } else if connection_from
             .can_connect_to(ConnectionType::InternalTcpPort(self.project.clone()))
         {
-            // we use the project as a way to uniquely identify the VPC network
-            BindType::TcpPort(self.internal_ip.as_ref().unwrap().clone())
+            BindType::InternalTcpPort
         } else {
             todo!()
         }

--- a/hydro_cli/src/core/hydroflow_crate.rs
+++ b/hydro_cli/src/core/hydroflow_crate.rs
@@ -68,7 +68,7 @@ impl HydroflowCrate {
             self.on
                 .try_read()
                 .unwrap()
-                .get_bind_type(from.host().try_read().unwrap().deref()),
+                .get_bind_type(from.on.try_read().unwrap().deref()),
         );
     }
 
@@ -248,9 +248,5 @@ impl Service for HydroflowCrate {
             .send(format!("start: {formatted_pipe_config}\n"))
             .await
             .unwrap();
-    }
-
-    fn host(&self) -> Arc<RwLock<dyn Host>> {
-        self.on.clone()
     }
 }

--- a/hydro_cli/src/core/hydroflow_crate.rs
+++ b/hydro_cli/src/core/hydroflow_crate.rs
@@ -17,7 +17,7 @@ use cargo::{
 use hydroflow::util::connection::ConnectionPipe;
 use tokio::{sync::RwLock, task::JoinHandle};
 
-use super::{Host, LaunchedBinary, LaunchedHost, ResourceBatch, ResourceResult, Service};
+use super::{BindType, Host, LaunchedBinary, LaunchedHost, ResourceBatch, ResourceResult, Service};
 
 pub struct HydroflowCrate {
     src: PathBuf,
@@ -26,11 +26,10 @@ pub struct HydroflowCrate {
     features: Option<Vec<String>>,
 
     /// A mapping from output ports to the service that the port sends data to.
-    /// Each `dyn Service` is guaranteed to be another `HydroflowCrate`.
-    outgoing_ports: HashMap<String, (Weak<RwLock<dyn Service>>, String)>,
+    outgoing_ports: HashMap<String, (Weak<RwLock<HydroflowCrate>>, String)>,
 
     /// A map of port names to the host that will be sending data to the port.
-    incoming_ports: HashMap<String, Arc<RwLock<dyn Host>>>,
+    incoming_ports: HashMap<String, BindType>,
 
     built_binary: Option<JoinHandle<PathBuf>>,
     launched_host: Option<Arc<dyn LaunchedHost>>,
@@ -64,13 +63,19 @@ impl HydroflowCrate {
     }
 
     pub fn add_incoming_port(&mut self, my_port: String, from: &HydroflowCrate) {
-        self.incoming_ports.insert(my_port, from.host());
+        self.incoming_ports.insert(
+            my_port,
+            self.on
+                .try_read()
+                .unwrap()
+                .get_bind_type(from.host().try_read().unwrap().deref()),
+        );
     }
 
     pub fn add_outgoing_port(
         &mut self,
         my_port: String,
-        to: &Arc<RwLock<dyn Service>>,
+        to: &Arc<RwLock<HydroflowCrate>>,
         to_port: String,
     ) {
         self.outgoing_ports
@@ -161,15 +166,19 @@ impl HydroflowCrate {
 
 #[async_trait]
 impl Service for HydroflowCrate {
-    fn collect_resources(&mut self, resource_batch: &mut ResourceBatch) {
+    fn collect_resources(&mut self, _resource_batch: &mut ResourceBatch) {
         let built = self.build();
         self.built_binary = Some(built);
 
-        let host = self
+        let mut host = self
             .on
-            .try_read()
-            .expect("No one should be writing to the host while resources are collected");
-        host.collect_resources(resource_batch);
+            .try_write()
+            .expect("No one should be reading/writing the host while resources are collected");
+
+        host.request_port(&BindType::ExternalTcpPort(22)); // always need SSH
+        for (_, bind_type) in self.incoming_ports.iter() {
+            host.request_port(bind_type);
+        }
     }
 
     async fn deploy(&mut self, resource_result: &Arc<ResourceResult>) {
@@ -179,25 +188,18 @@ impl Service for HydroflowCrate {
     }
 
     async fn ready(&mut self) -> Result<()> {
-        let binary = self
-            .launched_host
-            .as_ref()
-            .unwrap()
+        let launched_host = self.launched_host.as_ref().unwrap();
+
+        let binary = launched_host
             .launch_binary(self.built_binary.take().unwrap().await.as_ref().unwrap())
             .await?;
 
-        let mut bind_types = HashMap::new();
-        for (port_name, from_host) in self.incoming_ports.iter() {
-            bind_types.insert(
-                port_name.clone(),
-                self.on
-                    .read()
-                    .await
-                    .find_bind_type(from_host.read().await.deref()),
-            );
+        let mut bind_config = HashMap::new();
+        for (port_name, bind_type) in self.incoming_ports.iter() {
+            bind_config.insert(port_name.clone(), launched_host.get_bind_config(bind_type));
         }
 
-        let formatted_bind_types = serde_json::to_string(&bind_types).unwrap();
+        let formatted_bind_config = serde_json::to_string(&bind_config).unwrap();
 
         // request stdout before sending config so we don't miss the "ready" response
         let stdout_receiver = binary.write().await.stdout().await;
@@ -207,7 +209,7 @@ impl Service for HydroflowCrate {
             .await
             .stdin()
             .await
-            .send(format!("{formatted_bind_types}\n"))
+            .send(format!("{formatted_bind_config}\n"))
             .await?;
 
         let ready_line = stdout_receiver.recv().await.unwrap();
@@ -228,7 +230,6 @@ impl Service for HydroflowCrate {
         for (port_name, (target, target_port)) in self.outgoing_ports.iter() {
             let target = target.upgrade().unwrap();
             let target = target.read().await;
-            let target = target.as_any().downcast_ref::<HydroflowCrate>().unwrap();
 
             let conn = target.bound_pipes.get(target_port).unwrap();
 
@@ -251,13 +252,5 @@ impl Service for HydroflowCrate {
 
     fn host(&self) -> Arc<RwLock<dyn Host>> {
         self.on.clone()
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
-        self
     }
 }

--- a/hydro_cli/src/core/localhost.rs
+++ b/hydro_cli/src/core/localhost.rs
@@ -5,10 +5,12 @@ use async_channel::{Receiver, Sender};
 use async_process::{Command, Stdio};
 use async_trait::async_trait;
 use futures::{io::BufReader, AsyncBufReadExt, AsyncRead, AsyncWriteExt, StreamExt};
-use hydroflow::util::connection::BindType;
+use hydroflow::util::connection::BindConfig;
 use tokio::sync::RwLock;
 
-use super::{ConnectionType, Host, LaunchedBinary, LaunchedHost, ResourceBatch, ResourceResult};
+use super::{
+    BindType, ConnectionType, Host, LaunchedBinary, LaunchedHost, ResourceBatch, ResourceResult,
+};
 
 struct LaunchedLocalhostBinary {
     child: RwLock<async_process::Child>,
@@ -83,6 +85,14 @@ pub fn create_broadcast<T: AsyncRead + Send + Unpin + 'static>(
 
 #[async_trait]
 impl LaunchedHost for LaunchedLocalhost {
+    fn get_bind_config(&self, bind_type: &BindType) -> BindConfig {
+        match bind_type {
+            BindType::UnixSocket => BindConfig::UnixSocket,
+            BindType::InternalTcpPort => BindConfig::TcpPort("127.0.0.1".to_string()),
+            BindType::ExternalTcpPort(_) => panic!("Cannot bind to external port"),
+        }
+    }
+
     async fn launch_binary(&self, binary: &Path) -> Result<Arc<RwLock<dyn LaunchedBinary>>> {
         let mut child = Command::new(binary)
             .kill_on_drop(true)
@@ -120,19 +130,20 @@ pub struct LocalhostHost {
 
 #[async_trait]
 impl Host for LocalhostHost {
+    fn request_port(&mut self, _bind_type: &BindType) {}
     fn collect_resources(&self, _resource_batch: &mut ResourceBatch) {}
 
     async fn provision(&mut self, _resource_result: &Arc<ResourceResult>) -> Arc<dyn LaunchedHost> {
         Arc::new(LaunchedLocalhost {})
     }
 
-    fn find_bind_type(&self, connection_from: &dyn Host) -> BindType {
+    fn get_bind_type(&self, connection_from: &dyn Host) -> BindType {
         if connection_from.can_connect_to(ConnectionType::UnixSocket(self.id)) {
             BindType::UnixSocket
         } else if connection_from
             .can_connect_to(ConnectionType::InternalTcpPort(format!("{}", self.id)))
         {
-            BindType::TcpPort("127.0.0.1".to_string())
+            BindType::InternalTcpPort
         } else {
             todo!()
         }

--- a/hydro_cli/src/core/mod.rs
+++ b/hydro_cli/src/core/mod.rs
@@ -58,18 +58,24 @@ pub trait LaunchedBinary: Send + Sync {
 
 #[async_trait]
 pub trait LaunchedHost: Send + Sync {
-    /// Identifies a network type that this host can use for connections from the given host.
+    /// Given a pre-selected network type, computes concrete information needed for a service
+    /// to listen to network connections (such as the IP address to bind to).
     fn get_bind_config(&self, bind_type: &BindType) -> BindConfig;
 
     async fn launch_binary(&self, binary: &Path) -> Result<Arc<RwLock<dyn LaunchedBinary>>>;
 }
 
+/// Types of connections that a host can make to another host.
 pub enum BindType {
     UnixSocket,
     InternalTcpPort,
-    ExternalTcpPort(u16),
+    ExternalTcpPort(
+        /// The port number to bind to, which must be explicit to open the firewall.
+        u16,
+    ),
 }
 
+/// Like BindType, but includes metadata for determining whether a connection is possible.
 pub enum ConnectionType {
     UnixSocket(
         /// Unique identifier for the host this socket will be on.
@@ -94,6 +100,7 @@ pub trait Host: Send + Sync {
     /// Identifies a network type that this host can use for connections from the given host.
     fn get_bind_type(&self, connection_from: &dyn Host) -> BindType;
 
+    /// Determins whether this host can connect to another host using the given connection type.
     fn can_connect_to(&self, typ: ConnectionType) -> bool;
 }
 

--- a/hydro_cli/src/core/mod.rs
+++ b/hydro_cli/src/core/mod.rs
@@ -106,7 +106,10 @@ pub trait Host: Send + Sync {
 
 #[async_trait]
 pub trait Service: Send + Sync {
-    /// Makes requests for physical resources (servers) that this service needs to run.
+    /// Makes requests for physical resources server ports that this service needs to run.
+    /// This should **not** recursively call `collect_resources` on the host, since
+    /// we guarantee that `collect_resources` is only called once per host.
+    /// 
     /// This should also perform any "free", non-blocking computations (compilations),
     /// because the `deploy` method will be called after these resources are allocated.
     fn collect_resources(&mut self, resource_batch: &mut ResourceBatch);

--- a/hydro_cli/src/core/mod.rs
+++ b/hydro_cli/src/core/mod.rs
@@ -109,7 +109,7 @@ pub trait Service: Send + Sync {
     /// Makes requests for physical resources server ports that this service needs to run.
     /// This should **not** recursively call `collect_resources` on the host, since
     /// we guarantee that `collect_resources` is only called once per host.
-    /// 
+    ///
     /// This should also perform any "free", non-blocking computations (compilations),
     /// because the `deploy` method will be called after these resources are allocated.
     fn collect_resources(&mut self, resource_batch: &mut ResourceBatch);

--- a/hydro_cli/src/core/mod.rs
+++ b/hydro_cli/src/core/mod.rs
@@ -120,6 +120,4 @@ pub trait Service: Send + Sync {
 
     /// Starts the service by having it connect to other services and start computations.
     async fn start(&mut self);
-
-    fn host(&self) -> Arc<RwLock<dyn Host>>;
 }

--- a/hydro_cli/src/core/terraform.rs
+++ b/hydro_cli/src/core/terraform.rs
@@ -127,7 +127,7 @@ impl Drop for TerraformResult {
             .expect("Failed to destroy terraform deployment")
             .success()
         {
-            panic!("Failed to destroy terraform deployment");
+            eprintln!("WARNING: failed to destroy terraform deployment");
         }
     }
 }

--- a/hydro_cli/src/main.rs
+++ b/hydro_cli/src/main.rs
@@ -88,7 +88,11 @@ fn deploy(config: PathBuf) -> anyhow::Result<()> {
                     let mut underlying = underlying.blocking_write();
                     Err(underlying.take().unwrap()).context(format!("RustException\n{}", traceback))
                 } else {
-                    Err(PyErrWithTraceback { err_display: format!("{}", err), traceback }.into())
+                    Err(PyErrWithTraceback {
+                        err_display: format!("{}", err),
+                        traceback,
+                    }
+                    .into())
                 }
             }
         }

--- a/hydro_cli/src/main.rs
+++ b/hydro_cli/src/main.rs
@@ -37,7 +37,7 @@ fn async_wrapper_module(py: Python) -> Result<&PyModule, PyErr> {
 
 #[derive(Debug)]
 struct PyErrWithTraceback {
-    err: PyErr,
+    err_display: String,
     traceback: String,
 }
 
@@ -45,7 +45,7 @@ impl std::error::Error for PyErrWithTraceback {}
 
 impl Display for PyErrWithTraceback {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "{}", self.err)?;
+        writeln!(f, "{}", self.err_display)?;
         write!(f, "{}", self.traceback)
     }
 }
@@ -88,7 +88,7 @@ fn deploy(config: PathBuf) -> anyhow::Result<()> {
                     let mut underlying = underlying.blocking_write();
                     Err(underlying.take().unwrap()).context(format!("RustException\n{}", traceback))
                 } else {
-                    Err(PyErrWithTraceback { err, traceback }.into())
+                    Err(PyErrWithTraceback { err_display: format!("{}", err), traceback }.into())
                 }
             }
         }

--- a/hydro_cli/src/python_interface.rs
+++ b/hydro_cli/src/python_interface.rs
@@ -132,6 +132,19 @@ impl PyGCPComputeEngineHost {
             .external_ip
             .clone()
     }
+
+    #[getter]
+    fn ssh_key_path(&self) -> String {
+        self.underlying
+            .blocking_read()
+            .launched
+            .as_ref()
+            .unwrap()
+            .ssh_key_path()
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
 }
 
 #[pyclass(subclass)]

--- a/hydro_cli/src/python_interface.rs
+++ b/hydro_cli/src/python_interface.rs
@@ -96,10 +96,11 @@ impl PyGCPComputeEngineHost {
         deployment: &PyDeployment,
         project: String,
         machine_type: String,
+        image: String,
         region: String,
     ) -> (Self, PyHost) {
         let host = deployment.underlying.blocking_write().add_host(|id| {
-            crate::core::GCPComputeEngineHost::new(id, project, machine_type, region)
+            crate::core::GCPComputeEngineHost::new(id, project, machine_type, image, region)
         });
 
         (

--- a/hydro_cli/src/python_interface.rs
+++ b/hydro_cli/src/python_interface.rs
@@ -85,7 +85,9 @@ impl PyLocalhostHost {
 }
 
 #[pyclass(extends=PyHost, subclass)]
-struct PyGCPComputeEngineHost {}
+struct PyGCPComputeEngineHost {
+    underlying: Arc<RwLock<crate::core::GCPComputeEngineHost>>,
+}
 
 #[pymethods]
 impl PyGCPComputeEngineHost {
@@ -96,20 +98,44 @@ impl PyGCPComputeEngineHost {
         machine_type: String,
         region: String,
     ) -> (Self, PyHost) {
+        let host = deployment.underlying.blocking_write().add_host(|id| {
+            crate::core::GCPComputeEngineHost::new(id, project, machine_type, region)
+        });
+
         (
-            PyGCPComputeEngineHost {},
-            PyHost {
-                underlying: deployment.underlying.blocking_write().add_host(|id| {
-                    crate::core::GCPComputeEngineHost::new(id, project, machine_type, region)
-                }),
+            PyGCPComputeEngineHost {
+                underlying: host.clone(),
             },
+            PyHost { underlying: host },
         )
+    }
+
+    #[getter]
+    fn internal_ip(&self) -> String {
+        self.underlying
+            .blocking_read()
+            .launched
+            .as_ref()
+            .unwrap()
+            .internal_ip
+            .clone()
+    }
+
+    #[getter]
+    fn external_ip(&self) -> Option<String> {
+        self.underlying
+            .blocking_read()
+            .launched
+            .as_ref()
+            .unwrap()
+            .external_ip
+            .clone()
     }
 }
 
 #[pyclass(subclass)]
 pub struct PyService {
-    underlying: Arc<RwLock<dyn crate::core::Service>>,
+    _underlying: Arc<RwLock<dyn crate::core::Service>>,
 }
 
 #[pyclass]
@@ -130,7 +156,38 @@ impl PyReceiver {
 }
 
 #[pyclass(extends=PyService, subclass)]
-struct PyHydroflowCrate {}
+struct PyCustomService {
+    _underlying: Arc<RwLock<crate::core::CustomService>>,
+}
+
+#[pymethods]
+impl PyCustomService {
+    #[new]
+    fn new(deployment: &PyDeployment, on: &PyHost, external_ports: Vec<u16>) -> (Self, PyService) {
+        let service =
+            deployment
+                .underlying
+                .blocking_write()
+                .add_service(crate::core::CustomService::new(
+                    on.underlying.clone(),
+                    external_ports,
+                ));
+
+        (
+            PyCustomService {
+                _underlying: service.clone(),
+            },
+            PyService {
+                _underlying: service,
+            },
+        )
+    }
+}
+
+#[pyclass(extends=PyService, subclass)]
+struct PyHydroflowCrate {
+    underlying: Arc<RwLock<crate::core::HydroflowCrate>>,
+}
 
 #[pymethods]
 impl PyHydroflowCrate {
@@ -142,96 +199,88 @@ impl PyHydroflowCrate {
         example: Option<String>,
         features: Option<Vec<String>>,
     ) -> (Self, PyService) {
+        let service =
+            deployment
+                .underlying
+                .blocking_write()
+                .add_service(crate::core::HydroflowCrate::new(
+                    src.into(),
+                    on.underlying.clone(),
+                    example,
+                    features,
+                ));
+
         (
-            PyHydroflowCrate {},
+            PyHydroflowCrate {
+                underlying: service.clone(),
+            },
             PyService {
-                underlying: deployment.underlying.blocking_write().add_service(
-                    crate::core::HydroflowCrate::new(
-                        src.into(),
-                        on.underlying.clone(),
-                        example,
-                        features,
-                    ),
-                ),
+                _underlying: service,
             },
         )
     }
 
-    fn stdout<'p>(self_: PyRef<'p, Self>, py: Python<'p>) -> &'p pyo3::PyAny {
-        let underlying = &self_.as_ref().underlying;
-        let underlying = underlying.clone();
+    fn stdout<'p>(&self, py: Python<'p>) -> &'p pyo3::PyAny {
+        let underlying = self.underlying.clone();
         pyo3_asyncio::tokio::future_into_py(py, async move {
-            let mut underlying_mut = underlying.write().await;
-            let hydro = underlying_mut
-                .as_any_mut()
-                .downcast_mut::<crate::core::HydroflowCrate>()
-                .unwrap();
+            let underlying = underlying.read().await;
             Ok(PyReceiver {
-                receiver: Arc::new(hydro.stdout().await),
+                receiver: Arc::new(underlying.stdout().await),
             })
         })
         .unwrap()
     }
 
-    fn stderr<'p>(self_: PyRef<'p, Self>, py: Python<'p>) -> &'p pyo3::PyAny {
-        let underlying = &self_.as_ref().underlying;
-        let underlying = underlying.clone();
+    fn stderr<'p>(&self, py: Python<'p>) -> &'p pyo3::PyAny {
+        let underlying = self.underlying.clone();
         pyo3_asyncio::tokio::future_into_py(py, async move {
-            let mut underlying_mut = underlying.write().await;
-            let hydro = underlying_mut
-                .as_any_mut()
-                .downcast_mut::<crate::core::HydroflowCrate>()
-                .unwrap();
+            let underlying = underlying.read().await;
             Ok(PyReceiver {
-                receiver: Arc::new(hydro.stderr().await),
+                receiver: Arc::new(underlying.stderr().await),
             })
         })
         .unwrap()
     }
 
-    fn exit_code<'p>(self_: PyRef<'p, Self>, py: Python<'p>) -> &'p pyo3::PyAny {
-        let underlying = &self_.as_ref().underlying;
-        let underlying = underlying.clone();
+    fn exit_code<'p>(&self, py: Python<'p>) -> &'p pyo3::PyAny {
+        let underlying = self.underlying.clone();
         pyo3_asyncio::tokio::future_into_py(py, async move {
-            let mut underlying_mut = underlying.write().await;
-            let hydro = underlying_mut
-                .as_any_mut()
-                .downcast_mut::<crate::core::HydroflowCrate>()
-                .unwrap();
-            Ok(hydro.exit_code().await)
+            let underlying = underlying.read().await;
+            Ok(underlying.exit_code().await)
         })
         .unwrap()
     }
 }
 
 #[pyfunction]
-fn create_connection(from: &PyService, from_port: String, to: &PyService, to_port: String) {
+fn create_connection(
+    from: &PyHydroflowCrate,
+    from_port: String,
+    to: &PyHydroflowCrate,
+    to_port: String,
+) {
     let from = &from.underlying;
     let to = &to.underlying;
 
-    let mut from_mut = from.blocking_write();
-    let mut to_mut = to.blocking_write();
-    let from_hydro = from_mut
-        .as_any_mut()
-        .downcast_mut::<crate::core::HydroflowCrate>()
-        .unwrap();
-    let to_hydro = to_mut
-        .as_any_mut()
-        .downcast_mut::<crate::core::HydroflowCrate>()
-        .unwrap();
+    let mut from_write = from.blocking_write();
+    let mut to_write = to.blocking_write();
 
-    from_hydro.add_outgoing_port(from_port, to, to_port.clone());
-    to_hydro.add_incoming_port(to_port, from_hydro);
+    from_write.add_outgoing_port(from_port, to, to_port.clone());
+    to_write.add_incoming_port(to_port, &from_write);
 }
 
 #[pymodule]
 pub fn hydro_cli_rust(_py: Python<'_>, module: &PyModule) -> PyResult<()> {
     module.add_class::<AnyhowWrapper>()?;
+
     module.add_class::<PyDeployment>()?;
+
     module.add_class::<PyHost>()?;
     module.add_class::<PyLocalhostHost>()?;
     module.add_class::<PyGCPComputeEngineHost>()?;
 
+    module.add_class::<PyService>()?;
+    module.add_class::<PyCustomService>()?;
     module.add_class::<PyHydroflowCrate>()?;
 
     module.add_function(wrap_pyfunction!(create_connection, module)?)?;

--- a/hydro_cli/test.hydro.py
+++ b/hydro_cli/test.hydro.py
@@ -5,12 +5,14 @@ async def main():
     machine1 = deployment.GCPComputeEngineHost(
         project="autocompartmentalization",
         machine_type="e2-micro",
+        image="debian-cloud/debian-11",
         region="us-west1-a"
     )
 
     machine2 = deployment.GCPComputeEngineHost(
         project="autocompartmentalization",
         machine_type="e2-micro",
+        image="debian-cloud/debian-11",
         region="us-west1-a"
     )
 

--- a/hydroflow/examples/cli_receiver/main.rs
+++ b/hydroflow/examples/cli_receiver/main.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use hydroflow::{
     hydroflow_syntax,
-    util::connection::{BindType, ConnectionPipe},
+    util::connection::{BindConfig, ConnectionPipe},
 };
 
 #[tokio::main]
@@ -11,11 +11,11 @@ async fn main() {
     std::io::stdin().read_line(&mut input).unwrap();
     let trimmed = input.trim();
 
-    let mut bind_types = serde_json::from_str::<HashMap<String, BindType>>(trimmed).unwrap();
+    let mut bind_config = serde_json::from_str::<HashMap<String, BindConfig>>(trimmed).unwrap();
 
     // bind to sockets
     let mut bind_results: HashMap<String, ConnectionPipe> = HashMap::new();
-    let bar_bind = bind_types.remove("bar").unwrap().bind().await;
+    let bar_bind = bind_config.remove("bar").unwrap().bind().await;
     bind_results.insert("bar".to_string(), bar_bind.connection_pipe());
 
     let bind_serialized = serde_json::to_string(&bind_results).unwrap();

--- a/hydroflow/examples/cli_sender/main.rs
+++ b/hydroflow/examples/cli_sender/main.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use hydroflow::{
     hydroflow_syntax,
-    util::connection::{BindType, ConnectionPipe},
+    util::connection::{BindConfig, ConnectionPipe},
 };
 
 #[tokio::main]
@@ -12,7 +12,7 @@ async fn main() {
     let trimmed = input.trim();
 
     #[allow(unused)]
-    let mut bind_types = serde_json::from_str::<HashMap<String, BindType>>(trimmed).unwrap();
+    let mut bind_config = serde_json::from_str::<HashMap<String, BindConfig>>(trimmed).unwrap();
 
     // bind to sockets
     #[allow(unused)]

--- a/hydroflow/src/util/connection.rs
+++ b/hydroflow/src/util/connection.rs
@@ -14,7 +14,7 @@ use super::tcp_lines;
 use super::unix_lines;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub enum BindType {
+pub enum BindConfig {
     UnixSocket,
     TcpPort(
         /// The host the port should be bound on.
@@ -22,10 +22,10 @@ pub enum BindType {
     ),
 }
 
-impl BindType {
+impl BindConfig {
     pub async fn bind(self) -> BoundConnection {
         match self {
-            BindType::UnixSocket => {
+            BindConfig::UnixSocket => {
                 #[cfg(unix)]
                 {
                     let dir = tempfile::tempdir().unwrap();
@@ -38,7 +38,7 @@ impl BindType {
                     panic!("Unix sockets are not supported on this platform")
                 }
             }
-            BindType::TcpPort(host) => {
+            BindConfig::TcpPort(host) => {
                 let listener = TcpListener::bind((host, 0)).await.unwrap();
                 BoundConnection::TcpPort(listener)
             }


### PR DESCRIPTION
Also cleans up a bunch of downcasts due to poor `Arc` usage (evidently, `Arc<A> where A: B` can be used as an `Arc<dyn B>` (I need to really refine my understanding of `dyn`)