### PR TITLE
Build CLI wheels in CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,6 @@ rustflags = [
     # TODO(mingwei): Need rust-analyzer support:
     "-Aclippy::uninlined-format-args",
 ]
+
+[target.x86_64-unknown-linux-musl]
+linker = "lld"

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -3,7 +3,6 @@ name: Build CLI
 on:
   push:
     branches: [main]
-  pull_request:
 
 env:
   PACKAGE_NAME: hydro_cli

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -1,0 +1,76 @@
+name: Build CLI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  PACKAGE_NAME: hydro_cli
+  PYTHON_VERSION: "3.7" # to build abi3 wheels
+
+# based on Ruff's CI
+jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v3.4.0
+        with:
+          cancel_others: "true"
+
+  macos-universal:
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          architecture: x64
+      - name: "Build wheels - universal2"
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: hydro_cli
+          args: --release --universal2 --out dist
+      - name: "Install built wheel - universal2"
+        run: |
+          pip install hydro_cli/dist/${{ env.PACKAGE_NAME }}-*universal2.whl --force-reinstall
+      - name: "Upload wheels"
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: hydro_cli/dist
+  
+  linux:
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - i686-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          architecture: x64
+      - name: "Build wheels"
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: hydro_cli
+          target: ${{ matrix.target }}
+          manylinux: auto
+          args: --release --out dist
+      - name: "Install built wheel"
+        if: ${{ startsWith(matrix.target, 'x86_64') }}
+        run: |
+          pip install hydro_cli/dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
+      - name: "Upload wheels"
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: hydro_cli/dist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,7 @@ dependencies = [
  "log",
  "memchr",
  "opener",
+ "openssl",
  "os_info",
  "pathdiff",
  "percent-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,7 +1426,7 @@ dependencies = [
  "clap 4.1.8",
  "futures",
  "futures-core",
- "hydroflow",
+ "hydroflow_cli_integration",
  "pyo3",
  "pyo3-asyncio",
  "serde",
@@ -1451,6 +1451,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.6",
  "hdrhistogram",
+ "hydroflow_cli_integration",
  "hydroflow_datalog",
  "hydroflow_lang",
  "hydroflow_macro",
@@ -1467,7 +1468,6 @@ dependencies = [
  "serde_json",
  "slotmap",
  "static_assertions",
- "tempfile",
  "textnonce",
  "time",
  "tokio",
@@ -1478,6 +1478,19 @@ dependencies = [
  "wasm-bindgen-test",
  "wasm-bindgen-test-macro",
  "zipf",
+]
+
+[[package]]
+name = "hydroflow_cli_integration"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "hydroflow_datalog_core",
     "hydroflow_datalog",
     "hydro_cli",
+    "hydroflow_cli_integration",
     "benches",
     "relalg",
     "pusherator",

--- a/hydro_cli/Cargo.toml
+++ b/hydro_cli/Cargo.toml
@@ -15,8 +15,8 @@ name = "hydro._core"
 tokio = { version = "1.16", features = [ "full" ] }
 anyhow = { version = "1.0.69", features = [ "backtrace" ] }
 clap = { version = "4.1.8", features = ["derive"] }
-cargo = "0.68.0"
-pyo3 = { version = "0.18.1", features = ["auto-initialize", "abi3-py37"] }
+cargo = { version = "0.68.0", features = ["vendored-openssl", "vendored-libgit2"] }
+pyo3 = { version = "0.18.1", features = ["abi3-py37"] }
 pyo3-asyncio = { version = "0.18.0", features = ["attributes", "unstable-streams", "tokio-runtime"] }
 async-trait = "0.1.64"
 async-process = "1.6.0"

--- a/hydro_cli/Cargo.toml
+++ b/hydro_cli/Cargo.toml
@@ -28,6 +28,6 @@ serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 tempfile = "3.3.0"
 async-ssh2-lite = { version = "0.4.2", features = [ "tokio", "vendored-openssl" ] }
-hydroflow = { path = "../hydroflow", features = ["cli_integration"] }
+hydroflow_cli_integration = { path = "../hydroflow_cli_integration" }
 
 [dev-dependencies]

--- a/hydro_cli/src/core/gcp.rs
+++ b/hydro_cli/src/core/gcp.rs
@@ -11,7 +11,7 @@ use async_channel::{Receiver, Sender};
 use async_ssh2_lite::{AsyncChannel, AsyncSession, SessionConfiguration};
 use async_trait::async_trait;
 use futures::{AsyncWriteExt, StreamExt};
-use hydroflow::util::cli::BindConfig;
+use hydroflow_cli_integration::BindConfig;
 use serde_json::json;
 use tokio::{net::TcpStream, sync::RwLock};
 

--- a/hydro_cli/src/core/hydroflow_crate.rs
+++ b/hydro_cli/src/core/hydroflow_crate.rs
@@ -15,7 +15,7 @@ use cargo::{
     util::{command_prelude::CompileMode, interning::InternedString},
     Config,
 };
-use hydroflow::util::cli::ConnectionPipe;
+use hydroflow_cli_integration::ConnectionPipe;
 use tokio::{sync::RwLock, task::JoinHandle};
 
 use super::{BindType, Host, LaunchedBinary, LaunchedHost, ResourceBatch, ResourceResult, Service};

--- a/hydro_cli/src/core/localhost.rs
+++ b/hydro_cli/src/core/localhost.rs
@@ -5,7 +5,7 @@ use async_channel::{Receiver, Sender};
 use async_process::{Command, Stdio};
 use async_trait::async_trait;
 use futures::{io::BufReader, AsyncBufReadExt, AsyncRead, AsyncWriteExt, StreamExt};
-use hydroflow::util::cli::BindConfig;
+use hydroflow_cli_integration::BindConfig;
 use tokio::sync::RwLock;
 
 use super::{

--- a/hydro_cli/src/core/mod.rs
+++ b/hydro_cli/src/core/mod.rs
@@ -3,7 +3,7 @@ use std::{path::Path, sync::Arc};
 use anyhow::Result;
 use async_channel::{Receiver, Sender};
 use async_trait::async_trait;
-use hydroflow::util::cli::BindConfig;
+use hydroflow_cli_integration::BindConfig;
 use tokio::sync::RwLock;
 
 pub mod deployment;

--- a/hydroflow/Cargo.toml
+++ b/hydroflow/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 default = [ "async", "macros" ]
 async = [ "futures" ]
 macros = [ "hydroflow_macro", "hydroflow_datalog" ]
-cli_integration = [ "tempfile", "async-trait" ]
+cli_integration = [ "hydroflow_cli_integration", "async-trait" ]
 
 [[example]]
 name = "echoserver"
@@ -69,7 +69,7 @@ static_assertions = "1.1.0"
 tokio-stream = { version = "0.1.10", features = [ "io-util" ] }
 variadics = { path = "../variadics" }
 rustc-hash = "1.1.0"
-tempfile = { version = "3.3.0", optional = true }
+hydroflow_cli_integration = { optional = true, path = "../hydroflow_cli_integration", features = [ "runtime" ] }
 async-trait = { version = "0.1", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/hydroflow/Cargo.toml
+++ b/hydroflow/Cargo.toml
@@ -71,8 +71,6 @@ variadics = { path = "../variadics" }
 rustc-hash = "1.1.0"
 tempfile = { version = "3.3.0", optional = true }
 async-trait = { version = "0.1", optional = true }
-wasm-bindgen-test-macro = "0.3.34"
-wasm-bindgen-test = "0.3.34"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.16", features = [ "full" ] }
@@ -97,6 +95,8 @@ futures = { version = "0.3" }
 insta = "1.7.1"
 itertools = "0.10.3"
 multiplatform_test = { path = "../multiplatform_test" }
+wasm-bindgen-test-macro = "0.3.34"
+wasm-bindgen-test = "0.3.34"
 rand = "0.8.4"
 textnonce = "1.0.0"
 time = "0.3"

--- a/hydroflow_cli_integration/Cargo.toml
+++ b/hydroflow_cli_integration/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "hydroflow_cli_integration"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = []
+runtime = [ "tempfile", "async-trait", "bytes", "tokio", "futures" ]
+
+[dependencies]
+serde = { version = "1", features = [ "derive" ] }
+serde_json = "1"
+tempfile = { version = "3.3.0", optional = true }
+async-trait = { version = "0.1", optional = true }
+bytes = { version = "1.1.0", optional = true }
+futures = { version = "0.3.26", optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1.16", features = [ "full" ], optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio = { version = "1.16", features = [ "rt" , "sync", "macros", "io-util", "time" ], optional = true }

--- a/hydroflow_cli_integration/src/lib.rs
+++ b/hydroflow_cli_integration/src/lib.rs
@@ -1,0 +1,130 @@
+use std::{collections::HashMap, net::SocketAddr, path::PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "runtime")]
+use std::{pin::Pin, sync::Arc};
+
+#[cfg(feature = "runtime")]
+use async_trait::async_trait;
+#[cfg(feature = "runtime")]
+use bytes::BytesMut;
+#[cfg(feature = "runtime")]
+use futures::{Sink, Stream};
+
+#[cfg(feature = "runtime")]
+#[cfg(unix)]
+use tokio::net::UnixListener;
+
+#[cfg(feature = "runtime")]
+#[cfg(not(unix))]
+type UnixListener = !;
+
+#[cfg(feature = "runtime")]
+use tokio::{io, net::TcpListener};
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum BindConfig {
+    UnixSocket,
+    TcpPort(
+        /// The host the port should be bound on.
+        String,
+    ),
+}
+
+impl BindConfig {
+    #[cfg(feature = "runtime")]
+    pub async fn bind(self) -> BoundConnection {
+        match self {
+            BindConfig::UnixSocket => {
+                #[cfg(unix)]
+                {
+                    let dir = tempfile::tempdir().unwrap();
+                    let socket_path = dir.path().join("socket");
+                    BoundConnection::UnixSocket(UnixListener::bind(socket_path).unwrap(), dir)
+                }
+
+                #[cfg(not(unix))]
+                {
+                    panic!("Unix sockets are not supported on this platform")
+                }
+            }
+            BindConfig::TcpPort(host) => {
+                let listener = TcpListener::bind((host, 0)).await.unwrap();
+                BoundConnection::TcpPort(listener)
+            }
+        }
+    }
+}
+
+/// Describes a medium through which two Hydroflow services can communicate.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum ConnectionPipe {
+    UnixSocket(PathBuf),
+    TcpPort(SocketAddr),
+    Demux(HashMap<u32, ConnectionPipe>),
+    #[cfg(feature = "runtime")]
+    #[serde(skip)]
+    Bind(Arc<BoundConnection>),
+}
+
+#[cfg(feature = "runtime")]
+impl ConnectionPipe {
+    pub async fn connect<T: Connected>(self) -> T {
+        T::from_pipe(self).await
+    }
+}
+
+#[cfg(feature = "runtime")]
+pub type DynStream = Pin<Box<dyn Stream<Item = Result<BytesMut, io::Error>> + Send>>;
+#[cfg(feature = "runtime")]
+pub type DynSink<Input> = Pin<Box<dyn Sink<Input, Error = io::Error> + Send + Sync>>;
+
+#[cfg(feature = "runtime")]
+#[async_trait]
+pub trait Connected: Send {
+    type Input: Send;
+
+    fn take_source(&mut self) -> DynStream;
+    fn take_sink(&mut self) -> DynSink<Self::Input>;
+
+    async fn from_pipe(pipe: ConnectionPipe) -> Self;
+}
+
+#[cfg(feature = "runtime")]
+#[derive(Debug)]
+pub enum BoundConnection {
+    UnixSocket(UnixListener, tempfile::TempDir),
+    TcpPort(TcpListener),
+}
+
+#[cfg(feature = "runtime")]
+impl BoundConnection {
+    pub fn connection_pipe(&self) -> ConnectionPipe {
+        match self {
+            BoundConnection::UnixSocket(listener, _) => {
+                #[cfg(unix)]
+                {
+                    ConnectionPipe::UnixSocket(
+                        listener
+                            .local_addr()
+                            .unwrap()
+                            .as_pathname()
+                            .unwrap()
+                            .to_path_buf(),
+                    )
+                }
+
+                #[cfg(not(unix))]
+                {
+                    let _ = listener;
+                    panic!("Unix sockets are not supported on this platform")
+                }
+            }
+            BoundConnection::TcpPort(listener) => {
+                let addr = listener.local_addr().unwrap();
+                ConnectionPipe::TcpPort(SocketAddr::new(addr.ip(), addr.port()))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Also extracts out common serialized types between CLI and runtime to minimize size of CLI.