### PR TITLE
unique uses FxHash instead of SipHash

### DIFF
--- a/hydroflow/src/lang/clear.rs
+++ b/hydroflow/src/lang/clear.rs
@@ -46,10 +46,8 @@ macro_rules! clear_impl {
 clear_impl!(BTreeMap<K, V>);
 clear_impl!(BTreeSet<T>);
 clear_impl!(BinaryHeap<T>);
-clear_impl!(HashMap<K, V>);
-clear_impl!(FxHashMap<K, V>);
-clear_impl!(HashSet<T>);
-clear_impl!(FxHashSet<T>);
+clear_impl!(HashMap<K, V, S>);
+clear_impl!(HashSet<T, S>);
 clear_impl!(LinkedList<T>);
 clear_impl!(OsString);
 clear_impl!(String);

--- a/hydroflow/src/lang/clear.rs
+++ b/hydroflow/src/lang/clear.rs
@@ -1,3 +1,4 @@
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
 use std::ffi::OsString;
 
@@ -46,7 +47,9 @@ clear_impl!(BTreeMap<K, V>);
 clear_impl!(BTreeSet<T>);
 clear_impl!(BinaryHeap<T>);
 clear_impl!(HashMap<K, V>);
+clear_impl!(FxHashMap<K, V>);
 clear_impl!(HashSet<T>);
+clear_impl!(FxHashSet<T>);
 clear_impl!(LinkedList<T>);
 clear_impl!(OsString);
 clear_impl!(String);

--- a/hydroflow/src/lang/clear.rs
+++ b/hydroflow/src/lang/clear.rs
@@ -1,4 +1,3 @@
-use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
 use std::ffi::OsString;
 

--- a/hydroflow/src/lang/monotonic_map.rs
+++ b/hydroflow/src/lang/monotonic_map.rs
@@ -1,3 +1,5 @@
+use super::clear::Clear;
+
 /// A map-like interface which in reality only stores one value at a time. The keys must be
 /// monotonically increasing (i.e. timestamps). For Hydroflow, this allows state to be stored which
 /// resets each tick by using the tick counter as the key. In the generic `Map` case it can be
@@ -6,6 +8,7 @@
 pub struct MonotonicMap<K, V>
 where
     K: PartialOrd,
+    V: Clear,
 {
     key: Option<K>,
     val: V,
@@ -14,7 +17,7 @@ where
 impl<K, V> Default for MonotonicMap<K, V>
 where
     K: PartialOrd,
-    V: Default,
+    V: Clear + Default,
 {
     fn default() -> Self {
         Self {
@@ -27,6 +30,7 @@ where
 impl<K, V> MonotonicMap<K, V>
 where
     K: PartialOrd,
+    V: Clear,
 {
     /// Creates a new `MonotonicMap` initialized with the given value. The
     /// vaue will be `Clear`ed before it is accessed.

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__aggregations_and_comments@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__aggregations_and_comments@datalog_program.snap
@@ -59,7 +59,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -109,7 +109,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -207,7 +207,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -318,7 +318,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -367,7 +367,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -437,7 +437,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__anti_join@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__anti_join@datalog_program.snap
@@ -44,7 +44,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -84,7 +84,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -235,7 +235,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -244,7 +244,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -282,7 +282,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -310,7 +310,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -336,7 +336,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -527,7 +527,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__expr_lhs@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__expr_lhs@datalog_program.snap
@@ -54,7 +54,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -115,7 +115,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -174,7 +174,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -293,7 +293,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__expr_predicate@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__expr_predicate@datalog_program.snap
@@ -49,7 +49,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -101,7 +101,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -218,7 +218,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -316,7 +316,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__join_with_other@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__join_with_other@datalog_program.snap
@@ -29,7 +29,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -52,7 +52,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -81,7 +81,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -118,7 +118,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -163,7 +163,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -291,7 +291,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__join_with_self@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__join_with_self@datalog_program.snap
@@ -39,7 +39,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -81,7 +81,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -151,7 +151,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -274,7 +274,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__local_constraints@datalog_program-2.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__local_constraints@datalog_program-2.snap
@@ -29,7 +29,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -38,7 +38,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -74,7 +74,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -128,7 +128,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__local_constraints@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__local_constraints@datalog_program.snap
@@ -29,7 +29,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -38,7 +38,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -74,7 +74,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -121,7 +121,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__max@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__max@datalog_program.snap
@@ -34,7 +34,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -73,7 +73,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -117,7 +117,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -187,7 +187,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__max_all@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__max_all@datalog_program.snap
@@ -34,7 +34,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -73,7 +73,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -117,7 +117,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -193,7 +193,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__minimal_program@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__minimal_program@datalog_program.snap
@@ -29,7 +29,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -38,7 +38,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -74,7 +74,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -110,7 +110,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__multiple_contributors@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__multiple_contributors@datalog_program.snap
@@ -29,7 +29,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -52,7 +52,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -61,7 +61,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -98,7 +98,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -143,7 +143,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -212,7 +212,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__non_copy_but_clone@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__non_copy_but_clone@datalog_program.snap
@@ -29,7 +29,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -38,7 +38,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -74,7 +74,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -110,7 +110,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist@datalog_program.snap
@@ -49,7 +49,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -92,7 +92,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -156,7 +156,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -193,7 +193,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -234,7 +234,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -448,7 +448,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -512,7 +512,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -521,7 +521,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -566,7 +566,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -608,7 +608,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -705,7 +705,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -723,7 +723,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -760,7 +760,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -860,7 +860,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist_uniqueness@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist_uniqueness@datalog_program.snap
@@ -34,7 +34,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -43,7 +43,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -54,7 +54,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -94,7 +94,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -131,7 +131,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -172,7 +172,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -219,7 +219,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -289,7 +289,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__send_to_node@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__send_to_node@datalog_program.snap
@@ -29,7 +29,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -38,7 +38,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -75,7 +75,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -102,7 +102,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -165,7 +165,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -174,7 +174,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -210,7 +210,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -258,7 +258,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__simple_filter@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__simple_filter@datalog_program.snap
@@ -29,7 +29,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -38,7 +38,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -74,7 +74,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -122,7 +122,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__single_column_program@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__single_column_program@datalog_program.snap
@@ -29,7 +29,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -52,7 +52,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -81,7 +81,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -118,7 +118,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -163,7 +163,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -291,7 +291,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__transitive_closure@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__transitive_closure@datalog_program.snap
@@ -34,7 +34,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -57,7 +57,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -86,7 +86,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -128,7 +128,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -173,7 +173,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -333,7 +333,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__triple_relation_join@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__triple_relation_join@datalog_program.snap
@@ -29,7 +29,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -52,7 +52,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -75,7 +75,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -124,7 +124,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -161,7 +161,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -206,7 +206,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -251,7 +251,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -478,7 +478,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__wildcard_fields@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__wildcard_fields@datalog_program.snap
@@ -39,7 +39,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -81,7 +81,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));
@@ -151,7 +151,7 @@ fn main() {
                 ::std::cell::RefCell::new(
                     hydroflow::lang::monotonic_map::MonotonicMap::<
                         _,
-                        ::std::collections::HashSet<_>,
+                        hydroflow::rustc_hash::FxHashSet<_>,
                     >::default(),
                 ),
             );
@@ -274,7 +274,7 @@ fn main() {
                         let set = borrow
                             .try_insert_with(
                                 (context.current_tick(), context.current_stratum()),
-                                ::std::collections::HashSet::new,
+                                hydroflow::rustc_hash::FxHashSet::default,
                             );
                         if !set.contains(item) {
                             set.insert(::std::clone::Clone::clone(item));

--- a/hydroflow_lang/src/graph/ops/unique.rs
+++ b/hydroflow_lang/src/graph/ops/unique.rs
@@ -98,18 +98,18 @@ pub const UNIQUE: OperatorConstraints = OperatorConstraints {
             Persistence::Tick => {
                 let write_prologue = quote_spanned! {op_span=>
                     let #uniquedata_ident = #hydroflow.add_state(::std::cell::RefCell::new(
-                        #root::lang::monotonic_map::MonotonicMap::<_, ::std::collections::HashSet<_>>::default(),
+                        #root::lang::monotonic_map::MonotonicMap::<_, #root::rustc_hash::FxHashSet<_>>::default(),
                     ));
                 };
                 let get_set = quote_spanned! {op_span=>
                     let mut borrow = #context.state_ref(#uniquedata_ident).borrow_mut();
-                    let set = borrow.try_insert_with((#context.current_tick(), #context.current_stratum()), ::std::collections::HashSet::new);
+                    let set = borrow.try_insert_with((#context.current_tick(), #context.current_stratum()), #root::rustc_hash::FxHashSet::default);
                 };
                 (write_prologue, get_set)
             }
             Persistence::Static => {
                 let write_prologue = quote_spanned! {op_span=>
-                    let #uniquedata_ident = #hydroflow.add_state(::std::cell::RefCell::new(::std::collections::HashSet::new()));
+                    let #uniquedata_ident = #hydroflow.add_state(::std::cell::RefCell::new(#root::rustc_hash::FxHashSet::default()));
                 };
                 let get_set = quote_spanned! {op_span=>
                     let mut set = #context.state_ref(#uniquedata_ident).borrow_mut();


### PR DESCRIPTION
micro/ops/unique        time:   [84.333 µs 84.933 µs 85.651 µs]
                        change: [-68.397% -68.069% -67.798%] (p = 0.00 < 0.05)
                        Performance has improved.