### PR TITLE
antijoin uses FxHash instead of SipHash

### DIFF
--- a/hydroflow/src/lang/monotonic_map.rs
+++ b/hydroflow/src/lang/monotonic_map.rs
@@ -1,5 +1,3 @@
-use super::clear::Clear;
-
 /// A map-like interface which in reality only stores one value at a time. The keys must be
 /// monotonically increasing (i.e. timestamps). For Hydroflow, this allows state to be stored which
 /// resets each tick by using the tick counter as the key. In the generic `Map` case it can be
@@ -8,7 +6,6 @@ use super::clear::Clear;
 pub struct MonotonicMap<K, V>
 where
     K: PartialOrd,
-    V: Clear,
 {
     key: Option<K>,
     val: V,
@@ -17,7 +14,7 @@ where
 impl<K, V> Default for MonotonicMap<K, V>
 where
     K: PartialOrd,
-    V: Clear + Default,
+    V: Default,
 {
     fn default() -> Self {
         Self {
@@ -30,7 +27,6 @@ where
 impl<K, V> MonotonicMap<K, V>
 where
     K: PartialOrd,
-    V: Clear,
 {
     /// Creates a new `MonotonicMap` initialized with the given value. The
     /// vaue will be `Clear`ed before it is accessed.

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__anti_join@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__anti_join@datalog_program.snap
@@ -301,10 +301,10 @@ fn main() {
             );
         let sg_1v1_node_21v1_diffdata_handle = df
             .add_state(
-                std::cell::RefCell::new(
+                ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -559,10 +559,10 @@ fn main() {
                     fn check_inputs<'a, K, I1, V, I2>(
                         input_pos: I1,
                         input_neg: I2,
-                        borrow_state: &'a mut std::collections::HashSet<K>,
+                        borrow_state: &'a mut hydroflow::rustc_hash::FxHashSet<K>,
                     ) -> impl 'a + Iterator<Item = (K, V)>
                     where
-                        K: Eq + std::hash::Hash + Clone,
+                        K: Eq + ::std::hash::Hash + Clone,
                         V: Eq + Clone,
                         I1: 'a + Iterator<Item = (K, V)>,
                         I2: 'a + Iterator<Item = K>,

--- a/hydroflow_lang/src/graph/ops/anti_join.rs
+++ b/hydroflow_lang/src/graph/ops/anti_join.rs
@@ -59,8 +59,8 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
                _| {
         let handle_ident = wc.make_ident("diffdata_handle");
         let write_prologue = quote_spanned! {op_span=>
-            let #handle_ident = #hydroflow.add_state(std::cell::RefCell::new(
-                #root::lang::monotonic_map::MonotonicMap::<_, std::collections::HashSet<_>>::default(),
+            let #handle_ident = #hydroflow.add_state(::std::cell::RefCell::new(
+                #root::lang::monotonic_map::MonotonicMap::<_, #root::rustc_hash::FxHashSet<_>>::default(),
             ));
         };
         let write_iterator = {
@@ -76,10 +76,10 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
                     fn check_inputs<'a, K, I1, V, I2>(
                         input_pos: I1,
                         input_neg: I2,
-                        borrow_state: &'a mut std::collections::HashSet<K>,
+                        borrow_state: &'a mut #root::rustc_hash::FxHashSet<K>,
                     ) -> impl 'a + Iterator<Item = (K, V)>
                     where
-                        K: Eq + std::hash::Hash + Clone,
+                        K: Eq + ::std::hash::Hash + Clone,
                         V: Eq + Clone,
                         I1: 'a + Iterator<Item = (K, V)>,
                         I2: 'a + Iterator<Item = K>,


### PR DESCRIPTION
micro/ops/anti_join     time:   [13.142 µs 13.184 µs 13.232 µs]
                        change: [-69.713% -69.428% -68.945%] (p = 0.00 < 0.05)
                        Performance has improved.