### PR TITLE
Add `.async` Dedalus directive to specify pipeline for inter-Dedalus messaging

### DIFF
--- a/hydroflow/examples/cli_receiver/main.rs
+++ b/hydroflow/examples/cli_receiver/main.rs
@@ -8,10 +8,10 @@ async fn main() {
 
     let mut df = datalog!(
         r#"
-        .input bar `source_stream(bar_recv) -> map(|x| deserialize_from_bytes::<(String,)>(x.unwrap()))`
+        .async repeated `for_each(|_: String| ())` `source_stream(bar_recv) -> map(|x| deserialize_from_bytes::<(String,)>(x.unwrap()))`
         .output stdout `for_each(|tup| println!("echo {:?}", tup))`
 
-        stdout(x) :- bar(x)
+        stdout(x) :- repeated(x)
     "#
     );
 

--- a/hydroflow/examples/cli_sender/main.rs
+++ b/hydroflow/examples/cli_sender/main.rs
@@ -8,10 +8,11 @@ async fn main() {
 
     let mut df = datalog!(
         r#"
-        .input repeated `repeat_iter(["Hello".to_string(), "world".to_string()]) -> map(|x| (x,))`
-        .output foo `map(|(v,)| serialize_to_bytes(v)) -> dest_sink(foo_send)`
+        .input repeated `repeat_iter([("Hello".to_string(),), ("world".to_string(),)])`
+        .input peers `repeat_iter([(0,)])`
+        .async repeated `map(|(node_id, v)| serialize_to_bytes(v)) -> dest_sink(foo_send)` `null()`
 
-        foo(x) :- repeated(x)
+        repeated@n(x) :~ repeated(x), peers(n)
     "#
     );
 

--- a/hydroflow/tests/datalog_frontend.rs
+++ b/hydroflow/tests/datalog_frontend.rs
@@ -696,16 +696,16 @@ fn test_send_to_node() {
         let async_receive_result = async_receive_result_1;
         let result = result_1;
 
-        let async_send_result = move |node: usize, data: (usize,)| -> Result<(), ()> {
+        let async_send_result = move |node: usize, data: (usize,)| {
             assert!(node == 2);
             async_send_result_2.send(data).unwrap();
-            Ok(())
         };
 
         datalog!(
             r#"
             .input ints `source_stream(ints)`
             .output result `for_each(|v| result.send(v).unwrap())`
+            .async result `for_each(|(node, data)| async_send_result(node, data))` `source_stream(async_receive_result)`
 
             result@b(a) :~ ints(a, b)
             "#
@@ -717,7 +717,7 @@ fn test_send_to_node() {
         let async_receive_result = async_receive_result_2;
         let result = result_2;
 
-        let async_send_result = |_: usize, _: (usize,)| -> Result<(), ()> {
+        let async_send_result = |_: usize, _: (usize,)| {
             panic!("Should not be called");
         };
 
@@ -725,6 +725,7 @@ fn test_send_to_node() {
             r#"
             .input ints `source_stream(ints)`
             .output result `for_each(|v| result.send(v).unwrap())`
+            .async result `for_each(|(node, data)| async_send_result(node, data))` `source_stream(async_receive_result)`
 
             result@b(a) :~ ints(a, b)
             "#

--- a/hydroflow_datalog_core/src/grammar.rs
+++ b/hydroflow_datalog_core/src/grammar.rs
@@ -15,6 +15,14 @@ pub mod datalog {
             Ident,
             RustSnippet,
         ),
+        Async(
+            #[rust_sitter::leaf(text = ".async")] (),
+            Ident,
+            /// A pipeline for data to be sent to another node, which must consume `(NodeID, Data)` pairs.
+            RustSnippet,
+            /// A pipeline for data received from another node, which must produce `Data` values.
+            RustSnippet,
+        ),
         Rule(Rule),
     }
 

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__send_to_node@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__send_to_node@datalog_program.snap
@@ -7,9 +7,9 @@ fn main() {
         {
             use hydroflow::{var_expr, var_args};
             let mut df = hydroflow::scheduled::graph::Hydroflow::new_with_graph(
-                "{\"nodes\":[{\"value\":null,\"version\":0},{\"value\":\"merge ()\",\"version\":1},{\"value\":\"unique :: < 'tick > ()\",\"version\":1},{\"value\":\"tee ()\",\"version\":1},{\"value\":\"merge ()\",\"version\":1},{\"value\":\"unique :: < 'tick > ()\",\"version\":1},{\"value\":\"tee ()\",\"version\":1},{\"value\":\"source_stream (ints)\",\"version\":1},{\"value\":\"for_each (| v | result . send (v) . unwrap ())\",\"version\":1},{\"value\":\"source_stream (async_receive_result)\",\"version\":1},{\"value\":\"map (| row : (_ , _ ,) | (row . 0 , row . 1 ,))\",\"version\":1},{\"value\":\"for_each (| v : (_ , _ ,) | async_send_result (v . 1 , (v . 0 ,)) . unwrap ())\",\"version\":1}],\"node_color_map\":[{\"value\":null,\"version\":0},{\"value\":\"Pull\",\"version\":1},{\"value\":\"Push\",\"version\":1},{\"value\":\"Push\",\"version\":1},{\"value\":\"Pull\",\"version\":1},{\"value\":\"Push\",\"version\":1},{\"value\":\"Push\",\"version\":1},{\"value\":\"Pull\",\"version\":1},{\"value\":\"Push\",\"version\":1},{\"value\":\"Pull\",\"version\":1},{\"value\":\"Push\",\"version\":1},{\"value\":\"Push\",\"version\":1}],\"edges\":[{\"value\":null,\"version\":0},{\"value\":[{\"src\":{\"idx\":1,\"version\":1},\"dst\":{\"idx\":2,\"version\":1},\"blocking\":false,\"label\":null}],\"version\":1},{\"value\":[{\"src\":{\"idx\":2,\"version\":1},\"dst\":{\"idx\":3,\"version\":1},\"blocking\":false,\"label\":null}],\"version\":1},{\"value\":[{\"src\":{\"idx\":3,\"version\":1},\"dst\":{\"idx\":10,\"version\":1},\"blocking\":false,\"label\":\"0\"}],\"version\":1},{\"value\":[{\"src\":{\"idx\":4,\"version\":1},\"dst\":{\"idx\":5,\"version\":1},\"blocking\":false,\"label\":null}],\"version\":1},{\"value\":[{\"src\":{\"idx\":5,\"version\":1},\"dst\":{\"idx\":6,\"version\":1},\"blocking\":false,\"label\":null}],\"version\":1},{\"value\":[{\"src\":{\"idx\":6,\"version\":1},\"dst\":{\"idx\":8,\"version\":1},\"blocking\":false,\"label\":\"0\"}],\"version\":1},{\"value\":[{\"src\":{\"idx\":7,\"version\":1},\"dst\":{\"idx\":1,\"version\":1},\"blocking\":false,\"label\":\"0\"}],\"version\":1},{\"value\":null,\"version\":0},{\"value\":[{\"src\":{\"idx\":9,\"version\":1},\"dst\":{\"idx\":4,\"version\":1},\"blocking\":false,\"label\":\"0\"}],\"version\":1},{\"value\":[{\"src\":{\"idx\":10,\"version\":1},\"dst\":{\"idx\":11,\"version\":1},\"blocking\":false,\"label\":null}],\"version\":1}],\"barrier_handoffs\":[{\"value\":null,\"version\":0}],\"subgraph_nodes\":[{\"value\":null,\"version\":0},{\"value\":[{\"idx\":9,\"version\":1},{\"idx\":4,\"version\":1},{\"idx\":5,\"version\":1},{\"idx\":6,\"version\":1},{\"idx\":8,\"version\":1}],\"version\":1},{\"value\":[{\"idx\":7,\"version\":1},{\"idx\":1,\"version\":1},{\"idx\":2,\"version\":1},{\"idx\":3,\"version\":1},{\"idx\":10,\"version\":1},{\"idx\":11,\"version\":1}],\"version\":1}],\"subgraph_stratum\":[{\"value\":null,\"version\":0},{\"value\":0,\"version\":1},{\"value\":0,\"version\":1}],\"subgraph_internal_handoffs\":[{\"value\":null,\"version\":0}],\"varname_nodes\":{\"ints\":[{\"idx\":1,\"version\":1},{\"idx\":2,\"version\":1},{\"idx\":3,\"version\":1}],\"result\":[{\"idx\":4,\"version\":1},{\"idx\":5,\"version\":1},{\"idx\":6,\"version\":1}]}}\n",
+                "{\"nodes\":[{\"value\":null,\"version\":0},{\"value\":\"merge ()\",\"version\":1},{\"value\":\"unique :: < 'tick > ()\",\"version\":1},{\"value\":\"tee ()\",\"version\":1},{\"value\":\"merge ()\",\"version\":1},{\"value\":\"unique :: < 'tick > ()\",\"version\":1},{\"value\":\"tee ()\",\"version\":1},{\"value\":\"source_stream (ints)\",\"version\":1},{\"value\":\"for_each (| v | result . send (v) . unwrap ())\",\"version\":1},{\"value\":\"merge ()\",\"version\":1},{\"value\":\"for_each (| (node , data) | async_send_result (node , data))\",\"version\":1},{\"value\":\"source_stream (async_receive_result)\",\"version\":1},{\"value\":\"map (| row : (_ , _ ,) | (row . 0 , row . 1 ,))\",\"version\":1},{\"value\":\"map (| v : (_ , _ ,) | (v . 1 , (v . 0 ,)))\",\"version\":1}],\"node_color_map\":[{\"value\":null,\"version\":0},{\"value\":\"Pull\",\"version\":1},{\"value\":\"Push\",\"version\":1},{\"value\":\"Push\",\"version\":1},{\"value\":\"Pull\",\"version\":1},{\"value\":\"Push\",\"version\":1},{\"value\":\"Push\",\"version\":1},{\"value\":\"Pull\",\"version\":1},{\"value\":\"Push\",\"version\":1},{\"value\":\"Push\",\"version\":1},{\"value\":\"Push\",\"version\":1},{\"value\":\"Pull\",\"version\":1},{\"value\":\"Push\",\"version\":1},{\"value\":\"Push\",\"version\":1}],\"edges\":[{\"value\":null,\"version\":0},{\"value\":[{\"src\":{\"idx\":1,\"version\":1},\"dst\":{\"idx\":2,\"version\":1},\"blocking\":false,\"label\":null}],\"version\":1},{\"value\":[{\"src\":{\"idx\":2,\"version\":1},\"dst\":{\"idx\":3,\"version\":1},\"blocking\":false,\"label\":null}],\"version\":1},{\"value\":[{\"src\":{\"idx\":3,\"version\":1},\"dst\":{\"idx\":12,\"version\":1},\"blocking\":false,\"label\":\"0\"}],\"version\":1},{\"value\":[{\"src\":{\"idx\":4,\"version\":1},\"dst\":{\"idx\":5,\"version\":1},\"blocking\":false,\"label\":null}],\"version\":1},{\"value\":[{\"src\":{\"idx\":5,\"version\":1},\"dst\":{\"idx\":6,\"version\":1},\"blocking\":false,\"label\":null}],\"version\":1},{\"value\":[{\"src\":{\"idx\":6,\"version\":1},\"dst\":{\"idx\":8,\"version\":1},\"blocking\":false,\"label\":\"0\"}],\"version\":1},{\"value\":[{\"src\":{\"idx\":7,\"version\":1},\"dst\":{\"idx\":1,\"version\":1},\"blocking\":false,\"label\":\"0\"}],\"version\":1},{\"value\":null,\"version\":0},{\"value\":[{\"src\":{\"idx\":9,\"version\":1},\"dst\":{\"idx\":10,\"version\":1},\"blocking\":false,\"label\":null}],\"version\":1},{\"value\":null,\"version\":0},{\"value\":[{\"src\":{\"idx\":11,\"version\":1},\"dst\":{\"idx\":4,\"version\":1},\"blocking\":false,\"label\":\"0\"}],\"version\":1},{\"value\":[{\"src\":{\"idx\":12,\"version\":1},\"dst\":{\"idx\":13,\"version\":1},\"blocking\":false,\"label\":null}],\"version\":1},{\"value\":[{\"src\":{\"idx\":13,\"version\":1},\"dst\":{\"idx\":9,\"version\":1},\"blocking\":false,\"label\":null}],\"version\":1}],\"barrier_handoffs\":[{\"value\":null,\"version\":0}],\"subgraph_nodes\":[{\"value\":null,\"version\":0},{\"value\":[{\"idx\":11,\"version\":1},{\"idx\":4,\"version\":1},{\"idx\":5,\"version\":1},{\"idx\":6,\"version\":1},{\"idx\":8,\"version\":1}],\"version\":1},{\"value\":[{\"idx\":7,\"version\":1},{\"idx\":1,\"version\":1},{\"idx\":2,\"version\":1},{\"idx\":3,\"version\":1},{\"idx\":12,\"version\":1},{\"idx\":13,\"version\":1},{\"idx\":9,\"version\":1},{\"idx\":10,\"version\":1}],\"version\":1}],\"subgraph_stratum\":[{\"value\":null,\"version\":0},{\"value\":0,\"version\":1},{\"value\":0,\"version\":1}],\"subgraph_internal_handoffs\":[{\"value\":null,\"version\":0}],\"varname_nodes\":{\"ints\":[{\"idx\":1,\"version\":1},{\"idx\":2,\"version\":1},{\"idx\":3,\"version\":1}],\"result\":[{\"idx\":4,\"version\":1},{\"idx\":5,\"version\":1},{\"idx\":6,\"version\":1}],\"result_async_send\":[{\"idx\":9,\"version\":1},{\"idx\":10,\"version\":1}]}}\n",
             );
-            let mut sg_1v1_node_9v1_stream = Box::pin(async_receive_result);
+            let mut sg_1v1_node_11v1_stream = Box::pin(async_receive_result);
             let sg_1v1_node_5v1_uniquedata = df
                 .add_state(
                     ::std::cell::RefCell::new(
@@ -25,24 +25,24 @@ fn main() {
                 var_expr!(),
                 var_expr!(),
                 move |context, var_args!(), var_args!()| {
-                    let op_9v1 = std::iter::from_fn(|| {
+                    let op_11v1 = std::iter::from_fn(|| {
                         match hydroflow::futures::stream::Stream::poll_next(
-                            sg_1v1_node_9v1_stream.as_mut(),
+                            sg_1v1_node_11v1_stream.as_mut(),
                             &mut std::task::Context::from_waker(&context.waker()),
                         ) {
                             std::task::Poll::Ready(maybe) => maybe,
                             std::task::Poll::Pending => None,
                         }
                     });
-                    let op_9v1 = {
+                    let op_11v1 = {
                         #[inline(always)]
-                        pub fn check_op_9v1<
+                        pub fn check_op_11v1<
                             Input: ::std::iter::Iterator<Item = Item>,
                             Item,
                         >(input: Input) -> impl ::std::iter::Iterator<Item = Item> {
                             input
                         }
-                        check_op_9v1(op_9v1)
+                        check_op_11v1(op_11v1)
                     };
                     let op_4v1 = {
                         #[allow(unused)]
@@ -54,7 +54,7 @@ fn main() {
                         >(a: A, b: B) -> impl ::std::iter::Iterator<Item = Item> {
                             a.chain(b)
                         }
-                        op_9v1
+                        op_11v1
                     };
                     let op_4v1 = {
                         #[inline(always)]
@@ -225,23 +225,56 @@ fn main() {
                         }
                         check_op_3v1(op_3v1)
                     };
-                    let op_10v1 = op_3v1.map(|row: (_, _)| (row.0, row.1));
-                    let op_10v1 = {
+                    let op_12v1 = op_3v1.map(|row: (_, _)| (row.0, row.1));
+                    let op_12v1 = {
                         #[inline(always)]
-                        pub fn check_op_10v1<
+                        pub fn check_op_12v1<
                             Input: ::std::iter::Iterator<Item = Item>,
                             Item,
                         >(input: Input) -> impl ::std::iter::Iterator<Item = Item> {
                             input
                         }
-                        check_op_10v1(op_10v1)
+                        check_op_12v1(op_12v1)
                     };
-                    let op_11v1 = hydroflow::pusherator::for_each::ForEach::new(|
-                        v: (_, _)|
-                    async_send_result(v.1, (v.0,)).unwrap());
-                    let op_11v1 = {
+                    let op_13v1 = op_12v1.map(|v: (_, _)| (v.1, (v.0,)));
+                    let op_13v1 = {
                         #[inline(always)]
-                        pub fn check_op_11v1<
+                        pub fn check_op_13v1<
+                            Input: ::std::iter::Iterator<Item = Item>,
+                            Item,
+                        >(input: Input) -> impl ::std::iter::Iterator<Item = Item> {
+                            input
+                        }
+                        check_op_13v1(op_13v1)
+                    };
+                    let op_9v1 = {
+                        #[allow(unused)]
+                        #[inline(always)]
+                        fn check_inputs<
+                            A: ::std::iter::Iterator<Item = Item>,
+                            B: ::std::iter::Iterator<Item = Item>,
+                            Item,
+                        >(a: A, b: B) -> impl ::std::iter::Iterator<Item = Item> {
+                            a.chain(b)
+                        }
+                        op_13v1
+                    };
+                    let op_9v1 = {
+                        #[inline(always)]
+                        pub fn check_op_9v1<
+                            Input: ::std::iter::Iterator<Item = Item>,
+                            Item,
+                        >(input: Input) -> impl ::std::iter::Iterator<Item = Item> {
+                            input
+                        }
+                        check_op_9v1(op_9v1)
+                    };
+                    let op_10v1 = hydroflow::pusherator::for_each::ForEach::new(|
+                        (node, data)|
+                    async_send_result(node, data));
+                    let op_10v1 = {
+                        #[inline(always)]
+                        pub fn check_op_10v1<
                             Input: hydroflow::pusherator::Pusherator<Item = Item>,
                             Item,
                         >(
@@ -249,7 +282,7 @@ fn main() {
                         ) -> impl hydroflow::pusherator::Pusherator<Item = Item> {
                             input
                         }
-                        check_op_11v1(op_11v1)
+                        check_op_10v1(op_10v1)
                     };
                     #[inline(always)]
                     fn check_pivot_run<
@@ -259,7 +292,7 @@ fn main() {
                     >(pull: Pull, push: Push) {
                         hydroflow::pusherator::pivot::Pivot::new(pull, push).run();
                     }
-                    check_pivot_run(op_10v1, op_11v1);
+                    check_pivot_run(op_9v1, op_10v1);
                 },
             );
             df

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__send_to_node@surface_graph.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__send_to_node@surface_graph.snap
@@ -10,9 +10,11 @@ expression: graph.surface_syntax_string()
 6v1 = tee ();
 7v1 = source_stream (ints);
 8v1 = for_each (| v | result . send (v) . unwrap ());
-9v1 = source_stream (async_receive_result);
-10v1 = map (| row : (_ , _ ,) | (row . 0 , row . 1 ,));
-11v1 = for_each (| v : (_ , _ ,) | async_send_result (v . 1 , (v . 0 ,)) . unwrap ());
+9v1 = merge ();
+10v1 = for_each (| (node , data) | async_send_result (node , data));
+11v1 = source_stream (async_receive_result);
+12v1 = map (| row : (_ , _ ,) | (row . 0 , row . 1 ,));
+13v1 = map (| v : (_ , _ ,) | (v . 1 , (v . 0 ,)));
 
 2v1 -> 3v1;
 1v1 -> 2v1;
@@ -20,7 +22,9 @@ expression: graph.surface_syntax_string()
 4v1 -> 5v1;
 7v1 -> 1v1;
 6v1 -> 8v1;
-9v1 -> 4v1;
-10v1 -> 11v1;
-3v1 -> 10v1;
+9v1 -> 10v1;
+11v1 -> 4v1;
+13v1 -> 9v1;
+12v1 -> 13v1;
+3v1 -> 12v1;
 


### PR DESCRIPTION
Add `.async` Dedalus directive to specify pipeline for inter-Dedalus messaging

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydroflow/pull/443).
* #445
* __->__ #443
