### PR TITLE
Generalize null source support into `SourcePath` abstraction

### DIFF
--- a/hydro_cli/src/core/hydroflow_crate/mod.rs
+++ b/hydro_cli/src/core/hydroflow_crate/mod.rs
@@ -12,7 +12,7 @@ use cargo::{
 use hydroflow_cli_integration::ServerPort;
 use tokio::{sync::RwLock, task::JoinHandle};
 
-use self::ports::{HydroflowPortConfig, HydroflowSink};
+use self::ports::{HydroflowPortConfig, HydroflowSink, SourcePath};
 
 use super::{
     Host, HostTargetType, LaunchedBinary, LaunchedHost, ResourceBatch, ResourceResult,
@@ -76,7 +76,7 @@ impl HydroflowCrate {
         my_port: String,
         sink: &mut dyn HydroflowSink,
     ) -> Result<()> {
-        let forward_res = sink.instantiate(&self.on);
+        let forward_res = sink.instantiate(&SourcePath::Direct(self.on.clone()));
         if let Ok(instantiated) = forward_res {
             // TODO(shadaj): if already in this map, we want to broadcast
             assert!(!self.port_to_server.contains_key(&my_port));


### PR DESCRIPTION
Generalize null source support into `SourcePath` abstraction

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydroflow/pull/532).
* #533
* __->__ #532