### PR TITLE
Support `_` as a wildcard variable in Dedalus rules that is not joined on

### DIFF
--- a/hydroflow_datalog_core/src/join_plan.rs
+++ b/hydroflow_datalog_core/src/join_plan.rs
@@ -137,11 +137,13 @@ fn find_relation_local_constraints<'a>(
 ) -> BTreeMap<String, Vec<usize>> {
     let mut indices_grouped_by_var = BTreeMap::new();
     for (i, ident) in fields.enumerate() {
-        let entry = indices_grouped_by_var
-            // TODO(shadaj): Can we avoid cloning here?
-            .entry(ident.name.clone())
-            .or_insert_with(Vec::new);
-        entry.push(i);
+        if ident.name != "_" {
+            let entry = indices_grouped_by_var
+                // TODO(shadaj): Can we avoid cloning here?
+                .entry(ident.name.clone())
+                .or_insert_with(Vec::new);
+            entry.push(i);
+        }
     }
 
     indices_grouped_by_var.retain(|_, v| v.len() > 1);
@@ -234,8 +236,10 @@ pub fn expand_join_plan(
             for (i, ident) in target.fields.iter().enumerate() {
                 row_types.push(parse_quote!(_));
 
-                if let Entry::Vacant(e) = variable_mapping.entry(ident.name.clone()) {
-                    e.insert(i);
+                if ident.name != "_" {
+                    if let Entry::Vacant(e) = variable_mapping.entry(ident.name.clone()) {
+                        e.insert(i);
+                    }
                 }
             }
 
@@ -564,7 +568,12 @@ pub fn expand_join_plan(
             }
 
             flattened_elements.push(parse_quote!(v));
-            flattened_mapping.insert(less_than.name.clone(), flattened_elements.len() - 1);
+
+            if less_than.name == threshold.name {
+                panic!("The threshold and less_than variables must be different")
+            } else if less_than.name != "_" {
+                flattened_mapping.insert(less_than.name.clone(), flattened_elements.len() - 1);
+            }
 
             flat_graph_builder.add_statement(parse_quote_spanned! {get_span(rule_span)=>
                 #magic_node = #inner_name -> flat_map(|row: #row_type| (0..(row.#threshold_index)).map(move |v| (#(#flattened_elements, )*)) )

--- a/hydroflow_datalog_core/src/lib.rs
+++ b/hydroflow_datalog_core/src/lib.rs
@@ -742,6 +742,18 @@ mod tests {
     }
 
     #[test]
+    fn wildcard_fields() {
+        test_snapshots!(
+            r#"
+            .input input `source_stream(input)`
+            .output out `for_each(|v| out.send(v).unwrap())`
+
+            out(x) :- input(x, _), input(_, x).
+            "#
+        );
+    }
+
+    #[test]
     fn join_with_other() {
         test_snapshots!(
             r#"

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__wildcard_fields@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__wildcard_fields@datalog_program.snap
@@ -1,0 +1,376 @@
+---
+source: hydroflow_datalog_core/src/lib.rs
+expression: "prettyplease::unparse(&wrapped)"
+---
+fn main() {
+    {
+        use hydroflow::{var_expr, var_args};
+        let mut df = hydroflow::scheduled::graph::Hydroflow::new();
+        df.__assign_meta_graph(
+            "{\"nodes\":[{\"value\":null,\"version\":0},{\"value\":{\"Operator\":\"merge ()\"},\"version\":1},{\"value\":{\"Operator\":\"unique :: < 'tick > ()\"},\"version\":1},{\"value\":{\"Operator\":\"tee ()\"},\"version\":1},{\"value\":{\"Operator\":\"merge ()\"},\"version\":1},{\"value\":{\"Operator\":\"unique :: < 'tick > ()\"},\"version\":1},{\"value\":{\"Operator\":\"tee ()\"},\"version\":1},{\"value\":{\"Operator\":\"source_stream (input)\"},\"version\":1},{\"value\":{\"Operator\":\"for_each (| v | out . send (v) . unwrap ())\"},\"version\":1},{\"value\":{\"Operator\":\"join :: < 'tick > ()\"},\"version\":1},{\"value\":{\"Operator\":\"map (| kv : ((_ ,) , (() , ())) | (kv . 0 . 0 ,))\"},\"version\":1},{\"value\":{\"Operator\":\"map (| _v : (_ , _ ,) | ((_v . 0 ,) , ()))\"},\"version\":1},{\"value\":{\"Operator\":\"map (| _v : (_ , _ ,) | ((_v . 1 ,) , ()))\"},\"version\":1},{\"value\":{\"Operator\":\"map (| row : (_ ,) | (row . 0 ,))\"},\"version\":1},{\"value\":{\"Handoff\":{}},\"version\":1},{\"value\":{\"Handoff\":{}},\"version\":1}],\"graph\":[{\"value\":null,\"version\":0},{\"value\":[{\"idx\":2,\"version\":1},{\"idx\":3,\"version\":1}],\"version\":1},{\"value\":[{\"idx\":1,\"version\":1},{\"idx\":2,\"version\":1}],\"version\":1},{\"value\":[{\"idx\":5,\"version\":1},{\"idx\":6,\"version\":1}],\"version\":1},{\"value\":[{\"idx\":4,\"version\":1},{\"idx\":5,\"version\":1}],\"version\":1},{\"value\":[{\"idx\":7,\"version\":1},{\"idx\":1,\"version\":1}],\"version\":1},{\"value\":[{\"idx\":6,\"version\":1},{\"idx\":8,\"version\":1}],\"version\":1},{\"value\":[{\"idx\":9,\"version\":1},{\"idx\":10,\"version\":1}],\"version\":1},{\"value\":[{\"idx\":11,\"version\":1},{\"idx\":9,\"version\":1}],\"version\":1},{\"value\":[{\"idx\":3,\"version\":1},{\"idx\":14,\"version\":1}],\"version\":3},{\"value\":[{\"idx\":12,\"version\":1},{\"idx\":9,\"version\":1}],\"version\":1},{\"value\":[{\"idx\":3,\"version\":1},{\"idx\":15,\"version\":1}],\"version\":3},{\"value\":[{\"idx\":13,\"version\":1},{\"idx\":4,\"version\":1}],\"version\":1},{\"value\":[{\"idx\":10,\"version\":1},{\"idx\":13,\"version\":1}],\"version\":1},{\"value\":[{\"idx\":14,\"version\":1},{\"idx\":11,\"version\":1}],\"version\":1},{\"value\":[{\"idx\":15,\"version\":1},{\"idx\":12,\"version\":1}],\"version\":1}],\"ports\":[{\"value\":null,\"version\":0},{\"value\":[\"Elided\",\"Elided\"],\"version\":1},{\"value\":[\"Elided\",\"Elided\"],\"version\":1},{\"value\":[\"Elided\",\"Elided\"],\"version\":1},{\"value\":[\"Elided\",\"Elided\"],\"version\":1},{\"value\":[\"Elided\",{\"Int\":\"0\"}],\"version\":1},{\"value\":[{\"Int\":\"0\"},\"Elided\"],\"version\":1},{\"value\":[\"Elided\",\"Elided\"],\"version\":1},{\"value\":[\"Elided\",{\"Int\":\"0\"}],\"version\":1},{\"value\":[{\"Int\":\"0\"},\"Elided\"],\"version\":3},{\"value\":[\"Elided\",{\"Int\":\"1\"}],\"version\":1},{\"value\":[{\"Int\":\"1\"},\"Elided\"],\"version\":3},{\"value\":[\"Elided\",{\"Int\":\"0\"}],\"version\":1},{\"value\":[\"Elided\",\"Elided\"],\"version\":1},{\"value\":[\"Elided\",\"Elided\"],\"version\":1},{\"value\":[\"Elided\",\"Elided\"],\"version\":1}],\"node_subgraph\":[{\"value\":null,\"version\":0},{\"value\":{\"idx\":1,\"version\":1},\"version\":1},{\"value\":{\"idx\":1,\"version\":1},\"version\":1},{\"value\":{\"idx\":1,\"version\":1},\"version\":1},{\"value\":{\"idx\":2,\"version\":1},\"version\":1},{\"value\":{\"idx\":2,\"version\":1},\"version\":1},{\"value\":{\"idx\":2,\"version\":1},\"version\":1},{\"value\":{\"idx\":1,\"version\":1},\"version\":1},{\"value\":{\"idx\":2,\"version\":1},\"version\":1},{\"value\":{\"idx\":2,\"version\":1},\"version\":1},{\"value\":{\"idx\":2,\"version\":1},\"version\":1},{\"value\":{\"idx\":2,\"version\":1},\"version\":1},{\"value\":{\"idx\":2,\"version\":1},\"version\":1},{\"value\":{\"idx\":2,\"version\":1},\"version\":1}],\"subgraph_nodes\":[{\"value\":null,\"version\":0},{\"value\":[{\"idx\":7,\"version\":1},{\"idx\":1,\"version\":1},{\"idx\":2,\"version\":1},{\"idx\":3,\"version\":1}],\"version\":1},{\"value\":[{\"idx\":11,\"version\":1},{\"idx\":12,\"version\":1},{\"idx\":9,\"version\":1},{\"idx\":10,\"version\":1},{\"idx\":13,\"version\":1},{\"idx\":4,\"version\":1},{\"idx\":5,\"version\":1},{\"idx\":6,\"version\":1},{\"idx\":8,\"version\":1}],\"version\":1}],\"subgraph_stratum\":[{\"value\":null,\"version\":0},{\"value\":0,\"version\":1},{\"value\":0,\"version\":1}],\"node_varnames\":[{\"value\":null,\"version\":0},{\"value\":\"input\",\"version\":1},{\"value\":\"input\",\"version\":1},{\"value\":\"input\",\"version\":1},{\"value\":\"out\",\"version\":1},{\"value\":\"out\",\"version\":1},{\"value\":\"out\",\"version\":1},{\"value\":null,\"version\":0},{\"value\":null,\"version\":0},{\"value\":\"join_0\",\"version\":1},{\"value\":\"join_0\",\"version\":1}]}",
+        );
+        df.__assign_diagnostics("[]");
+        let (hoff_14v1_send, hoff_14v1_recv) = df
+            .make_edge::<
+                _,
+                hydroflow::scheduled::handoff::VecHandoff<_>,
+            >("handoff GraphNodeId(14v1)");
+        let (hoff_15v1_send, hoff_15v1_recv) = df
+            .make_edge::<
+                _,
+                hydroflow::scheduled::handoff::VecHandoff<_>,
+            >("handoff GraphNodeId(15v1)");
+        let mut sg_1v1_node_7v1_stream = {
+            #[inline(always)]
+            fn check_stream<
+                Stream: hydroflow::futures::stream::Stream<Item = Item>,
+                Item,
+            >(
+                stream: Stream,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<impl hydroflow::futures::stream::Stream<Item = Item>>,
+            > {
+                ::std::boxed::Box::pin(stream)
+            }
+            check_stream(input)
+        };
+        let sg_1v1_node_2v1_uniquedata = df
+            .add_state(
+                ::std::cell::RefCell::new(
+                    hydroflow::lang::monotonic_map::MonotonicMap::<
+                        _,
+                        ::std::collections::HashSet<_>,
+                    >::default(),
+                ),
+            );
+        df.add_subgraph_stratified(
+            "Subgraph GraphSubgraphId(1v1)",
+            0,
+            var_expr!(),
+            var_expr!(hoff_14v1_send, hoff_15v1_send),
+            move |context, var_args!(), var_args!(hoff_14v1_send, hoff_15v1_send)| {
+                let hoff_14v1_send = hydroflow::pusherator::for_each::ForEach::new(|v| {
+                    hoff_14v1_send.give(Some(v));
+                });
+                let hoff_15v1_send = hydroflow::pusherator::for_each::ForEach::new(|v| {
+                    hoff_15v1_send.give(Some(v));
+                });
+                let op_7v1 = std::iter::from_fn(|| {
+                    match hydroflow::futures::stream::Stream::poll_next(
+                        sg_1v1_node_7v1_stream.as_mut(),
+                        &mut std::task::Context::from_waker(&context.waker()),
+                    ) {
+                        std::task::Poll::Ready(maybe) => maybe,
+                        std::task::Poll::Pending => None,
+                    }
+                });
+                let op_7v1 = {
+                    #[inline(always)]
+                    pub fn check_op_7v1<Input: ::std::iter::Iterator<Item = Item>, Item>(
+                        input: Input,
+                    ) -> impl ::std::iter::Iterator<Item = Item> {
+                        input
+                    }
+                    check_op_7v1(op_7v1)
+                };
+                let op_1v1 = {
+                    #[allow(unused)]
+                    #[inline(always)]
+                    fn check_inputs<
+                        A: ::std::iter::Iterator<Item = Item>,
+                        B: ::std::iter::Iterator<Item = Item>,
+                        Item,
+                    >(a: A, b: B) -> impl ::std::iter::Iterator<Item = Item> {
+                        a.chain(b)
+                    }
+                    op_7v1
+                };
+                let op_1v1 = {
+                    #[inline(always)]
+                    pub fn check_op_1v1<Input: ::std::iter::Iterator<Item = Item>, Item>(
+                        input: Input,
+                    ) -> impl ::std::iter::Iterator<Item = Item> {
+                        input
+                    }
+                    check_op_1v1(op_1v1)
+                };
+                let op_2v1 = op_1v1
+                    .filter(|item| {
+                        let mut borrow = context
+                            .state_ref(sg_1v1_node_2v1_uniquedata)
+                            .borrow_mut();
+                        let set = borrow
+                            .try_insert_with(
+                                (context.current_tick(), context.current_stratum()),
+                                ::std::collections::HashSet::new,
+                            );
+                        if !set.contains(item) {
+                            set.insert(::std::clone::Clone::clone(item));
+                            true
+                        } else {
+                            false
+                        }
+                    });
+                let op_2v1 = {
+                    #[inline(always)]
+                    pub fn check_op_2v1<Input: ::std::iter::Iterator<Item = Item>, Item>(
+                        input: Input,
+                    ) -> impl ::std::iter::Iterator<Item = Item> {
+                        input
+                    }
+                    check_op_2v1(op_2v1)
+                };
+                let op_3v1 = hydroflow::pusherator::tee::Tee::new(
+                    hoff_14v1_send,
+                    hoff_15v1_send,
+                );
+                let op_3v1 = {
+                    #[inline(always)]
+                    pub fn check_op_3v1<
+                        Input: hydroflow::pusherator::Pusherator<Item = Item>,
+                        Item,
+                    >(
+                        input: Input,
+                    ) -> impl hydroflow::pusherator::Pusherator<Item = Item> {
+                        input
+                    }
+                    check_op_3v1(op_3v1)
+                };
+                #[inline(always)]
+                fn check_pivot_run<
+                    Pull: ::std::iter::Iterator<Item = Item>,
+                    Push: hydroflow::pusherator::Pusherator<Item = Item>,
+                    Item,
+                >(pull: Pull, push: Push) {
+                    hydroflow::pusherator::pivot::Pivot::new(pull, push).run();
+                }
+                check_pivot_run(op_2v1, op_3v1);
+            },
+        );
+        let sg_2v1_node_9v1_joindata_lhs = df
+            .add_state(
+                std::cell::RefCell::new(
+                    hydroflow::lang::monotonic_map::MonotonicMap::new_init(
+                        hydroflow::lang::clear::ClearDefault(
+                            hydroflow::compiled::pull::HalfJoinState::default(),
+                        ),
+                    ),
+                ),
+            );
+        let sg_2v1_node_9v1_joindata_rhs = df
+            .add_state(
+                std::cell::RefCell::new(
+                    hydroflow::lang::monotonic_map::MonotonicMap::new_init(
+                        hydroflow::lang::clear::ClearDefault(
+                            hydroflow::compiled::pull::HalfJoinState::default(),
+                        ),
+                    ),
+                ),
+            );
+        let sg_2v1_node_5v1_uniquedata = df
+            .add_state(
+                ::std::cell::RefCell::new(
+                    hydroflow::lang::monotonic_map::MonotonicMap::<
+                        _,
+                        ::std::collections::HashSet<_>,
+                    >::default(),
+                ),
+            );
+        df.add_subgraph_stratified(
+            "Subgraph GraphSubgraphId(2v1)",
+            0,
+            var_expr!(hoff_14v1_recv, hoff_15v1_recv),
+            var_expr!(),
+            move |context, var_args!(hoff_14v1_recv, hoff_15v1_recv), var_args!()| {
+                let mut hoff_14v1_recv = hoff_14v1_recv.borrow_mut_swap();
+                let hoff_14v1_recv = hoff_14v1_recv.drain(..);
+                let mut hoff_15v1_recv = hoff_15v1_recv.borrow_mut_swap();
+                let hoff_15v1_recv = hoff_15v1_recv.drain(..);
+                let op_11v1 = hoff_14v1_recv.map(|_v: (_, _)| ((_v.0,), ()));
+                let op_11v1 = {
+                    #[inline(always)]
+                    pub fn check_op_11v1<
+                        Input: ::std::iter::Iterator<Item = Item>,
+                        Item,
+                    >(input: Input) -> impl ::std::iter::Iterator<Item = Item> {
+                        input
+                    }
+                    check_op_11v1(op_11v1)
+                };
+                let op_12v1 = hoff_15v1_recv.map(|_v: (_, _)| ((_v.1,), ()));
+                let op_12v1 = {
+                    #[inline(always)]
+                    pub fn check_op_12v1<
+                        Input: ::std::iter::Iterator<Item = Item>,
+                        Item,
+                    >(input: Input) -> impl ::std::iter::Iterator<Item = Item> {
+                        input
+                    }
+                    check_op_12v1(op_12v1)
+                };
+                let mut sg_2v1_node_9v1_joindata_lhs_borrow = context
+                    .state_ref(sg_2v1_node_9v1_joindata_lhs)
+                    .borrow_mut();
+                let mut sg_2v1_node_9v1_joindata_rhs_borrow = context
+                    .state_ref(sg_2v1_node_9v1_joindata_rhs)
+                    .borrow_mut();
+                let op_9v1 = {
+                    /// Limit error propagation by bounding locally, erasing output iterator type.
+                    #[inline(always)]
+                    fn check_inputs<'a, K, I1, V1, I2, V2>(
+                        lhs: I1,
+                        rhs: I2,
+                        lhs_state: &'a mut hydroflow::compiled::pull::HalfJoinState<
+                            K,
+                            V1,
+                            V2,
+                        >,
+                        rhs_state: &'a mut hydroflow::compiled::pull::HalfJoinState<
+                            K,
+                            V2,
+                            V1,
+                        >,
+                    ) -> impl 'a + Iterator<Item = (K, (V1, V2))>
+                    where
+                        K: Eq + std::hash::Hash + Clone,
+                        V1: Eq + Clone,
+                        V2: Eq + Clone,
+                        I1: 'a + Iterator<Item = (K, V1)>,
+                        I2: 'a + Iterator<Item = (K, V2)>,
+                    {
+                        hydroflow::compiled::pull::SymmetricHashJoin::new_from_mut(
+                            lhs,
+                            rhs,
+                            lhs_state,
+                            rhs_state,
+                        )
+                    }
+                    check_inputs(
+                        op_11v1,
+                        op_12v1,
+                        &mut sg_2v1_node_9v1_joindata_lhs_borrow
+                            .try_insert_with(context.current_tick(), Default::default)
+                            .0,
+                        &mut sg_2v1_node_9v1_joindata_rhs_borrow
+                            .try_insert_with(context.current_tick(), Default::default)
+                            .0,
+                    )
+                };
+                let op_9v1 = {
+                    #[inline(always)]
+                    pub fn check_op_9v1<Input: ::std::iter::Iterator<Item = Item>, Item>(
+                        input: Input,
+                    ) -> impl ::std::iter::Iterator<Item = Item> {
+                        input
+                    }
+                    check_op_9v1(op_9v1)
+                };
+                let op_10v1 = op_9v1.map(|kv: ((_,), ((), ()))| (kv.0.0,));
+                let op_10v1 = {
+                    #[inline(always)]
+                    pub fn check_op_10v1<
+                        Input: ::std::iter::Iterator<Item = Item>,
+                        Item,
+                    >(input: Input) -> impl ::std::iter::Iterator<Item = Item> {
+                        input
+                    }
+                    check_op_10v1(op_10v1)
+                };
+                let op_13v1 = op_10v1.map(|row: (_,)| (row.0,));
+                let op_13v1 = {
+                    #[inline(always)]
+                    pub fn check_op_13v1<
+                        Input: ::std::iter::Iterator<Item = Item>,
+                        Item,
+                    >(input: Input) -> impl ::std::iter::Iterator<Item = Item> {
+                        input
+                    }
+                    check_op_13v1(op_13v1)
+                };
+                let op_4v1 = {
+                    #[allow(unused)]
+                    #[inline(always)]
+                    fn check_inputs<
+                        A: ::std::iter::Iterator<Item = Item>,
+                        B: ::std::iter::Iterator<Item = Item>,
+                        Item,
+                    >(a: A, b: B) -> impl ::std::iter::Iterator<Item = Item> {
+                        a.chain(b)
+                    }
+                    op_13v1
+                };
+                let op_4v1 = {
+                    #[inline(always)]
+                    pub fn check_op_4v1<Input: ::std::iter::Iterator<Item = Item>, Item>(
+                        input: Input,
+                    ) -> impl ::std::iter::Iterator<Item = Item> {
+                        input
+                    }
+                    check_op_4v1(op_4v1)
+                };
+                let op_5v1 = op_4v1
+                    .filter(|item| {
+                        let mut borrow = context
+                            .state_ref(sg_2v1_node_5v1_uniquedata)
+                            .borrow_mut();
+                        let set = borrow
+                            .try_insert_with(
+                                (context.current_tick(), context.current_stratum()),
+                                ::std::collections::HashSet::new,
+                            );
+                        if !set.contains(item) {
+                            set.insert(::std::clone::Clone::clone(item));
+                            true
+                        } else {
+                            false
+                        }
+                    });
+                let op_5v1 = {
+                    #[inline(always)]
+                    pub fn check_op_5v1<Input: ::std::iter::Iterator<Item = Item>, Item>(
+                        input: Input,
+                    ) -> impl ::std::iter::Iterator<Item = Item> {
+                        input
+                    }
+                    check_op_5v1(op_5v1)
+                };
+                let op_6v1 = op_5v1;
+                let op_6v1 = {
+                    #[inline(always)]
+                    pub fn check_op_6v1<Input: ::std::iter::Iterator<Item = Item>, Item>(
+                        input: Input,
+                    ) -> impl ::std::iter::Iterator<Item = Item> {
+                        input
+                    }
+                    check_op_6v1(op_6v1)
+                };
+                let op_8v1 = hydroflow::pusherator::for_each::ForEach::new(|v| {
+                    out.send(v).unwrap()
+                });
+                let op_8v1 = {
+                    #[inline(always)]
+                    pub fn check_op_8v1<
+                        Input: hydroflow::pusherator::Pusherator<Item = Item>,
+                        Item,
+                    >(
+                        input: Input,
+                    ) -> impl hydroflow::pusherator::Pusherator<Item = Item> {
+                        input
+                    }
+                    check_op_8v1(op_8v1)
+                };
+                #[inline(always)]
+                fn check_pivot_run<
+                    Pull: ::std::iter::Iterator<Item = Item>,
+                    Push: hydroflow::pusherator::Pusherator<Item = Item>,
+                    Item,
+                >(pull: Pull, push: Push) {
+                    hydroflow::pusherator::pivot::Pivot::new(pull, push).run();
+                }
+                check_pivot_run(op_6v1, op_8v1);
+            },
+        );
+        df
+    }
+}
+

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__wildcard_fields@surface_graph.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__wildcard_fields@surface_graph.snap
@@ -1,0 +1,32 @@
+---
+source: hydroflow_datalog_core/src/lib.rs
+expression: flat_graph_ref.surface_syntax_string()
+---
+1v1 = merge ();
+2v1 = unique :: < 'tick > ();
+3v1 = tee ();
+4v1 = merge ();
+5v1 = unique :: < 'tick > ();
+6v1 = tee ();
+7v1 = source_stream (input);
+8v1 = for_each (| v | out . send (v) . unwrap ());
+9v1 = join :: < 'tick > ();
+10v1 = map (| kv : ((_ ,) , (() , ())) | (kv . 0 . 0 ,));
+11v1 = map (| _v : (_ , _ ,) | ((_v . 0 ,) , ()));
+12v1 = map (| _v : (_ , _ ,) | ((_v . 1 ,) , ()));
+13v1 = map (| row : (_ ,) | (row . 0 ,));
+
+2v1 -> 3v1;
+1v1 -> 2v1;
+5v1 -> 6v1;
+4v1 -> 5v1;
+7v1 -> 1v1;
+6v1 -> 8v1;
+9v1 -> 10v1;
+11v1 -> 9v1;
+3v1 -> 11v1;
+12v1 -> 9v1;
+3v1 -> 12v1;
+13v1 -> 4v1;
+10v1 -> 13v1;
+


### PR DESCRIPTION
Support `_` as a wildcard variable in Dedalus rules that is not joined on

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydroflow/pull/549).
* #551
* __->__ #549