### PR TITLE
Add specialized `lattice_merge::<MyLatRepr>()` operator

### DIFF
--- a/hydroflow/tests/compile-fail/surface_lattice_merge_badgeneric.rs
+++ b/hydroflow/tests/compile-fail/surface_lattice_merge_badgeneric.rs
@@ -1,0 +1,10 @@
+use hydroflow::hydroflow_syntax;
+
+fn main() {
+    let mut df = hydroflow_syntax! {
+        source_iter([1,2,3,4,5])
+            -> lattice_merge::<'static, usize>()
+            -> for_each(|x| println!("Least upper bound: {:?}", x));
+    };
+    df.run_available();
+}

--- a/hydroflow/tests/compile-fail/surface_lattice_merge_badgeneric.stderr
+++ b/hydroflow/tests/compile-fail/surface_lattice_merge_badgeneric.stderr
@@ -1,0 +1,66 @@
+error[E0277]: the trait bound `usize: LatticeRepr` is not satisfied
+ --> tests/compile-fail/surface_lattice_merge_badgeneric.rs:6:41
+  |
+6 |             -> lattice_merge::<'static, usize>()
+  |                                         ^^^^^ the trait `LatticeRepr` is not implemented for `usize`
+  |
+  = help: the following other types implement trait `LatticeRepr`:
+            BottomRepr<Lr>
+            DomPairRepr<Ra, Rb>
+            LastWriteWinsRepr<M, T>
+            MapUnionRepr<Tag, K, B>
+            MaxRepr<T>
+            MinRepr<T>
+            PairRepr<Ra, Rb>
+            SetUnionRepr<Tag, T>
+            TopRepr<Lr>
+
+error[E0277]: the trait bound `usize: LatticeRepr` is not satisfied
+ --> tests/compile-fail/surface_lattice_merge_badgeneric.rs:6:16
+  |
+6 |             -> lattice_merge::<'static, usize>()
+  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `LatticeRepr` is not implemented for `usize`
+  |
+  = help: the following other types implement trait `LatticeRepr`:
+            BottomRepr<Lr>
+            DomPairRepr<Ra, Rb>
+            LastWriteWinsRepr<M, T>
+            MapUnionRepr<Tag, K, B>
+            MaxRepr<T>
+            MinRepr<T>
+            PairRepr<Ra, Rb>
+            SetUnionRepr<Tag, T>
+            TopRepr<Lr>
+
+error[E0277]: the trait bound `usize: Merge<usize>` is not satisfied
+ --> tests/compile-fail/surface_lattice_merge_badgeneric.rs:6:41
+  |
+6 |             -> lattice_merge::<'static, usize>()
+  |                                         ^^^^^ the trait `Merge<usize>` is not implemented for `usize`
+  |
+  = help: the following other types implement trait `Merge<Delta>`:
+            <BottomRepr<SelfLr> as Merge<BottomRepr<DeltaLr>>>
+            <DomPairRepr<SelfRA, SelfRB> as Merge<DomPairRepr<DeltaRA, DeltaRB>>>
+            <LastWriteWinsRepr<M, T> as Merge<LastWriteWinsRepr<M, T>>>
+            <MapUnionRepr<SelfTag, K, SelfLr> as Merge<MapUnionRepr<DeltaTag, K, DeltaLr>>>
+            <MaxRepr<T> as Merge<MaxRepr<T>>>
+            <MinRepr<T> as Merge<MinRepr<T>>>
+            <PairRepr<SelfRA, SelfRB> as Merge<PairRepr<DeltaRA, DeltaRB>>>
+            <SetUnionRepr<SelfTag, T> as Merge<SetUnionRepr<DeltaTag, T>>>
+
+error[E0277]: the trait bound `usize: Merge<usize>` is not satisfied
+ --> tests/compile-fail/surface_lattice_merge_badgeneric.rs:5:9
+  |
+5 | /         source_iter([1,2,3,4,5])
+6 | |             -> lattice_merge::<'static, usize>()
+  | |________________________________________________^ the trait `Merge<usize>` is not implemented for `usize`
+  |
+  = help: the following other types implement trait `Merge<Delta>`:
+            <BottomRepr<SelfLr> as Merge<BottomRepr<DeltaLr>>>
+            <DomPairRepr<SelfRA, SelfRB> as Merge<DomPairRepr<DeltaRA, DeltaRB>>>
+            <LastWriteWinsRepr<M, T> as Merge<LastWriteWinsRepr<M, T>>>
+            <MapUnionRepr<SelfTag, K, SelfLr> as Merge<MapUnionRepr<DeltaTag, K, DeltaLr>>>
+            <MaxRepr<T> as Merge<MaxRepr<T>>>
+            <MinRepr<T> as Merge<MinRepr<T>>>
+            <PairRepr<SelfRA, SelfRB> as Merge<PairRepr<DeltaRA, DeltaRB>>>
+            <SetUnionRepr<SelfTag, T> as Merge<SetUnionRepr<DeltaTag, T>>>

--- a/hydroflow/tests/compile-fail/surface_lattice_merge_nogeneric.rs
+++ b/hydroflow/tests/compile-fail/surface_lattice_merge_nogeneric.rs
@@ -1,0 +1,10 @@
+use hydroflow::hydroflow_syntax;
+
+fn main() {
+    let mut df = hydroflow_syntax! {
+        source_iter([1,2,3,4,5])
+            -> lattice_merge::<'static>()
+            -> for_each(|x| println!("Least upper bound: {:?}", x));
+    };
+    df.run_available();
+}

--- a/hydroflow/tests/compile-fail/surface_lattice_merge_nogeneric.stderr
+++ b/hydroflow/tests/compile-fail/surface_lattice_merge_nogeneric.stderr
@@ -1,0 +1,5 @@
+error: `lattice_merge` should have exactly 1 generic type arguments, actually has 0.
+ --> tests/compile-fail/surface_lattice_merge_nogeneric.rs:6:32
+  |
+6 |             -> lattice_merge::<'static>()
+  |                                ^^^^^^^

--- a/hydroflow/tests/compile-fail/surface_lattice_merge_wronggeneric.rs
+++ b/hydroflow/tests/compile-fail/surface_lattice_merge_wronggeneric.rs
@@ -1,0 +1,10 @@
+use hydroflow::hydroflow_syntax;
+
+fn main() {
+    let mut df = hydroflow_syntax! {
+        source_iter([1,2,3,4,5])
+            -> lattice_merge::<'static, hydroflow::lang::lattice::set_union::SetUnionRepr<hydroflow::lang::tag::HASH_SET, u32>>()
+            -> for_each(|x| println!("Least upper bound: {:?}", x));
+    };
+    df.run_available();
+}

--- a/hydroflow/tests/compile-fail/surface_lattice_merge_wronggeneric.stderr
+++ b/hydroflow/tests/compile-fail/surface_lattice_merge_wronggeneric.stderr
@@ -1,0 +1,15 @@
+error[E0271]: expected `Drain<'_, {integer}>` to be an iterator that yields `HashSet<u32>`, but it yields `{integer}`
+ --> tests/compile-fail/surface_lattice_merge_wronggeneric.rs:5:9
+  |
+5 |         source_iter([1,2,3,4,5])
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^ expected `HashSet<u32>`, found integer
+6 |             -> lattice_merge::<'static, hydroflow::lang::lattice::set_union::SetUnionRepr<hydroflow::lang::tag::HASH_SET, u32>>()
+  |                                         -------------------------------------------------------------------------------------- required by a bound introduced by this call
+  |
+  = note: expected struct `HashSet<u32>`
+               found type `{integer}`
+note: required by a bound in `check_inputs`
+ --> tests/compile-fail/surface_lattice_merge_wronggeneric.rs:6:41
+  |
+6 |             -> lattice_merge::<'static, hydroflow::lang::lattice::set_union::SetUnionRepr<hydroflow::lang::tag::HASH_SET, u32>>()
+  |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `check_inputs`

--- a/hydroflow/tests/surface_lattice_merge.rs
+++ b/hydroflow/tests/surface_lattice_merge.rs
@@ -1,0 +1,11 @@
+use hydroflow::hydroflow_syntax;
+
+#[test]
+fn test_basic() {
+    let mut df = hydroflow_syntax! {
+        source_iter([1,2,3,4,5])
+            -> lattice_merge::<'static, hydroflow::lang::lattice::ord::MaxRepr<u32>>()
+            -> for_each(|x| println!("Least upper bound: {:?}", x));
+    };
+    df.run_available();
+}

--- a/hydroflow_lang/src/graph/ops/lattice_merge.rs
+++ b/hydroflow_lang/src/graph/ops/lattice_merge.rs
@@ -1,0 +1,107 @@
+use crate::graph::ops::OperatorWriteOutput;
+
+use super::{
+    DelayType, FlowProperties, FlowPropertyVal, OpInstGenerics, OperatorConstraints,
+    OperatorInstance, WriteContextArgs, RANGE_1,
+};
+
+use quote::quote_spanned;
+use syn::{parse_quote_spanned, spanned::Spanned};
+
+/// > 1 input stream, 1 output stream
+///
+/// > Generic parameters: A [`LatticeRepr`](https://hydro-project.github.io/hydroflow/doc/hydroflow/lang/lattice/trait.LatticeRepr.html)
+/// type.
+///
+/// A specialized operator for merging lattices together into a accumulated value. Like [`fold()`](#fold)
+/// but specialized for lattice types. `lattice_merge::<MyLatRepr>()` is equivalent to `fold(Default::default, <MyLatRepr as LatticeRepr>::merge_owned)`.
+///
+/// `lattice_merge` can also be provided with one generic lifetime persistence argument, either
+/// `'tick` or `'static`, to specify how data persists. With `'tick`, values will only be collected
+/// within the same tick. With `'static`, values will be remembered across ticks and will be
+/// aggregated with pairs arriving in later ticks. When not explicitly specified persistence
+/// defaults to `'static`.
+///
+/// ```hydroflow
+/// source_iter([1,2,3,4,5])
+///     -> lattice_merge::<'static, hydroflow::lang::lattice::ord::MaxRepr<usize>>()
+///     -> for_each(|x| println!("Least upper bound: {}", x));
+/// ```
+#[hydroflow_internalmacro::operator_docgen]
+pub const LATTICE_MERGE: OperatorConstraints = OperatorConstraints {
+    name: "lattice_merge",
+    hard_range_inn: RANGE_1,
+    soft_range_inn: RANGE_1,
+    hard_range_out: RANGE_1,
+    soft_range_out: RANGE_1,
+    num_args: 0,
+    persistence_args: &(0..=1),
+    type_args: RANGE_1,
+    is_external_input: false,
+    ports_inn: None,
+    ports_out: None,
+    properties: FlowProperties {
+        deterministic: FlowPropertyVal::Preserve,
+        monotonic: FlowPropertyVal::Yes,
+        inconsistency_tainted: false,
+    },
+    input_delaytype_fn: |_| Some(DelayType::Stratum),
+    write_fn: |wc @ &WriteContextArgs {
+                   root,
+                   inputs,
+                   is_pull,
+                   op_inst:
+                       op_inst @ OperatorInstance {
+                           generics: OpInstGenerics { type_args, .. },
+                           ..
+                       },
+                   ..
+               },
+               diagnostics| {
+        assert!(is_pull);
+
+        assert_eq!(1, inputs.len());
+        let input = &inputs[0];
+
+        assert_eq!(1, type_args.len());
+        let lat_repr = &type_args[0];
+
+        let arguments = parse_quote_spanned! {lat_repr.span()=> // Uses `lat_repr.span()`!
+            ::std::default::Default::default(), <#lat_repr as #root::lang::lattice::Merge<#lat_repr>>::merge_owned
+        };
+        let wc = WriteContextArgs {
+            op_inst: &OperatorInstance {
+                arguments,
+                ..op_inst.clone()
+            },
+            ..wc.clone()
+        };
+
+        let OperatorWriteOutput {
+            write_prologue,
+            write_iterator,
+            write_iterator_after,
+        } = (super::fold::FOLD.write_fn)(&wc, diagnostics)?;
+        let write_iterator = quote_spanned! {lat_repr.span()=> // Uses `lat_repr.span()`!
+            let #input = {
+                /// Improve errors with `#lat_repr` trait bound.
+                #[inline(always)]
+                fn check_inputs<Lr>(
+                    input: impl Iterator<Item = <Lr as #root::lang::lattice::LatticeRepr>::Repr>
+                ) -> impl Iterator<Item = <Lr as #root::lang::lattice::LatticeRepr>::Repr>
+                where
+                    Lr: #root::lang::lattice::LatticeRepr,
+                {
+                    input
+                }
+                check_inputs::<#lat_repr>(#input)
+            };
+            #write_iterator
+        };
+        Ok(OperatorWriteOutput {
+            write_prologue,
+            write_iterator,
+            write_iterator_after,
+        })
+    },
+};

--- a/hydroflow_lang/src/graph/ops/mod.rs
+++ b/hydroflow_lang/src/graph/ops/mod.rs
@@ -246,6 +246,7 @@ declare_ops![
     inspect::INSPECT,
     join::JOIN,
     lattice_join::LATTICE_JOIN,
+    lattice_merge::LATTICE_MERGE,
     map::MAP,
     merge::MERGE,
     next_stratum::NEXT_STRATUM,


### PR DESCRIPTION
Baby steps

I guess for now all the lattice-based operators will be prefixed with `lattice_`