### PR TITLE
Update Rust Sitter to fix Dedalus parser on WASM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2690,9 +2690,9 @@ dependencies = [
 
 [[package]]
 name = "rust-sitter"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60facd4d74dd1b7679ab7d77ff52ce8bc46be9a04ed79f6726c2b026c64e2d2"
+checksum = "27fac3bd28bfd717686f21701fe06d2ffc559523ec2928b3628a6457eb956b8f"
 dependencies = [
  "rust-sitter-macro",
  "tree-sitter-c2rust",
@@ -2700,9 +2700,9 @@ dependencies = [
 
 [[package]]
 name = "rust-sitter-common"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71998b0ab9d159e5f99c474cdaa5d02bdedfab53e921a2e030ec95d9328181a"
+checksum = "f1e9745a1f472a5449c1cd54bc6db2c6f788ac6ccf68fea03259528d65eb8638"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -2710,9 +2710,9 @@ dependencies = [
 
 [[package]]
 name = "rust-sitter-macro"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc44fd9bed03a1bbafc4db638da80a9da8a62ea3ab3c69748ce5adeb5ffce4c7"
+checksum = "49a48a6bb47a99653680a736df653cdeaef66b72540d7468d20d9080f48394bc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2722,9 +2722,9 @@ dependencies = [
 
 [[package]]
 name = "rust-sitter-tool"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d7b74902cb1df9b4d8eba096f8cd734c67dac415246245650c64279a6db717"
+checksum = "30639eac096fb662d559b4fa703d0c4566f685f9b4d66a5fd7c4cfcca93f98a7"
 dependencies = [
  "cc",
  "rust-sitter-common",

--- a/hydroflow/tests/compile-fail/surface_dest_sink_badsink.stderr
+++ b/hydroflow/tests/compile-fail/surface_dest_sink_badsink.stderr
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `&str: hydroflow::futures::Sink<_>` is not satisfi
             <Buffered<S> as hydroflow::futures::Sink<Item>>
             <DemuxDrain<T, S> as hydroflow::futures::Sink<(u32, T)>>
             <Fanout<Si1, Si2> as hydroflow::futures::Sink<Item>>
-            <FlattenSink<Fut, Si> as hydroflow::futures::Sink<_Item>>
+            <FlatMapUnordered<St, U, F> as hydroflow::futures::Sink<_Item>>
           and $N others
 note: required by a bound in `sink_feed_flush`
  --> tests/compile-fail/surface_dest_sink_badsink.rs:5:18

--- a/hydroflow_datalog_core/Cargo.toml
+++ b/hydroflow_datalog_core/Cargo.toml
@@ -16,11 +16,11 @@ slotmap = "1.0.6"
 syn = { version = "1.0.0", features = [ "parsing", "extra-traits" ] }
 proc-macro2 = "1.0.27"
 proc-macro-crate = "1.1.0"
-rust-sitter = "0.3.1"
+rust-sitter = "0.3.2"
 hydroflow_lang = { path = "../hydroflow_lang" }
 
 [build-dependencies]
-rust-sitter-tool = "0.3.1"
+rust-sitter-tool = "0.3.2"
 
 [dev-dependencies]
 insta = "1.7.1"


### PR DESCRIPTION
Update Rust Sitter to fix Dedalus parser on WASM
