### PR TITLE
Enable local deployments on non-Linux hosts

### DIFF
--- a/hydro_cli/README.md
+++ b/hydro_cli/README.md
@@ -23,15 +23,27 @@ $ maturin develop
 The CLI is a Python package that can be imported into other Python programs. It can also be used as a command line tool.
 
 ### Command Line Tool
-The CLI can be used as a command line tool. To see the available commands, run:
+After building the CLI, it will be automatically available on your path in the virtual environment. To see the available commands, run:
 ```bash
 $ hydro --help
 ```
 
 ### Python Package
-The CLI can be imported into other Python programs. To use it, import the `hydro` package:
+The deployment API can be imported into other Python programs. To use it, import the `hydro` package:
 ```python
 import hydro
 ```
 
 See `test.hydro.py` for an example of how to use the available APIs.
+
+### Managing Rust Toolchains
+The CLI will use its own copy of `cargo` to build any Rust code. This means that the Rust toolchain used by the CLI is the one on your `$PATH`. If using `rustup` to manage toolchains, you will need to run the deployment with the appropriate toolchain activated. For example, to use the toolchain in `rust-toolchain.toml`, first run:
+```bash
+$ rustup show active-toolchain
+# nightly-2023-03-01-aarch64-apple-darwin (environment override by RUSTUP_TOOLCHAIN)
+```
+
+Then, copying the toolchain name, run:
+```bash
+rustup run nightly-2023-03-01-aarch64-apple-darwin hydro deploy ...
+```

--- a/hydro_cli/src/core/gcp.rs
+++ b/hydro_cli/src/core/gcp.rs
@@ -19,7 +19,8 @@ use super::{
     localhost::create_broadcast,
     terraform::{TerraformOutput, TerraformProvider},
     util::async_retry,
-    BindType, ConnectionType, Host, LaunchedBinary, LaunchedHost, ResourceBatch, ResourceResult,
+    BindType, ConnectionType, Host, HostTargetType, LaunchedBinary, LaunchedHost, ResourceBatch,
+    ResourceResult,
 };
 
 struct LaunchedComputeEngineBinary {
@@ -198,6 +199,10 @@ impl GCPComputeEngineHost {
 
 #[async_trait]
 impl Host for GCPComputeEngineHost {
+    fn target_type(&self) -> HostTargetType {
+        HostTargetType::Linux
+    }
+
     fn request_port(&mut self, bind_type: &BindType) {
         match bind_type {
             BindType::UnixSocket => {}

--- a/hydro_cli/src/core/hydroflow_crate.rs
+++ b/hydro_cli/src/core/hydroflow_crate.rs
@@ -18,7 +18,10 @@ use cargo::{
 use hydroflow::util::cli::ConnectionPipe;
 use tokio::{sync::RwLock, task::JoinHandle};
 
-use super::{BindType, Host, LaunchedBinary, LaunchedHost, ResourceBatch, ResourceResult, Service};
+use super::{
+    BindType, Host, HostTargetType, LaunchedBinary, LaunchedHost, ResourceBatch, ResourceResult,
+    Service,
+};
 
 #[derive(Clone)]
 pub enum OutgoingPort {
@@ -157,6 +160,7 @@ impl HydroflowCrate {
         let src_cloned = self.src.join("Cargo.toml").canonicalize().unwrap();
         let example_cloned = self.example.clone();
         let features_cloned = self.features.clone();
+        let host = self.on.clone();
 
         tokio::task::spawn_blocking(move || {
             let config = Config::default().unwrap();
@@ -174,14 +178,16 @@ impl HydroflowCrate {
                 benches: FilterRule::Just(vec![]),
             };
 
+            let target_type = host.blocking_read().target_type();
+
             compile_options.build_config = BuildConfig::new(
                 &config,
                 None,
                 false,
-                &[
-                    // TODO(shadaj): make configurable
-                    "x86_64-unknown-linux-musl".to_string(),
-                ],
+                &(match target_type {
+                    HostTargetType::Local => vec![],
+                    HostTargetType::Linux => vec!["x86_64-unknown-linux-musl".to_string()],
+                }),
                 CompileMode::Build,
             )
             .unwrap();

--- a/hydro_cli/src/core/localhost.rs
+++ b/hydro_cli/src/core/localhost.rs
@@ -9,7 +9,8 @@ use hydroflow::util::cli::BindConfig;
 use tokio::sync::RwLock;
 
 use super::{
-    BindType, ConnectionType, Host, LaunchedBinary, LaunchedHost, ResourceBatch, ResourceResult,
+    BindType, ConnectionType, Host, HostTargetType, LaunchedBinary, LaunchedHost, ResourceBatch,
+    ResourceResult,
 };
 
 struct LaunchedLocalhostBinary {
@@ -130,6 +131,10 @@ pub struct LocalhostHost {
 
 #[async_trait]
 impl Host for LocalhostHost {
+    fn target_type(&self) -> HostTargetType {
+        HostTargetType::Local
+    }
+
     fn request_port(&mut self, _bind_type: &BindType) {}
     fn collect_resources(&self, _resource_batch: &mut ResourceBatch) {}
     fn request_custom_binary(&mut self) {}

--- a/hydro_cli/src/core/mod.rs
+++ b/hydro_cli/src/core/mod.rs
@@ -87,8 +87,15 @@ pub enum ConnectionType {
     ),
 }
 
+pub enum HostTargetType {
+    Local,
+    Linux,
+}
+
 #[async_trait]
 pub trait Host: Send + Sync {
+    fn target_type(&self) -> HostTargetType;
+
     fn request_port(&mut self, bind_type: &BindType);
 
     /// Configures the host to support copying and running a custom binary.


### PR DESCRIPTION
Enable local deployments on non-Linux hosts

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydroflow/pull/451).
* #454
* #453
* #452
* __->__ #451
