### PR TITLE
Even faster groupby

### DIFF
--- a/hydroflow/src/lib.rs
+++ b/hydroflow/src/lib.rs
@@ -14,6 +14,7 @@ pub mod util;
 pub use bytes;
 pub use futures;
 pub use pusherator;
+pub use rustc_hash;
 pub use serde;
 pub use serde_json;
 pub use static_assertions;

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__aggregations_and_comments@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__aggregations_and_comments@datalog_program.snap
@@ -69,7 +69,10 @@ fn main() {
                         }
                         check_input(hoff_23v1_recv)
                             .fold(
-                                ::std::collections::HashMap::<(_,), (Option<_>,)>::new(),
+                                hydroflow::rustc_hash::FxHashMap::<
+                                    (_,),
+                                    (Option<_>,),
+                                >::default(),
                                 |mut ht, kv| {
                                     let entry = ht.entry(kv.0).or_insert_with(|| (None,));
                                     #[allow(clippy::redundant_closure_call)]
@@ -237,7 +240,10 @@ fn main() {
                         }
                         check_input(hoff_27v1_recv)
                             .fold(
-                                ::std::collections::HashMap::<(_,), (Option<_>,)>::new(),
+                                hydroflow::rustc_hash::FxHashMap::<
+                                    (_,),
+                                    (Option<_>,),
+                                >::default(),
                                 |mut ht, kv| {
                                     let entry = ht.entry(kv.0).or_insert_with(|| (None,));
                                     #[allow(clippy::redundant_closure_call)]
@@ -383,7 +389,10 @@ fn main() {
                         }
                         check_input(hoff_26v1_recv)
                             .fold(
-                                ::std::collections::HashMap::<(_,), (Option<_>,)>::new(),
+                                hydroflow::rustc_hash::FxHashMap::<
+                                    (_,),
+                                    (Option<_>,),
+                                >::default(),
                                 |mut ht, kv| {
                                     let entry = ht.entry(kv.0).or_insert_with(|| (None,));
                                     #[allow(clippy::redundant_closure_call)]

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__max@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__max@datalog_program.snap
@@ -42,7 +42,10 @@ fn main() {
                         }
                         check_input(hoff_12v1_recv)
                             .fold(
-                                ::std::collections::HashMap::<(_,), (Option<_>,)>::new(),
+                                hydroflow::rustc_hash::FxHashMap::<
+                                    (_,),
+                                    (Option<_>,),
+                                >::default(),
                                 |mut ht, kv| {
                                     let entry = ht.entry(kv.0).or_insert_with(|| (None,));
                                     #[allow(clippy::redundant_closure_call)]

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__max_all@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__max_all@datalog_program.snap
@@ -42,10 +42,10 @@ fn main() {
                         }
                         check_input(hoff_12v1_recv)
                             .fold(
-                                ::std::collections::HashMap::<
+                                hydroflow::rustc_hash::FxHashMap::<
                                     (),
                                     (Option<_>, Option<_>),
-                                >::new(),
+                                >::default(),
                                 |mut ht, kv| {
                                     let entry = ht.entry(kv.0).or_insert_with(|| (None, None));
                                     #[allow(clippy::redundant_closure_call)]

--- a/hydroflow_lang/src/graph/ops/group_by.rs
+++ b/hydroflow_lang/src/graph/ops/group_by.rs
@@ -83,6 +83,7 @@ pub const GROUP_BY: OperatorConstraints = OperatorConstraints {
                    ident,
                    inputs,
                    is_pull,
+                   root,
                    op_inst:
                        OperatorInstance {
                            arguments,
@@ -127,7 +128,7 @@ pub const GROUP_BY: OperatorConstraints = OperatorConstraints {
                     let #ident = {
                         #[inline(always)]
                         fn check_input<Iter: ::std::iter::Iterator<Item = (A, B)>, A, B>(iter: Iter) -> impl ::std::iter::Iterator<Item = (A, B)> { iter }
-                        check_input(#input).fold(::std::collections::HashMap::<#( #generic_type_args ),*>::new(), |mut ht, kv| {
+                        check_input(#input).fold(#root::rustc_hash::FxHashMap::<#( #generic_type_args ),*>::default(), |mut ht, kv| {
                             let entry = ht.entry(kv.0).or_insert_with(#initfn);
                             #[allow(clippy::redundant_closure_call)] (#aggfn)(entry, kv.1);
                             ht
@@ -142,7 +143,7 @@ pub const GROUP_BY: OperatorConstraints = OperatorConstraints {
 
                 (
                     quote_spanned! {op_span=>
-                        let #groupbydata_ident = #hydroflow.add_state(::std::cell::RefCell::new(::std::collections::HashMap::<#( #generic_type_args ),*>::new()));
+                        let #groupbydata_ident = #hydroflow.add_state(::std::cell::RefCell::new(#root::rustc_hash::FxHashMap::<#( #generic_type_args ),*>::default()));
                     },
                     quote_spanned! {op_span=>
                     let mut #hashtable_ident = #context.state_ref(#groupbydata_ident).borrow_mut();


### PR DESCRIPTION
This is a much faster hash function but it is not dos resistant.

groupby started to show up on the profile for the kvs benchmark so I made this change which greatly improved the perf of the kvs benchmark.

```
micro/ops/group_by      time:   [13.960 µs 14.044 µs 14.153 µs]
                        change: [-52.734% -52.343% -51.936%] (p = 0.00 < 0.05)
                        Performance has improved.
```