### PR TITLE
Only skipped pinned Rust builds if nothing has changed when merging a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
     name: Check
     timeout-minutes: 10
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -38,6 +37,7 @@ jobs:
           # and nothing is truthy, so the entire && operator will resolve to
           # 'nothing'. Then the || operator will resolve to 'nothing' so we
           # will exclude 'nothing'. https://stackoverflow.com/a/73822998
+          - rust_release: ${{ (needs.pre_job.outputs.should_skip != 'true' && 'nothing') || 'pinned-nightly' }}
           - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-nightly' }}
 
     steps:
@@ -61,7 +61,6 @@ jobs:
     name: Check WebAssembly
     timeout-minutes: 10
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -71,6 +70,7 @@ jobs:
           # and nothing is truthy, so the entire && operator will resolve to
           # 'nothing'. Then the || operator will resolve to 'nothing' so we
           # will exclude 'nothing'. https://stackoverflow.com/a/73822998
+          - rust_release: ${{ (needs.pre_job.outputs.should_skip != 'true' && 'nothing') || 'pinned-nightly' }}
           - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-nightly' }}
 
     steps:
@@ -95,7 +95,6 @@ jobs:
     name: Test Suite
     timeout-minutes: 15
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -105,6 +104,7 @@ jobs:
           # and nothing is truthy, so the entire && operator will resolve to
           # 'nothing'. Then the || operator will resolve to 'nothing' so we
           # will exclude 'nothing'. https://stackoverflow.com/a/73822998
+          - rust_release: ${{ (needs.pre_job.outputs.should_skip != 'true' && 'nothing') || 'pinned-nightly' }}
           - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-nightly' }}
 
     steps:
@@ -117,7 +117,6 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: ${{ matrix.rust_release == 'latest-nightly' }}
-          components: rustfmt
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
@@ -129,7 +128,6 @@ jobs:
     name: Test Suite (WebAssembly)
     timeout-minutes: 15
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -139,6 +137,7 @@ jobs:
           # and nothing is truthy, so the entire && operator will resolve to
           # 'nothing'. Then the || operator will resolve to 'nothing' so we
           # will exclude 'nothing'. https://stackoverflow.com/a/73822998
+          - rust_release: ${{ (needs.pre_job.outputs.should_skip != 'true' && 'nothing') || 'pinned-nightly' }}
           - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-nightly' }}
 
     steps:
@@ -150,8 +149,8 @@ jobs:
         with:
           profile: minimal
           toolchain: nightly
+          target: wasm32-unknown-unknown
           override: ${{ matrix.rust_release == 'latest-nightly' }}
-          components: rustfmt
 
       - name: Install WebAssembly test runner
         uses: actions-rs/cargo@v1
@@ -171,7 +170,6 @@ jobs:
     name: Lints
     timeout-minutes: 10
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -181,6 +179,7 @@ jobs:
           # and nothing is truthy, so the entire && operator will resolve to
           # 'nothing'. Then the || operator will resolve to 'nothing' so we
           # will exclude 'nothing'. https://stackoverflow.com/a/73822998
+          - rust_release: ${{ (needs.pre_job.outputs.should_skip != 'true' && 'nothing') || 'pinned-nightly' }}
           - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-nightly' }}
 
     steps:


### PR DESCRIPTION
Only skipped pinned Rust builds if nothing has changed when merging a PR

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydroflow/pull/447).
* __->__ #447
