### PR TITLE
Start accepting connections in the background of CLI initialization to avoid deadlocks

### DIFF
--- a/hydroflow/tests/compile-fail/surface_lattice_merge_badgeneric.stderr
+++ b/hydroflow/tests/compile-fail/surface_lattice_merge_badgeneric.stderr
@@ -32,35 +32,35 @@ error[E0277]: the trait bound `usize: LatticeRepr` is not satisfied
             SetUnionRepr<Tag, T>
             TopRepr<Lr>
 
-error[E0277]: the trait bound `usize: Merge<usize>` is not satisfied
+error[E0277]: the trait bound `usize: hydroflow::lang::lattice::Merge<usize>` is not satisfied
  --> tests/compile-fail/surface_lattice_merge_badgeneric.rs:6:41
   |
 6 |             -> lattice_merge::<'static, usize>()
-  |                                         ^^^^^ the trait `Merge<usize>` is not implemented for `usize`
+  |                                         ^^^^^ the trait `hydroflow::lang::lattice::Merge<usize>` is not implemented for `usize`
   |
-  = help: the following other types implement trait `Merge<Delta>`:
-            <BottomRepr<SelfLr> as Merge<BottomRepr<DeltaLr>>>
-            <DomPairRepr<SelfRA, SelfRB> as Merge<DomPairRepr<DeltaRA, DeltaRB>>>
-            <LastWriteWinsRepr<M, T> as Merge<LastWriteWinsRepr<M, T>>>
-            <MapUnionRepr<SelfTag, K, SelfLr> as Merge<MapUnionRepr<DeltaTag, K, DeltaLr>>>
-            <MaxRepr<T> as Merge<MaxRepr<T>>>
-            <MinRepr<T> as Merge<MinRepr<T>>>
-            <PairRepr<SelfRA, SelfRB> as Merge<PairRepr<DeltaRA, DeltaRB>>>
-            <SetUnionRepr<SelfTag, T> as Merge<SetUnionRepr<DeltaTag, T>>>
+  = help: the following other types implement trait `hydroflow::lang::lattice::Merge<Delta>`:
+            <BottomRepr<SelfLr> as hydroflow::lang::lattice::Merge<BottomRepr<DeltaLr>>>
+            <DomPairRepr<SelfRA, SelfRB> as hydroflow::lang::lattice::Merge<DomPairRepr<DeltaRA, DeltaRB>>>
+            <LastWriteWinsRepr<M, T> as hydroflow::lang::lattice::Merge<LastWriteWinsRepr<M, T>>>
+            <MapUnionRepr<SelfTag, K, SelfLr> as hydroflow::lang::lattice::Merge<MapUnionRepr<DeltaTag, K, DeltaLr>>>
+            <MaxRepr<T> as hydroflow::lang::lattice::Merge<MaxRepr<T>>>
+            <MinRepr<T> as hydroflow::lang::lattice::Merge<MinRepr<T>>>
+            <PairRepr<SelfRA, SelfRB> as hydroflow::lang::lattice::Merge<PairRepr<DeltaRA, DeltaRB>>>
+            <SetUnionRepr<SelfTag, T> as hydroflow::lang::lattice::Merge<SetUnionRepr<DeltaTag, T>>>
 
-error[E0277]: the trait bound `usize: Merge<usize>` is not satisfied
+error[E0277]: the trait bound `usize: hydroflow::lang::lattice::Merge<usize>` is not satisfied
  --> tests/compile-fail/surface_lattice_merge_badgeneric.rs:5:9
   |
 5 | /         source_iter([1,2,3,4,5])
 6 | |             -> lattice_merge::<'static, usize>()
-  | |________________________________________________^ the trait `Merge<usize>` is not implemented for `usize`
+  | |________________________________________________^ the trait `hydroflow::lang::lattice::Merge<usize>` is not implemented for `usize`
   |
-  = help: the following other types implement trait `Merge<Delta>`:
-            <BottomRepr<SelfLr> as Merge<BottomRepr<DeltaLr>>>
-            <DomPairRepr<SelfRA, SelfRB> as Merge<DomPairRepr<DeltaRA, DeltaRB>>>
-            <LastWriteWinsRepr<M, T> as Merge<LastWriteWinsRepr<M, T>>>
-            <MapUnionRepr<SelfTag, K, SelfLr> as Merge<MapUnionRepr<DeltaTag, K, DeltaLr>>>
-            <MaxRepr<T> as Merge<MaxRepr<T>>>
-            <MinRepr<T> as Merge<MinRepr<T>>>
-            <PairRepr<SelfRA, SelfRB> as Merge<PairRepr<DeltaRA, DeltaRB>>>
-            <SetUnionRepr<SelfTag, T> as Merge<SetUnionRepr<DeltaTag, T>>>
+  = help: the following other types implement trait `hydroflow::lang::lattice::Merge<Delta>`:
+            <BottomRepr<SelfLr> as hydroflow::lang::lattice::Merge<BottomRepr<DeltaLr>>>
+            <DomPairRepr<SelfRA, SelfRB> as hydroflow::lang::lattice::Merge<DomPairRepr<DeltaRA, DeltaRB>>>
+            <LastWriteWinsRepr<M, T> as hydroflow::lang::lattice::Merge<LastWriteWinsRepr<M, T>>>
+            <MapUnionRepr<SelfTag, K, SelfLr> as hydroflow::lang::lattice::Merge<MapUnionRepr<DeltaTag, K, DeltaLr>>>
+            <MaxRepr<T> as hydroflow::lang::lattice::Merge<MaxRepr<T>>>
+            <MinRepr<T> as hydroflow::lang::lattice::Merge<MinRepr<T>>>
+            <PairRepr<SelfRA, SelfRB> as hydroflow::lang::lattice::Merge<PairRepr<DeltaRA, DeltaRB>>>
+            <SetUnionRepr<SelfTag, T> as hydroflow::lang::lattice::Merge<SetUnionRepr<DeltaTag, T>>>

--- a/hydroflow_cli_integration/src/lib.rs
+++ b/hydroflow_cli_integration/src/lib.rs
@@ -18,8 +18,8 @@ use async_recursion::async_recursion;
 use async_trait::async_trait;
 use pin_project::pin_project;
 
-use tokio::io;
 use tokio::net::{TcpListener, TcpStream};
+use tokio::{io, task::JoinHandle};
 
 #[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
@@ -55,7 +55,11 @@ impl ServerBindConfig {
                 {
                     let dir = tempfile::tempdir().unwrap();
                     let socket_path = dir.path().join("socket");
-                    BoundConnection::UnixSocket(UnixListener::bind(socket_path).unwrap(), dir)
+                    let bound = UnixListener::bind(socket_path).unwrap();
+                    BoundConnection::UnixSocket(
+                        tokio::spawn(async move { Ok(bound.accept().await?.0) }),
+                        dir,
+                    )
                 }
 
                 #[cfg(not(unix))]
@@ -65,7 +69,11 @@ impl ServerBindConfig {
             }
             ServerBindConfig::TcpPort(host) => {
                 let listener = TcpListener::bind((host, 0)).await.unwrap();
-                BoundConnection::TcpPort(listener)
+                let addr = listener.local_addr().unwrap();
+                BoundConnection::TcpPort(
+                    tokio::spawn(async move { Ok(listener.accept().await?.0) }),
+                    addr,
+                )
             }
             ServerBindConfig::Demux(bindings) => {
                 let mut demux = HashMap::new();
@@ -141,8 +149,8 @@ pub trait ConnectedSource {
 
 #[derive(Debug)]
 pub enum BoundConnection {
-    UnixSocket(UnixListener, tempfile::TempDir),
-    TcpPort(TcpListener),
+    UnixSocket(JoinHandle<io::Result<UnixStream>>, tempfile::TempDir),
+    TcpPort(JoinHandle<io::Result<TcpStream>>, SocketAddr),
     Demux(HashMap<u32, BoundConnection>),
     Merge(Vec<BoundConnection>),
     Mux(HashMap<u32, BoundConnection>),
@@ -152,17 +160,10 @@ pub enum BoundConnection {
 impl BoundConnection {
     pub fn sink_port(&self) -> ServerPort {
         match self {
-            BoundConnection::UnixSocket(listener, _) => {
+            BoundConnection::UnixSocket(_, tempdir) => {
                 #[cfg(unix)]
                 {
-                    ServerPort::UnixSocket(
-                        listener
-                            .local_addr()
-                            .unwrap()
-                            .as_pathname()
-                            .unwrap()
-                            .to_path_buf(),
-                    )
+                    ServerPort::UnixSocket(tempdir.path().join("socket"))
                 }
 
                 #[cfg(not(unix))]
@@ -171,8 +172,7 @@ impl BoundConnection {
                     panic!("Unix sockets are not supported on this platform")
                 }
             }
-            BoundConnection::TcpPort(listener) => {
-                let addr = listener.local_addr().unwrap();
+            BoundConnection::TcpPort(_, addr) => {
                 ServerPort::TcpPort(SocketAddr::new(addr.ip(), addr.port()))
             }
 
@@ -206,12 +206,12 @@ impl BoundConnection {
 }
 
 #[async_recursion]
-async fn accept(bound: &BoundConnection) -> ConnectedBidi {
+async fn accept(bound: BoundConnection) -> ConnectedBidi {
     match bound {
         BoundConnection::UnixSocket(listener, _) => {
             #[cfg(unix)]
             {
-                let (stream, _) = listener.accept().await.unwrap();
+                let stream = listener.await.unwrap().unwrap();
                 let (sink, source) = unix_bytes(stream);
                 ConnectedBidi {
                     source: Some(Box::pin(source)),
@@ -225,8 +225,8 @@ async fn accept(bound: &BoundConnection) -> ConnectedBidi {
                 panic!("Unix sockets are not supported on this platform")
             }
         }
-        BoundConnection::TcpPort(listener) => {
-            let (stream, _) = listener.accept().await.unwrap();
+        BoundConnection::TcpPort(listener, _) => {
+            let stream = listener.await.unwrap().unwrap();
             let (sink, source) = tcp_bytes(stream);
             ConnectedBidi {
                 source: Some(Box::pin(source)),
@@ -373,7 +373,7 @@ impl Connected for ConnectedBidi {
                 })),
             },
 
-            ServerOrBound::Bound(bound) => accept(&bound).await,
+            ServerOrBound::Bound(bound) => accept(bound).await,
         }
     }
 }


### PR DESCRIPTION
Start accepting connections in the background of CLI initialization to avoid deadlocks

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydroflow/pull/541).
* #543
* #542
* __->__ #541