### PR TITLE
Use `null` write fn when operator codegen errors

### DIFF
--- a/hydroflow_lang/src/graph/hydroflow_graph.rs
+++ b/hydroflow_lang/src/graph/hydroflow_graph.rs
@@ -11,6 +11,7 @@ use slotmap::{Key, SecondaryMap, SlotMap, SparseSecondaryMap};
 use syn::spanned::Spanned;
 
 use crate::diagnostic::{Diagnostic, Level};
+use crate::graph::ops::null_write_iterator_fn;
 use crate::pretty_span::{PrettyRowCol, PrettySpan};
 
 use super::graph_write::{Dot, GraphWrite, Mermaid};
@@ -667,13 +668,11 @@ impl HydroflowGraph {
                             };
 
                             let write_result = (op_constraints.write_fn)(&context_args, diagnostics);
-                            let Ok(OperatorWriteOutput {
+                            let OperatorWriteOutput {
                                 write_prologue,
                                 write_iterator,
                                 write_iterator_after,
-                            }) = write_result else {
-                                continue;
-                            };
+                            } = write_result.unwrap_or_else(|()| OperatorWriteOutput { write_iterator: null_write_iterator_fn(&context_args), ..Default::default() });
 
                             op_prologue_code.push(write_prologue);
                             subgraph_op_iter_code.push(write_iterator);

--- a/hydroflow_lang/src/graph/ops/null.rs
+++ b/hydroflow_lang/src/graph/ops/null.rs
@@ -1,12 +1,4 @@
-use crate::graph::{OpInstGenerics, OperatorInstance};
-
-use super::{
-    FlowProperties, FlowPropertyVal, OperatorConstraints, OperatorWriteOutput, WriteContextArgs,
-    RANGE_0,
-};
-
-use quote::quote_spanned;
-use syn::parse_quote_spanned;
+use super::{FlowProperties, FlowPropertyVal, OperatorConstraints, NULL_WRITE_FN, RANGE_0};
 
 /// > unbounded number of input streams of any type, unbounded number of output streams of any type.
 ///
@@ -41,43 +33,5 @@ pub const NULL: OperatorConstraints = OperatorConstraints {
         inconsistency_tainted: false,
     },
     input_delaytype_fn: |_| None,
-    write_fn: |&WriteContextArgs {
-                   root,
-                   op_span,
-                   ident,
-                   inputs,
-                   outputs,
-                   is_pull,
-                   op_inst:
-                       OperatorInstance {
-                           generics: OpInstGenerics { type_args, .. },
-                           ..
-                       },
-                   ..
-               },
-               _| {
-        let write_iterator = if is_pull {
-            let default_type = parse_quote_spanned! {op_span=> _};
-            let iter_type = type_args.get(0).unwrap_or(&default_type);
-            quote_spanned! {op_span=>
-                #(
-                    #inputs.for_each(std::mem::drop);
-                )*
-                let #ident = std::iter::empty::<#iter_type>();
-            }
-        } else {
-            let default_type = parse_quote_spanned! {op_span=> _};
-            let iter_type = type_args.get(0).unwrap_or(&default_type);
-
-            quote_spanned! {op_span=>
-                #[allow(clippy::let_unit_value)]
-                let _ = (#(#outputs),*);
-                let #ident = #root::pusherator::for_each::ForEach::<_, #iter_type>::new(std::mem::drop);
-            }
-        };
-        Ok(OperatorWriteOutput {
-            write_iterator,
-            ..Default::default()
-        })
-    },
+    write_fn: NULL_WRITE_FN,
 };


### PR DESCRIPTION
Since `HydroflowGraph::as_code()` always returns regardless of errors, we should do our best to make the returned code as sensible as possible in the face of errors.