### PR TITLE
deserialize_bytes takes &[u8] instead of BytesMut

### DIFF
--- a/hydro_cli_examples/examples/dedalus_2pc_coordinator/main.rs
+++ b/hydro_cli_examples/examples/dedalus_2pc_coordinator/main.rs
@@ -52,9 +52,9 @@ async fn main() {
         .input rollbackInstruct `repeat_iter([(false,),])`
 
         .async voteToParticipant `map(|(node_id, v):(u32,(u32,String))| (node_id, serialize_to_bytes(v))) -> dest_sink(vote_to_participant_sink)` `null::<(u32,String,)>()`
-        .async voteFromParticipant `null::<(u32,String,bool,u32,)>()` `source_stream(vote_from_participant_source) -> map(|v| deserialize_from_bytes::<(u32,String,bool,u32,)>(v.unwrap()))`
+        .async voteFromParticipant `null::<(u32,String,bool,u32,)>()` `source_stream(vote_from_participant_source) -> map(|v| deserialize_from_bytes::<(u32,String,bool,u32,)>(&v.unwrap()))`
         .async instructToParticipant `map(|(node_id, v):(u32,(u32,String,bool))| (node_id, serialize_to_bytes(v))) -> dest_sink(instruct_to_participant_sink)` `null::<(u32,String,bool,)>()`
-        .async ackFromParticipant `null::<(u32,String,u32,)>()` `source_stream(ack_from_participant_source) -> map(|v| deserialize_from_bytes::<(u32,String,u32,)>(v.unwrap()))`
+        .async ackFromParticipant `null::<(u32,String,u32,)>()` `source_stream(ack_from_participant_source) -> map(|v| deserialize_from_bytes::<(u32,String,u32,)>(&v.unwrap()))`
 
         # Persistence rules
         AllMsg(msg) :+ AllMsg(msg), !NextMsgToAssign(msg)

--- a/hydro_cli_examples/examples/dedalus_2pc_participant/main.rs
+++ b/hydro_cli_examples/examples/dedalus_2pc_participant/main.rs
@@ -48,9 +48,9 @@ async fn main() {
         .input verdict `repeat_iter([(true,),])`
         // .output voteOut `for_each(|(i,myID):(u32,u32,)| println!("participant {:?}: message {:?}", myID, i))`
         
-        .async voteToParticipant `null::<(u32,String,)>()` `source_stream(vote_to_participant_source) -> map(|x| deserialize_from_bytes::<(u32,String,)>(x.unwrap()))`
+        .async voteToParticipant `null::<(u32,String,)>()` `source_stream(vote_to_participant_source) -> map(|x| deserialize_from_bytes::<(u32,String,)>(&x.unwrap()))`
         .async voteFromParticipant `map(|(node_id, v)| (node_id, serialize_to_bytes(v))) -> dest_sink(vote_from_participant_sink)` `null::<(u32,String,)>()`
-        .async instructToParticipant `null::<(u32,String,bool,)>()` `source_stream(instruct_to_participant_source) -> map(|x| deserialize_from_bytes::<(u32,String,bool,)>(x.unwrap()))`
+        .async instructToParticipant `null::<(u32,String,bool,)>()` `source_stream(instruct_to_participant_source) -> map(|x| deserialize_from_bytes::<(u32,String,bool,)>(&x.unwrap()))`
         .async ackFromParticipant `map(|(node_id, v)| (node_id, serialize_to_bytes(v))) -> dest_sink(ack_from_participant_sink)` `null::<(u32,String,u32,)>()`
     
         # .output verdictRequest    

--- a/hydro_cli_examples/examples/dedalus_receiver/main.rs
+++ b/hydro_cli_examples/examples/dedalus_receiver/main.rs
@@ -16,7 +16,7 @@ async fn main() {
 
     let df = datalog!(
         r#"
-        .async broadcast `null::<(String,)>()` `source_stream(broadcast_recv) -> map(|x| deserialize_from_bytes::<(String,)>(x.unwrap()))`
+        .async broadcast `null::<(String,)>()` `source_stream(broadcast_recv) -> map(|x| deserialize_from_bytes::<(String,)>(&x.unwrap()))`
         .output stdout `for_each(|tup| println!("echo {:?}", tup))`
 
         stdout(x) :- broadcast(x)

--- a/hydro_cli_examples/examples/dedalus_vote_leader/main.rs
+++ b/hydro_cli_examples/examples/dedalus_vote_leader/main.rs
@@ -31,7 +31,7 @@ async fn main() {
         .input replicas `repeat_iter(peers.clone()) -> map(|p| (p,))`
 
         .async voteToReplica `map(|(node_id, v)| (node_id, serialize_to_bytes(v))) -> dest_sink(to_replica_sink)` `null::<(String,)>()`
-        .async voteFromReplica `null::<(u32,String,)>()` `source_stream(from_replica_source) -> map(|v| deserialize_from_bytes::<(u32,String,)>(v.unwrap()))`
+        .async voteFromReplica `null::<(u32,String,)>()` `source_stream(from_replica_source) -> map(|v| deserialize_from_bytes::<(u32,String,)>(&v.unwrap()))`
         
         voteToReplica@addr(v) :~ clientIn(v), replicas(addr)
         allVotes(s, v) :- voteFromReplica(s, v)

--- a/hydro_cli_examples/examples/dedalus_vote_participant/main.rs
+++ b/hydro_cli_examples/examples/dedalus_vote_participant/main.rs
@@ -30,7 +30,7 @@ async fn main() {
         r#"
             .input myID `repeat_iter(my_id.clone()) -> map(|p| (p,))`
             .input leader `repeat_iter(peers.clone()) -> map(|p| (p,))`
-            .async voteToReplica `null::<(String,)>()` `source_stream(to_replica_source) -> map(|x| deserialize_from_bytes::<(String,)>(x.unwrap()))`
+            .async voteToReplica `null::<(String,)>()` `source_stream(to_replica_source) -> map(|x| deserialize_from_bytes::<(String,)>(&x.unwrap()))`
             .async voteFromReplica `map(|(node_id, v)| (node_id, serialize_to_bytes(v))) -> dest_sink(from_replica_sink)` `null::<(u32,String,)>()`
             
             voteFromReplica@addr(i, v) :~ voteToReplica(v), leader(addr), myID(i)

--- a/hydroflow/src/util/mod.rs
+++ b/hydroflow/src/util/mod.rs
@@ -32,6 +32,17 @@ pub fn unbounded_channel<T>() -> (
     (send, recv)
 }
 
+pub fn bounded_channel<T>(
+    capacity: usize,
+) -> (
+    tokio::sync::mpsc::Sender<T>,
+    tokio_stream::wrappers::ReceiverStream<T>,
+) {
+    let (send, recv) = tokio::sync::mpsc::channel(capacity);
+    let recv = tokio_stream::wrappers::ReceiverStream::new(recv);
+    (send, recv)
+}
+
 pub fn ready_iter<S>(stream: S) -> impl Iterator<Item = S::Item>
 where
     S: Stream,
@@ -89,11 +100,11 @@ where
     bytes::Bytes::from(bincode::serialize(&msg).unwrap())
 }
 
-pub fn deserialize_from_bytes<T>(msg: bytes::BytesMut) -> T
+pub fn deserialize_from_bytes<T>(msg: &[u8]) -> T
 where
     T: Serialize + for<'a> Deserialize<'a> + Clone,
 {
-    bincode::deserialize(&msg).unwrap()
+    bincode::deserialize(msg).unwrap()
 }
 
 pub fn ipv4_resolve(addr: &str) -> Result<SocketAddr, std::io::Error> {

--- a/hydroflow/src/util/mod.rs
+++ b/hydroflow/src/util/mod.rs
@@ -32,17 +32,6 @@ pub fn unbounded_channel<T>() -> (
     (send, recv)
 }
 
-pub fn bounded_channel<T>(
-    capacity: usize,
-) -> (
-    tokio::sync::mpsc::Sender<T>,
-    tokio_stream::wrappers::ReceiverStream<T>,
-) {
-    let (send, recv) = tokio::sync::mpsc::channel(capacity);
-    let recv = tokio_stream::wrappers::ReceiverStream::new(recv);
-    (send, recv)
-}
-
 pub fn ready_iter<S>(stream: S) -> impl Iterator<Item = S::Item>
 where
     S: Stream,

--- a/hydroflow_lang/src/graph/ops/source_stream_serde.rs
+++ b/hydroflow_lang/src/graph/ops/source_stream_serde.rs
@@ -60,7 +60,7 @@ pub const SOURCE_STREAM_SERDE: OperatorConstraints = OperatorConstraints {
         let write_iterator = quote_spanned! {op_span=>
             let #ident = std::iter::from_fn(|| {
                 match #root::futures::stream::Stream::poll_next(#stream_ident.as_mut(), &mut std::task::Context::from_waker(&#context.waker())) {
-                    std::task::Poll::Ready(Some(std::result::Result::Ok((payload, addr)))) => Some((#root::util::deserialize_from_bytes(payload), addr)),
+                    std::task::Poll::Ready(Some(std::result::Result::Ok((payload, addr)))) => Some((#root::util::deserialize_from_bytes(&payload), addr)),
                     std::task::Poll::Ready(Some(Err(_))) => None,
                     std::task::Poll::Ready(None) => None,
                     std::task::Poll::Pending => None,


### PR DESCRIPTION
Currently deserialize_bytes takes ByteMut by value, so if you have just a slice you aren't able to use deserialize_bytes to deserialize it. This came up in the kvs benchmark since it is using zmq to pass messages around, and that does not use Bytes/BytesMut it instead uses Vec/slice.