### PR TITLE
Use `prettyplease` in relalg tests to avoid `rustfmt` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2543,8 +2543,9 @@ dependencies = [
  "anyhow",
  "datadriven",
  "hydroflow",
+ "prettyplease",
  "quote",
- "xshell",
+ "syn",
 ]
 
 [[package]]
@@ -3810,21 +3811,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
-
-[[package]]
-name = "xshell"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaad2035244c56da05573d4d7fda5f903c60a5f35b9110e157a14a1df45a9f14"
-dependencies = [
- "xshell-macros",
-]
-
-[[package]]
-name = "xshell-macros"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4916a4a3cad759e499a3620523bf9545cc162d7a06163727dde97ce9aaa4cf39"
 
 [[package]]
 name = "yaml-rust"

--- a/relalg/Cargo.toml
+++ b/relalg/Cargo.toml
@@ -8,4 +8,5 @@ anyhow = "1.0"
 datadriven = "0.6.0"
 hydroflow = { path = "../hydroflow" }
 quote = "1.0"
-xshell = "0.1"
+syn = { version = "1.0.0", features = [ "parsing", "extra-traits" ] }
+prettyplease = "0.1.21"

--- a/relalg/testdata/compile/compile
+++ b/relalg/testdata/compile/compile
@@ -1,118 +1,123 @@
 compile
 (values [[1 2 3]])
 ----
+----
 fn main() {
-    let __values_1 = vec![vec![
-        ScalarExpr::Literal(Datum::Int(1i64)).eval(&Vec::new()),
-        ScalarExpr::Literal(Datum::Int(2i64)).eval(&Vec::new()),
-        ScalarExpr::Literal(Datum::Int(3i64)).eval(&Vec::new()),
-    ]]
-    .into_iter();
+    let __values_1 = vec![
+        vec![ScalarExpr::Literal(Datum::Int(1i64)).eval(& Vec::new()),
+        ScalarExpr::Literal(Datum::Int(2i64)).eval(& Vec::new()),
+        ScalarExpr::Literal(Datum::Int(3i64)).eval(& Vec::new())]
+    ]
+        .into_iter();
     for row in __values_1 {
         println!("{:?}", row);
     }
 }
 
+----
+----
+
 compile
 (filter [(= @0 1)]
     (values [[1 2 3]]))
 ----
+----
 fn main() {
-    let __values_2 = vec![vec![
-        ScalarExpr::Literal(Datum::Int(1i64)).eval(&Vec::new()),
-        ScalarExpr::Literal(Datum::Int(2i64)).eval(&Vec::new()),
-        ScalarExpr::Literal(Datum::Int(3i64)).eval(&Vec::new()),
-    ]]
-    .into_iter();
-    let __filter_1 = __values_2.filter(|row| {
-        ScalarExpr::Eq(
-            Box::new(ScalarExpr::ColRef(0usize)),
-            Box::new(ScalarExpr::Literal(Datum::Int(1i64))),
-        )
-        .eval(row)
-        .is_true()
-    });
+    let __values_2 = vec![
+        vec![ScalarExpr::Literal(Datum::Int(1i64)).eval(& Vec::new()),
+        ScalarExpr::Literal(Datum::Int(2i64)).eval(& Vec::new()),
+        ScalarExpr::Literal(Datum::Int(3i64)).eval(& Vec::new())]
+    ]
+        .into_iter();
+    let __filter_1 = __values_2
+        .filter(|row| {
+            ScalarExpr::Eq(
+                    Box::new(ScalarExpr::ColRef(0usize)),
+                    Box::new(ScalarExpr::Literal(Datum::Int(1i64))),
+                )
+                .eval(row)
+                .is_true()
+        });
     for row in __filter_1 {
         println!("{:?}", row);
     }
 }
+
+----
+----
 
 compile
 (filter [(= @0 1) (= 5 (+ @1 @2))]
     (values [[1 2 3] [4 5 6]]))
 ----
+----
 fn main() {
     let __values_2 = vec![
-        vec![
-            ScalarExpr::Literal(Datum::Int(1i64)).eval(&Vec::new()),
-            ScalarExpr::Literal(Datum::Int(2i64)).eval(&Vec::new()),
-            ScalarExpr::Literal(Datum::Int(3i64)).eval(&Vec::new()),
-        ],
-        vec![
-            ScalarExpr::Literal(Datum::Int(4i64)).eval(&Vec::new()),
-            ScalarExpr::Literal(Datum::Int(5i64)).eval(&Vec::new()),
-            ScalarExpr::Literal(Datum::Int(6i64)).eval(&Vec::new()),
-        ],
+        vec![ScalarExpr::Literal(Datum::Int(1i64)).eval(& Vec::new()),
+        ScalarExpr::Literal(Datum::Int(2i64)).eval(& Vec::new()),
+        ScalarExpr::Literal(Datum::Int(3i64)).eval(& Vec::new())],
+        vec![ScalarExpr::Literal(Datum::Int(4i64)).eval(& Vec::new()),
+        ScalarExpr::Literal(Datum::Int(5i64)).eval(& Vec::new()),
+        ScalarExpr::Literal(Datum::Int(6i64)).eval(& Vec::new())]
     ]
-    .into_iter();
-    let __filter_1 = __values_2.filter(|row| {
-        ScalarExpr::Eq(
-            Box::new(ScalarExpr::ColRef(0usize)),
-            Box::new(ScalarExpr::Literal(Datum::Int(1i64))),
-        )
-        .eval(row)
-        .is_true()
-            && ScalarExpr::Eq(
-                Box::new(ScalarExpr::Literal(Datum::Int(5i64))),
-                Box::new(ScalarExpr::Plus(
-                    Box::new(ScalarExpr::ColRef(1usize)),
-                    Box::new(ScalarExpr::ColRef(2usize)),
-                )),
-            )
-            .eval(row)
-            .is_true()
-    });
+        .into_iter();
+    let __filter_1 = __values_2
+        .filter(|row| {
+            ScalarExpr::Eq(
+                    Box::new(ScalarExpr::ColRef(0usize)),
+                    Box::new(ScalarExpr::Literal(Datum::Int(1i64))),
+                )
+                .eval(row)
+                .is_true()
+                && ScalarExpr::Eq(
+                        Box::new(ScalarExpr::Literal(Datum::Int(5i64))),
+                        Box::new(
+                            ScalarExpr::Plus(
+                                Box::new(ScalarExpr::ColRef(1usize)),
+                                Box::new(ScalarExpr::ColRef(2usize)),
+                            ),
+                        ),
+                    )
+                    .eval(row)
+                    .is_true()
+        });
     for row in __filter_1 {
         println!("{:?}", row);
     }
 }
 
+----
+----
+
 compile
 (project [(+ @0 1) (+ 5 (+ @1 @2))]
     (values [[1 2 3] [4 5 6]]))
 ----
+----
 fn main() {
     let __values_2 = vec![
-        vec![
-            ScalarExpr::Literal(Datum::Int(1i64)).eval(&Vec::new()),
-            ScalarExpr::Literal(Datum::Int(2i64)).eval(&Vec::new()),
-            ScalarExpr::Literal(Datum::Int(3i64)).eval(&Vec::new()),
-        ],
-        vec![
-            ScalarExpr::Literal(Datum::Int(4i64)).eval(&Vec::new()),
-            ScalarExpr::Literal(Datum::Int(5i64)).eval(&Vec::new()),
-            ScalarExpr::Literal(Datum::Int(6i64)).eval(&Vec::new()),
-        ],
+        vec![ScalarExpr::Literal(Datum::Int(1i64)).eval(& Vec::new()),
+        ScalarExpr::Literal(Datum::Int(2i64)).eval(& Vec::new()),
+        ScalarExpr::Literal(Datum::Int(3i64)).eval(& Vec::new())],
+        vec![ScalarExpr::Literal(Datum::Int(4i64)).eval(& Vec::new()),
+        ScalarExpr::Literal(Datum::Int(5i64)).eval(& Vec::new()),
+        ScalarExpr::Literal(Datum::Int(6i64)).eval(& Vec::new())]
     ]
-    .into_iter();
-    let __project_1 = __values_2.map(|row| {
-        vec![
-            ScalarExpr::Plus(
-                Box::new(ScalarExpr::ColRef(0usize)),
-                Box::new(ScalarExpr::Literal(Datum::Int(1i64))),
-            )
-            .eval(&row),
-            ScalarExpr::Plus(
-                Box::new(ScalarExpr::Literal(Datum::Int(5i64))),
-                Box::new(ScalarExpr::Plus(
-                    Box::new(ScalarExpr::ColRef(1usize)),
-                    Box::new(ScalarExpr::ColRef(2usize)),
-                )),
-            )
-            .eval(&row),
-        ]
-    });
+        .into_iter();
+    let __project_1 = __values_2
+        .map(|row| {
+            vec![
+                ScalarExpr::Plus(Box::new(ScalarExpr::ColRef(0usize)),
+                Box::new(ScalarExpr::Literal(Datum::Int(1i64)))).eval(& row),
+                ScalarExpr::Plus(Box::new(ScalarExpr::Literal(Datum::Int(5i64))),
+                Box::new(ScalarExpr::Plus(Box::new(ScalarExpr::ColRef(1usize)),
+                Box::new(ScalarExpr::ColRef(2usize))))).eval(& row)
+            ]
+        });
     for row in __project_1 {
         println!("{:?}", row);
     }
 }
+
+----
+----


### PR DESCRIPTION
Use `prettyplease` in relalg tests to avoid `rustfmt` dependency

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydroflow/pull/449).
* __->__ #449
