### PR TITLE
Avoid deadlock in port loading when a service connects to itself

### DIFF
--- a/hydro_cli/python_tests/basic.py
+++ b/hydro_cli/python_tests/basic.py
@@ -5,6 +5,22 @@ import pytest
 import hydro
 
 @pytest.mark.asyncio
+async def test_connect_to_self():
+    deployment = hydro.Deployment()
+    localhost_machine = deployment.Localhost()
+
+    program = deployment.HydroflowCrate(
+        src=str((Path(__file__).parent.parent.parent / "hydro_cli_examples").absolute()),
+        example="empty_program",
+        on=localhost_machine
+    )
+
+    program.ports.out.send_to(program.ports.input)
+
+    await deployment.deploy()
+    await deployment.start()
+
+@pytest.mark.asyncio
 async def test_python_sender():
     deployment = hydro.Deployment()
     localhost_machine = deployment.Localhost()

--- a/hydro_cli/src/core/gcp.rs
+++ b/hydro_cli/src/core/gcp.rs
@@ -17,6 +17,7 @@ use super::{
     ServerStrategy,
 };
 
+#[derive(Debug)]
 pub struct LaunchedComputeEngine {
     resource_result: Arc<ResourceResult>,
     user: String,
@@ -118,6 +119,7 @@ impl LaunchedSSHHost for LaunchedComputeEngine {
     }
 }
 
+#[derive(Debug)]
 pub struct GCPNetwork {
     pub project: String,
     pub tf_path: Option<String>,
@@ -223,6 +225,7 @@ impl GCPNetwork {
     }
 }
 
+#[derive(Debug)]
 pub struct GCPComputeEngineHost {
     pub id: usize,
     pub project: String,
@@ -489,6 +492,12 @@ impl Host for GCPComputeEngineHost {
                 ),
             },
         );
+    }
+
+    fn launched(&self) -> Option<Arc<dyn LaunchedHost>> {
+        self.launched
+            .as_ref()
+            .map(|a| a.clone() as Arc<dyn LaunchedHost>)
     }
 
     async fn provision(&mut self, resource_result: &Arc<ResourceResult>) -> Arc<dyn LaunchedHost> {

--- a/hydro_cli/src/core/hydroflow_crate/mod.rs
+++ b/hydro_cli/src/core/hydroflow_crate/mod.rs
@@ -40,7 +40,7 @@ pub struct HydroflowCrate {
     /// A map of port names to config for how other services can connect to this one.
     /// Only valid after `ready` has been called, only contains ports that are configured
     /// in `server_ports`.
-    server_defns: HashMap<String, ServerPort>,
+    server_defns: Arc<RwLock<HashMap<String, ServerPort>>>,
 
     launched_binary: Option<Arc<RwLock<dyn LaunchedBinary>>>,
     started: bool,
@@ -64,9 +64,23 @@ impl HydroflowCrate {
             port_to_bind: HashMap::new(),
             built_binary: None,
             launched_host: None,
-            server_defns: HashMap::new(),
+            server_defns: Arc::new(RwLock::new(HashMap::new())),
             launched_binary: None,
             started: false,
+        }
+    }
+
+    pub fn get_port(
+        &self,
+        name: String,
+        self_arc: &Arc<RwLock<HydroflowCrate>>,
+    ) -> HydroflowPortConfig {
+        HydroflowPortConfig {
+            service: Arc::downgrade(self_arc),
+            service_host: self.on.clone(),
+            service_server_defns: self.server_defns.clone(),
+            port: name,
+            merge: false,
         }
     }
 
@@ -88,6 +102,8 @@ impl HydroflowCrate {
                 &self.on,
                 Arc::new(HydroflowPortConfig {
                     service: Arc::downgrade(self_arc),
+                    service_host: self.on.clone(),
+                    service_server_defns: self.server_defns.clone(),
                     port: my_port.clone(),
                     merge: false,
                 }),
@@ -254,7 +270,7 @@ impl Service for HydroflowCrate {
 
         let ready_line = stdout_receiver.recv().await.unwrap();
         if ready_line.starts_with("ready: ") {
-            self.server_defns =
+            *self.server_defns.try_write().unwrap() =
                 serde_json::from_str(ready_line.trim_start_matches("ready: ")).unwrap();
         } else {
             bail!("expected ready");

--- a/hydro_cli/src/core/localhost.rs
+++ b/hydro_cli/src/core/localhost.rs
@@ -216,6 +216,10 @@ impl Host for LocalhostHost {
         self
     }
 
+    fn launched(&self) -> Option<Arc<dyn LaunchedHost>> {
+        Some(Arc::new(LaunchedLocalhost {}))
+    }
+
     async fn provision(&mut self, _resource_result: &Arc<ResourceResult>) -> Arc<dyn LaunchedHost> {
         Arc::new(LaunchedLocalhost {})
     }

--- a/hydro_cli/src/core/mod.rs
+++ b/hydro_cli/src/core/mod.rs
@@ -50,6 +50,7 @@ impl ResourceBatch {
     }
 }
 
+#[derive(Debug)]
 pub struct ResourceResult {
     pub terraform: terraform::TerraformResult,
 }
@@ -118,7 +119,7 @@ pub enum HostTargetType {
 pub type HostStrategyGetter = Box<dyn FnOnce(&mut dyn std::any::Any) -> ServerStrategy>;
 
 #[async_trait]
-pub trait Host: Send + Sync {
+pub trait Host: Send + Sync + std::fmt::Debug {
     fn target_type(&self) -> HostTargetType;
 
     fn request_port(&mut self, bind_type: &ServerStrategy);
@@ -140,6 +141,8 @@ pub trait Host: Send + Sync {
 
     /// Connects to the acquired resources and prepares the host to run services.
     async fn provision(&mut self, resource_result: &Arc<ResourceResult>) -> Arc<dyn LaunchedHost>;
+
+    fn launched(&self) -> Option<Arc<dyn LaunchedHost>>;
 
     /// Identifies a network type that this host can use for connections if it is the server.
     /// The host will be `None` if the connection is from the same host as the target.

--- a/hydro_cli/src/core/terraform.rs
+++ b/hydro_cli/src/core/terraform.rs
@@ -274,11 +274,12 @@ pub struct TerraformProvider {
     pub version: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct TerraformOutput {
     pub value: String,
 }
 
+#[derive(Debug)]
 pub struct TerraformResult {
     pub outputs: HashMap<String, TerraformOutput>,
     /// `None` if no deployment was performed

--- a/hydro_cli/src/lib.rs
+++ b/hydro_cli/src/lib.rs
@@ -479,11 +479,10 @@ struct HydroflowCratePorts {
 impl HydroflowCratePorts {
     fn __getattribute__(&self, name: String, py: Python<'_>) -> PyResult<Py<pyo3::PyAny>> {
         let arc = Arc::new(RwLock::new(
-            crate::core::hydroflow_crate::ports::HydroflowPortConfig {
-                service: Arc::downgrade(&self.underlying),
-                port: name,
-                merge: false,
-            },
+            self.underlying
+                .try_read()
+                .unwrap()
+                .get_port(name, &self.underlying),
         ));
 
         Ok(Py::new(

--- a/hydro_cli_examples/Cargo.toml
+++ b/hydro_cli_examples/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [[example]]
+name = "empty_program"
+
+[[example]]
 name = "stdout_receiver"
 
 [[example]]

--- a/hydro_cli_examples/examples/empty_program/main.rs
+++ b/hydro_cli_examples/examples/empty_program/main.rs
@@ -1,0 +1,7 @@
+#[tokio::main]
+async fn main() {
+    let _ = hydroflow::util::cli::init().await;
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}


### PR DESCRIPTION
Avoid deadlock in port loading when a service connects to itself

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydroflow/pull/542).
* #543
* __->__ #542