### PR TITLE
Fix cross-build Linux and Windows not uploading wheels

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -109,7 +109,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: wheels
-          path: dist
+          path: hydro_cli/dist
   
   windows:
     runs-on: windows-latest
@@ -143,4 +143,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: wheels
-          path: dist
+          path: hydro_cli/dist


### PR DESCRIPTION
Fix cross-build Linux and Windows not uploading wheels

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydroflow/pull/457).
* __->__ #457
