### PR TITLE
Allow specifying args to launch `HydroflowCrate` with

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,6 +1431,7 @@ dependencies = [
  "pyo3-asyncio",
  "serde",
  "serde_json",
+ "shell-escape",
  "tempfile",
  "tokio",
 ]

--- a/hydro_cli/Cargo.toml
+++ b/hydro_cli/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 tempfile = "3.3.0"
 async-ssh2-lite = { version = "0.4.2", features = [ "tokio", "vendored-openssl" ] }
+shell-escape = "0.1.5"
 hydroflow_cli_integration = { path = "../hydroflow_cli_integration" }
 
 [dev-dependencies]

--- a/hydro_cli/hydro/__init__.py
+++ b/hydro_cli/hydro/__init__.py
@@ -16,8 +16,8 @@ class Deployment(object):
     def CustomService(self, on: "Host", external_ports: List[int]) -> "CustomService":
         return CustomService(self, on, external_ports)
 
-    def HydroflowCrate(self, src: str, on: "Host", example: Optional[str] = None, features: Optional[List[str]] = None) -> "HydroflowCrate":
-        return HydroflowCrate(self, src, on, example, features)
+    def HydroflowCrate(self, src: str, on: "Host", example: Optional[str] = None, features: Optional[List[str]] = None, args: Optional[List[str]] = None) -> "HydroflowCrate":
+        return HydroflowCrate(self, src, on, example, features, args)
 
     def deploy(self):
         return self.underlying.deploy()
@@ -102,8 +102,8 @@ async def pyreceiver_to_async_generator(pyreceiver):
             yield res
 
 class HydroflowCrate(Service):
-    def __init__(self, deployment: Deployment, src: str, on: Host, example: Optional[str], features: Optional[List[str]]) -> None:
-        super().__init__(hydro_cli_rust.PyHydroflowCrate(deployment.underlying, src, on.underlying, example, features))
+    def __init__(self, deployment: Deployment, src: str, on: Host, example: Optional[str], features: Optional[List[str]], args: Optional[List[str]]) -> None:
+        super().__init__(hydro_cli_rust.PyHydroflowCrate(deployment.underlying, src, on.underlying, example, features, args))
 
     @property
     def ports(self) -> HydroflowCratePorts:

--- a/hydro_cli/src/core/gcp.rs
+++ b/hydro_cli/src/core/gcp.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     net::SocketAddr,
     path::{Path, PathBuf},
     sync::{atomic::AtomicUsize, Arc},
@@ -91,7 +92,11 @@ impl LaunchedHost for LaunchedComputeEngine {
         }
     }
 
-    async fn launch_binary(&self, binary: &Path) -> Result<Arc<RwLock<dyn LaunchedBinary>>> {
+    async fn launch_binary(
+        &self,
+        binary: &Path,
+        args: &[String],
+    ) -> Result<Arc<RwLock<dyn LaunchedBinary>>> {
         let target_addr = SocketAddr::new(
             self.external_ip
                 .as_ref()
@@ -142,7 +147,14 @@ impl LaunchedHost for LaunchedComputeEngine {
         drop(created_file);
 
         let mut channel = session.channel_session().await?;
-        channel.exec(binary_path.to_str().unwrap()).await?;
+        let binary_path_string = binary_path.to_str().unwrap();
+        let args_string = args
+            .iter()
+            .map(|s| shell_escape::unix::escape(Cow::from(s)))
+            .fold("".to_string(), |acc, v| format!("{acc} {v}"));
+        channel
+            .exec(&format!("{binary_path_string}{args_string}"))
+            .await?;
 
         let (stdin_sender, mut stdin_receiver) = async_channel::unbounded::<String>();
         let mut stdin = channel.stream(0); // stream 0 is stdout/stdin, we use it for stdin

--- a/hydro_cli/src/core/hydroflow_crate.rs
+++ b/hydro_cli/src/core/hydroflow_crate.rs
@@ -73,6 +73,7 @@ pub struct HydroflowCrate {
     on: Arc<RwLock<dyn Host>>,
     example: Option<String>,
     features: Option<Vec<String>>,
+    args: Option<Vec<String>>,
 
     /// A mapping from output ports to the service that the port sends data to.
     outgoing_ports: HashMap<String, OutgoingPort>,
@@ -96,12 +97,14 @@ impl HydroflowCrate {
         on: Arc<RwLock<dyn Host>>,
         example: Option<String>,
         features: Option<Vec<String>>,
+        args: Option<Vec<String>>,
     ) -> Self {
         Self {
             src,
             on,
             example,
             features,
+            args,
             outgoing_ports: HashMap::new(),
             incoming_ports: HashMap::new(),
             built_binary: None,
@@ -240,7 +243,10 @@ impl Service for HydroflowCrate {
         let launched_host = self.launched_host.as_ref().unwrap();
 
         let binary = launched_host
-            .launch_binary(self.built_binary.take().unwrap().await.as_ref().unwrap())
+            .launch_binary(
+                self.built_binary.take().unwrap().await.as_ref().unwrap(),
+                &self.args.as_ref().cloned().unwrap_or_default(),
+            )
             .await?;
 
         let mut bind_config = HashMap::new();

--- a/hydro_cli/src/core/localhost.rs
+++ b/hydro_cli/src/core/localhost.rs
@@ -94,8 +94,13 @@ impl LaunchedHost for LaunchedLocalhost {
         }
     }
 
-    async fn launch_binary(&self, binary: &Path) -> Result<Arc<RwLock<dyn LaunchedBinary>>> {
+    async fn launch_binary(
+        &self,
+        binary: &Path,
+        args: &[String],
+    ) -> Result<Arc<RwLock<dyn LaunchedBinary>>> {
         let mut child = Command::new(binary)
+            .args(args)
             .kill_on_drop(true)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())

--- a/hydro_cli/src/core/mod.rs
+++ b/hydro_cli/src/core/mod.rs
@@ -62,7 +62,11 @@ pub trait LaunchedHost: Send + Sync {
     /// to listen to network connections (such as the IP address to bind to).
     fn get_bind_config(&self, bind_type: &BindType) -> BindConfig;
 
-    async fn launch_binary(&self, binary: &Path) -> Result<Arc<RwLock<dyn LaunchedBinary>>>;
+    async fn launch_binary(
+        &self,
+        binary: &Path,
+        args: &[String],
+    ) -> Result<Arc<RwLock<dyn LaunchedBinary>>>;
 }
 
 /// Types of connections that a host can make to another host.

--- a/hydro_cli/src/lib.rs
+++ b/hydro_cli/src/lib.rs
@@ -217,6 +217,7 @@ impl PyHydroflowCrate {
         on: &PyHost,
         example: Option<String>,
         features: Option<Vec<String>>,
+        args: Option<Vec<String>>,
     ) -> (Self, PyService) {
         let service =
             deployment
@@ -227,6 +228,7 @@ impl PyHydroflowCrate {
                     on.underlying.clone(),
                     example,
                     features,
+                    args,
                 ));
 
         (

--- a/hydro_cli/test.hydro.py
+++ b/hydro_cli/test.hydro.py
@@ -1,4 +1,5 @@
 import hydro
+import json
 
 async def main(args):
     gcp = args[0] == "gcp"
@@ -22,6 +23,7 @@ async def main(args):
         src="../hydroflow",
         example="cli_sender",
         features=["cli_integration"],
+        args=[json.dumps([0])],
         on=machine1
     )
 

--- a/hydroflow/examples/cli_sender/main.rs
+++ b/hydroflow/examples/cli_sender/main.rs
@@ -13,7 +13,7 @@ async fn main() {
         .connect::<ConnectedDemux<ConnectedBidi>>()
         .await;
 
-    let peers = broadcast_port.keys.clone();
+    let peers: Vec<u32> = serde_json::from_str(&std::env::args().nth(1).unwrap()).unwrap();
     let broadcast_sink = broadcast_port.take_sink();
 
     let mut df = datalog!(


### PR DESCRIPTION
Allow specifying args to launch `HydroflowCrate` with. Fixes #422

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydroflow/pull/460).
* #466
* #462
* #461
* __->__ #460