### PR TITLE
Make operators always emit code, best-effort

### DIFF
--- a/hydroflow_lang/src/graph/hydroflow_graph.rs
+++ b/hydroflow_lang/src/graph/hydroflow_graph.rs
@@ -666,14 +666,11 @@ impl HydroflowGraph {
                                 op_inst,
                             };
 
-                            let write_result = (op_constraints.write_fn)(&context_args, diagnostics);
-                            let Ok(OperatorWriteOutput {
+                            let OperatorWriteOutput {
                                 write_prologue,
                                 write_iterator,
                                 write_iterator_after,
-                            }) = write_result else {
-                                continue;
-                            };
+                            } = (op_constraints.write_fn)(&context_args, diagnostics);
 
                             op_prologue_code.push(write_prologue);
                             subgraph_op_iter_code.push(write_iterator);

--- a/hydroflow_lang/src/graph/ops/anti_join.rs
+++ b/hydroflow_lang/src/graph/ops/anti_join.rs
@@ -78,10 +78,10 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
                 let #ident = #input_pos.filter(move |x| !#negset_ident.contains(&x.0));
             }
         };
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_prologue,
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/batch.rs
+++ b/hydroflow_lang/src/graph/ops/batch.rs
@@ -117,10 +117,10 @@ pub const BATCH: OperatorConstraints = OperatorConstraints {
             }
         };
 
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_prologue,
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/cross_join.rs
+++ b/hydroflow_lang/src/graph/ops/cross_join.rs
@@ -60,7 +60,7 @@ pub const CROSS_JOIN: OperatorConstraints = OperatorConstraints {
                    ..
                },
                diagnostics| {
-        let mut output = (super::join::JOIN.write_fn)(wc, diagnostics)?;
+        let mut output = (super::join::JOIN.write_fn)(wc, diagnostics);
 
         let lhs = &inputs[0];
         let rhs = &inputs[1];
@@ -71,7 +71,6 @@ pub const CROSS_JOIN: OperatorConstraints = OperatorConstraints {
             #write_iterator
             let #ident = #ident.map(|((), (a, b))| (a, b));
         );
-
-        Ok(output)
+        output
     },
 };

--- a/hydroflow_lang/src/graph/ops/dest_sink.rs
+++ b/hydroflow_lang/src/graph/ops/dest_sink.rs
@@ -152,10 +152,10 @@ pub const DEST_SINK: OperatorConstraints = OperatorConstraints {
             });
         };
 
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_prologue,
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/dest_sink_serde.rs
+++ b/hydroflow_lang/src/graph/ops/dest_sink_serde.rs
@@ -84,10 +84,10 @@ pub const DEST_SINK_SERDE: OperatorConstraints = OperatorConstraints {
             });
         };
 
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_prologue,
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/difference.rs
+++ b/hydroflow_lang/src/graph/ops/difference.rs
@@ -75,10 +75,10 @@ pub const DIFFERENCE: OperatorConstraints = OperatorConstraints {
                 let #ident = #input_pos.filter(move |x| !#negset_ident.contains(x));
             }
         };
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_prologue,
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/filter.rs
+++ b/hydroflow_lang/src/graph/ops/filter.rs
@@ -59,9 +59,9 @@ pub const FILTER: OperatorConstraints = OperatorConstraints {
                 let #ident = #root::pusherator::filter::Filter::new(#arguments, #output);
             }
         };
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/filter_map.rs
+++ b/hydroflow_lang/src/graph/ops/filter_map.rs
@@ -56,9 +56,9 @@ pub const FILTER_MAP: OperatorConstraints = OperatorConstraints {
                 let #ident = #root::pusherator::filter_map::FilterMap::new(#arguments, #output);
             }
         };
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/flat_map.rs
+++ b/hydroflow_lang/src/graph/ops/flat_map.rs
@@ -63,9 +63,9 @@ pub const FLAT_MAP: OperatorConstraints = OperatorConstraints {
                 );
             }
         };
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/flatten.rs
+++ b/hydroflow_lang/src/graph/ops/flatten.rs
@@ -55,9 +55,9 @@ pub const FLATTEN: OperatorConstraints = OperatorConstraints {
                 let #ident = #root::pusherator::flatten::Flatten::new(#output);
             }
         };
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/fold.rs
+++ b/hydroflow_lang/src/graph/ops/fold.rs
@@ -115,10 +115,10 @@ pub const FOLD: OperatorConstraints = OperatorConstraints {
             ),
         };
 
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_prologue,
             write_iterator,
             write_iterator_after,
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/for_each.rs
+++ b/hydroflow_lang/src/graph/ops/for_each.rs
@@ -48,9 +48,9 @@ pub const FOR_EACH: OperatorConstraints = OperatorConstraints {
         let write_iterator = quote_spanned! {op_span=>
             let #ident = #root::pusherator::for_each::ForEach::new(#arguments);
         };
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/group_by.rs
+++ b/hydroflow_lang/src/graph/ops/group_by.rs
@@ -167,10 +167,10 @@ pub const GROUP_BY: OperatorConstraints = OperatorConstraints {
             }
         };
 
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_prologue,
             write_iterator,
             write_iterator_after,
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/inspect.rs
+++ b/hydroflow_lang/src/graph/ops/inspect.rs
@@ -58,9 +58,9 @@ pub const INSPECT: OperatorConstraints = OperatorConstraints {
                 let #ident = #root::pusherator::inspect::Inspect::new(#arguments, #output);
             }
         };
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/join.rs
+++ b/hydroflow_lang/src/graph/ops/join.rs
@@ -188,10 +188,10 @@ pub const JOIN: OperatorConstraints = OperatorConstraints {
             };
         };
 
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_prologue,
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/map.rs
+++ b/hydroflow_lang/src/graph/ops/map.rs
@@ -60,9 +60,9 @@ pub const MAP: OperatorConstraints = OperatorConstraints {
                 let #ident = #root::pusherator::map::Map::new(#arguments, #output);
             }
         };
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/merge.rs
+++ b/hydroflow_lang/src/graph/ops/merge.rs
@@ -70,9 +70,9 @@ pub const MERGE: OperatorConstraints = OperatorConstraints {
                 let #ident = #output;
             }
         };
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/mod.rs
+++ b/hydroflow_lang/src/graph/ops/mod.rs
@@ -141,8 +141,9 @@ impl Debug for OperatorConstraints {
     }
 }
 
-pub type WriteFn =
-    fn(&WriteContextArgs<'_>, &mut Vec<Diagnostic>) -> Result<OperatorWriteOutput, ()>;
+/// Operator write function. If an error occurs the operator should push a `Diagnostic` error but
+/// should still try to produce reasonable output.
+pub type WriteFn = fn(&WriteContextArgs<'_>, &mut Vec<Diagnostic>) -> OperatorWriteOutput;
 
 #[derive(Default)]
 #[non_exhaustive]
@@ -207,10 +208,10 @@ pub fn identity_write_iterator_fn(
 
 pub const IDENTITY_WRITE_FN: WriteFn = |write_context_args, _| {
     let write_iterator = identity_write_iterator_fn(write_context_args);
-    Ok(OperatorWriteOutput {
+    OperatorWriteOutput {
         write_iterator,
         ..Default::default()
-    })
+    }
 };
 
 pub const OPERATORS: &[OperatorConstraints] = &[

--- a/hydroflow_lang/src/graph/ops/null.rs
+++ b/hydroflow_lang/src/graph/ops/null.rs
@@ -75,9 +75,9 @@ pub const NULL: OperatorConstraints = OperatorConstraints {
                 let #ident = #root::pusherator::for_each::ForEach::<_, #iter_type>::new(std::mem::drop);
             }
         };
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/persist.rs
+++ b/hydroflow_lang/src/graph/ops/persist.rs
@@ -85,7 +85,6 @@ pub const PERSIST: OperatorConstraints = OperatorConstraints {
                 Level::Error,
                 format!("`{}()` can only have `'static` persistence.", op_name),
             ));
-            return Err(());
         };
 
         let persistdata_ident = wc.make_ident("persistdata");
@@ -124,10 +123,10 @@ pub const PERSIST: OperatorConstraints = OperatorConstraints {
             }
         };
 
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_prologue,
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/reduce.rs
+++ b/hydroflow_lang/src/graph/ops/reduce.rs
@@ -107,10 +107,10 @@ pub const REDUCE: OperatorConstraints = OperatorConstraints {
             ),
         };
 
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_prologue,
             write_iterator,
             write_iterator_after,
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/repeat_iter.rs
+++ b/hydroflow_lang/src/graph/ops/repeat_iter.rs
@@ -55,10 +55,10 @@ pub const REPEAT_ITER: OperatorConstraints = OperatorConstraints {
         let write_iterator_after = quote_spanned! {op_span=>
             #context.schedule_subgraph(#context.current_subgraph(), false);
         };
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_iterator,
             write_iterator_after,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/sort.rs
+++ b/hydroflow_lang/src/graph/ops/sort.rs
@@ -97,10 +97,10 @@ pub const SORT: OperatorConstraints = OperatorConstraints {
                         v.into_iter()
                     };
                 };
-                Ok(OperatorWriteOutput {
+                OperatorWriteOutput {
                     write_iterator,
                     ..Default::default()
-                })
+                }
             }
             Persistence::Static => {
                 let sortdata_ident = wc.make_ident("sortdata");
@@ -118,11 +118,11 @@ pub const SORT: OperatorConstraints = OperatorConstraints {
                     };
                 };
 
-                Ok(OperatorWriteOutput {
+                OperatorWriteOutput {
                     write_prologue,
                     write_iterator,
                     ..Default::default()
-                })
+                }
             }
         }
     },

--- a/hydroflow_lang/src/graph/ops/sort_by.rs
+++ b/hydroflow_lang/src/graph/ops/sort_by.rs
@@ -54,9 +54,9 @@ pub const SORT_BY: OperatorConstraints = OperatorConstraints {
             #root::util::sort_unstable_by_key_hrtb(&mut tmp, #arguments);
             let #ident = tmp.into_iter();
         };
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/source_interval.rs
+++ b/hydroflow_lang/src/graph/ops/source_interval.rs
@@ -82,11 +82,11 @@ pub const SOURCE_INTERVAL: OperatorConstraints = OperatorConstraints {
             },
             ..wc.clone()
         };
-        let write_output = (super::source_stream::SOURCE_STREAM.write_fn)(&wc, diagnostics)?;
+        let write_output = (super::source_stream::SOURCE_STREAM.write_fn)(&wc, diagnostics);
         write_prologue.extend(write_output.write_prologue);
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_prologue,
             ..write_output
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/source_iter.rs
+++ b/hydroflow_lang/src/graph/ops/source_iter.rs
@@ -58,10 +58,10 @@ pub const SOURCE_ITER: OperatorConstraints = OperatorConstraints {
         let write_iterator = quote_spanned! {op_span=>
             let #ident = #iter_ident.by_ref();
         };
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_prologue,
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/source_json.rs
+++ b/hydroflow_lang/src/graph/ops/source_json.rs
@@ -64,10 +64,10 @@ pub const SOURCE_JSON: OperatorConstraints = OperatorConstraints {
         let write_iterator = quote_spanned! {op_span=>
             let #ident = #ident_jsonread.by_ref();
         };
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_prologue,
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/source_stdin.rs
+++ b/hydroflow_lang/src/graph/ops/source_stdin.rs
@@ -63,10 +63,10 @@ pub const SOURCE_STDIN: OperatorConstraints = OperatorConstraints {
                 }
             });
         };
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_prologue,
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/source_stream.rs
+++ b/hydroflow_lang/src/graph/ops/source_stream.rs
@@ -75,10 +75,10 @@ pub const SOURCE_STREAM: OperatorConstraints = OperatorConstraints {
                 }
             });
         };
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_prologue,
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/source_stream_serde.rs
+++ b/hydroflow_lang/src/graph/ops/source_stream_serde.rs
@@ -67,10 +67,10 @@ pub const SOURCE_STREAM_SERDE: OperatorConstraints = OperatorConstraints {
                 }
             });
         };
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_prologue,
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/tee.rs
+++ b/hydroflow_lang/src/graph/ops/tee.rs
@@ -66,9 +66,9 @@ pub const TEE: OperatorConstraints = OperatorConstraints {
                 let #ident = #input;
             }
         };
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/unique.rs
+++ b/hydroflow_lang/src/graph/ops/unique.rs
@@ -139,10 +139,10 @@ pub const UNIQUE: OperatorConstraints = OperatorConstraints {
             }
         };
 
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_prologue,
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };

--- a/hydroflow_lang/src/graph/ops/unzip.rs
+++ b/hydroflow_lang/src/graph/ops/unzip.rs
@@ -50,9 +50,9 @@ pub const UNZIP: OperatorConstraints = OperatorConstraints {
         let write_iterator = quote_spanned! {op_span=>
             let #ident = #root::pusherator::unzip::Unzip::new(#output0, #output1);
         };
-        Ok(OperatorWriteOutput {
+        OperatorWriteOutput {
             write_iterator,
             ..Default::default()
-        })
+        }
     },
 };


### PR DESCRIPTION
small refactor, going back to operators having to emit some sort of output, since `HydroflowGraph::as_code()` always emits tokens even if operators have an error. Errors are handled thru diagnostics