### PR TITLE
Be more careful about the semantics of `count` and wildcard columns

### DIFF
--- a/hydro_cli_examples/examples/dedalus_vote_leader/main.rs
+++ b/hydro_cli_examples/examples/dedalus_vote_leader/main.rs
@@ -36,8 +36,8 @@ async fn main() {
         voteToReplica@addr(v) :~ clientIn(v), replicas(addr)
         allVotes(s, v) :- voteFromReplica(s, v)
         allVotes(s, v) :+ allVotes(s, v)
-        voteCounts(count(l), v) :- allVotes(l, v)
-        numReplicas(count(addr)) :- replicas(addr)
+        voteCounts(count(*), v) :- allVotes(l, v)
+        numReplicas(count(*)) :- replicas(addr)
         stdout(v) :- clientIn(v), voteCounts(n, v), numReplicas(n)
     "#
     );

--- a/hydroflow_datalog_core/src/grammar.rs
+++ b/hydroflow_datalog_core/src/grammar.rs
@@ -137,28 +137,44 @@ pub mod datalog {
         pub fn idents(&self) -> Vec<&Ident> {
             match self {
                 TargetExpr::Expr(e) => e.idents(),
-                TargetExpr::Aggregation(a) => vec![&a.ident],
+                TargetExpr::Aggregation(Aggregation::Count(_)) => vec![],
+                TargetExpr::Aggregation(
+                    Aggregation::Min(_, _, a, _)
+                    | Aggregation::Max(_, _, a, _)
+                    | Aggregation::Sum(_, _, a, _)
+                    | Aggregation::Choose(_, _, a, _),
+                ) => vec![a],
             }
         }
     }
 
     #[derive(Debug, Clone)]
-    pub struct Aggregation {
-        pub tpe: AggregationType,
-        #[rust_sitter::leaf(text = "(")]
-        _lparen: (),
-        pub ident: Spanned<Ident>,
-        #[rust_sitter::leaf(text = ")")]
-        _rparen: (),
-    }
-
-    #[derive(Debug, Clone)]
-    pub enum AggregationType {
-        Min(#[rust_sitter::leaf(text = "min")] ()),
-        Max(#[rust_sitter::leaf(text = "max")] ()),
-        Sum(#[rust_sitter::leaf(text = "sum")] ()),
-        Count(#[rust_sitter::leaf(text = "count")] ()),
-        Choose(#[rust_sitter::leaf(text = "choose")] ()),
+    pub enum Aggregation {
+        Min(
+            #[rust_sitter::leaf(text = "min")] (),
+            #[rust_sitter::leaf(text = "(")] (),
+            Spanned<Ident>,
+            #[rust_sitter::leaf(text = ")")] (),
+        ),
+        Max(
+            #[rust_sitter::leaf(text = "max")] (),
+            #[rust_sitter::leaf(text = "(")] (),
+            Spanned<Ident>,
+            #[rust_sitter::leaf(text = ")")] (),
+        ),
+        Sum(
+            #[rust_sitter::leaf(text = "sum")] (),
+            #[rust_sitter::leaf(text = "(")] (),
+            Spanned<Ident>,
+            #[rust_sitter::leaf(text = ")")] (),
+        ),
+        Count(#[rust_sitter::leaf(text = "count(*)")] ()),
+        Choose(
+            #[rust_sitter::leaf(text = "choose")] (),
+            #[rust_sitter::leaf(text = "(")] (),
+            Spanned<Ident>,
+            #[rust_sitter::leaf(text = ")")] (),
+        ),
     }
 
     #[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Debug)]

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__wildcard_fields@datalog_program.snap.new
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__wildcard_fields@datalog_program.snap.new
@@ -1,0 +1,326 @@
+---
+source: hydroflow_datalog_core/src/lib.rs
+assertion_line: 731
+expression: "prettyplease::unparse(&wrapped)"
+---
+fn main() {
+    {
+        use hydroflow::{var_expr, var_args};
+        let mut df = hydroflow::scheduled::graph::Hydroflow::new();
+        df.__assign_meta_graph(
+            "{\"nodes\":[{\"value\":null,\"version\":0},{\"value\":null,\"version\":2},{\"value\":{\"Operator\":\"unique :: < 'tick > ()\"},\"version\":1},{\"value\":{\"Operator\":\"tee ()\"},\"version\":1},{\"value\":{\"Handoff\":{}},\"version\":3},{\"value\":{\"Operator\":\"unique :: < 'tick > ()\"},\"version\":1},{\"value\":{\"Handoff\":{}},\"version\":3},{\"value\":{\"Operator\":\"source_stream (input)\"},\"version\":1},{\"value\":{\"Operator\":\"for_each (| v | out . send (v) . unwrap ())\"},\"version\":1},{\"value\":{\"Operator\":\"join :: < 'tick , 'tick > ()\"},\"version\":1},{\"value\":{\"Operator\":\"map (| kv : ((_ ,) , ((_ ,) , (_ ,))) | (kv . 0 . 0 , kv . 1 . 0 . 0 , kv . 1 . 1 . 0 ,))\"},\"version\":1},{\"value\":{\"Operator\":\"map (| _v : (_ , _ ,) | ((_v . 0 ,) , (_v . 1 ,)))\"},\"version\":1},{\"value\":{\"Operator\":\"map (| _v : (_ , _ ,) | ((_v . 1 ,) , (_v . 0 ,)))\"},\"version\":1},{\"value\":{\"Operator\":\"map (| row : (_ , _ , _ ,) | (row . 0 ,))\"},\"version\":1}],\"graph\":[{\"value\":null,\"version\":0},{\"value\":[{\"idx\":2,\"version\":1},{\"idx\":3,\"version\":1}],\"version\":1},{\"value\":[{\"idx\":7,\"version\":1},{\"idx\":2,\"version\":1}],\"version\":3},{\"value\":[{\"idx\":6,\"version\":3},{\"idx\":11,\"version\":1}],\"version\":3},{\"value\":[{\"idx\":13,\"version\":1},{\"idx\":5,\"version\":1}],\"version\":3},{\"value\":null,\"version\":2},{\"value\":[{\"idx\":5,\"version\":1},{\"idx\":8,\"version\":1}],\"version\":3},{\"value\":[{\"idx\":9,\"version\":1},{\"idx\":10,\"version\":1}],\"version\":1},{\"value\":[{\"idx\":11,\"version\":1},{\"idx\":9,\"version\":1}],\"version\":1},{\"value\":[{\"idx\":3,\"version\":1},{\"idx\":6,\"version\":3}],\"version\":3},{\"value\":[{\"idx\":12,\"version\":1},{\"idx\":9,\"version\":1}],\"version\":1},{\"value\":[{\"idx\":3,\"version\":1},{\"idx\":4,\"version\":3}],\"version\":3},{\"value\":[{\"idx\":4,\"version\":3},{\"idx\":12,\"version\":1}],\"version\":3},{\"value\":[{\"idx\":10,\"version\":1},{\"idx\":13,\"version\":1}],\"version\":1}],\"ports\":[{\"value\":null,\"version\":0},{\"value\":[\"Elided\",\"Elided\"],\"version\":1},{\"value\":[\"Elided\",\"Elided\"],\"version\":3},{\"value\":[\"Elided\",\"Elided\"],\"version\":3},{\"value\":[\"Elided\",\"Elided\"],\"version\":3},{\"value\":null,\"version\":0},{\"value\":[\"Elided\",\"Elided\"],\"version\":3},{\"value\":[\"Elided\",\"Elided\"],\"version\":1},{\"value\":[\"Elided\",{\"Int\":\"0\"}],\"version\":1},{\"value\":[{\"Int\":\"0\"},\"Elided\"],\"version\":3},{\"value\":[\"Elided\",{\"Int\":\"1\"}],\"version\":1},{\"value\":[{\"Int\":\"1\"},\"Elided\"],\"version\":3},{\"value\":[\"Elided\",\"Elided\"],\"version\":3},{\"value\":[\"Elided\",\"Elided\"],\"version\":1}],\"node_subgraph\":[{\"value\":null,\"version\":0},{\"value\":null,\"version\":0},{\"value\":{\"idx\":1,\"version\":1},\"version\":1},{\"value\":{\"idx\":1,\"version\":1},\"version\":1},{\"value\":null,\"version\":0},{\"value\":{\"idx\":2,\"version\":1},\"version\":1},{\"value\":null,\"version\":0},{\"value\":{\"idx\":1,\"version\":1},\"version\":1},{\"value\":{\"idx\":2,\"version\":1},\"version\":1},{\"value\":{\"idx\":2,\"version\":1},\"version\":1},{\"value\":{\"idx\":2,\"version\":1},\"version\":1},{\"value\":{\"idx\":2,\"version\":1},\"version\":1},{\"value\":{\"idx\":2,\"version\":1},\"version\":1},{\"value\":{\"idx\":2,\"version\":1},\"version\":1}],\"subgraph_nodes\":[{\"value\":null,\"version\":0},{\"value\":[{\"idx\":7,\"version\":1},{\"idx\":2,\"version\":1},{\"idx\":3,\"version\":1}],\"version\":1},{\"value\":[{\"idx\":11,\"version\":1},{\"idx\":12,\"version\":1},{\"idx\":9,\"version\":1},{\"idx\":10,\"version\":1},{\"idx\":13,\"version\":1},{\"idx\":5,\"version\":1},{\"idx\":8,\"version\":1}],\"version\":1}],\"subgraph_stratum\":[{\"value\":null,\"version\":0},{\"value\":0,\"version\":1},{\"value\":0,\"version\":1}],\"node_varnames\":[{\"value\":null,\"version\":0},{\"value\":null,\"version\":0},{\"value\":\"input\",\"version\":1},{\"value\":\"input\",\"version\":1},{\"value\":null,\"version\":0},{\"value\":\"out\",\"version\":1},{\"value\":null,\"version\":0},{\"value\":null,\"version\":0},{\"value\":null,\"version\":0},{\"value\":\"join_0\",\"version\":1},{\"value\":\"join_0\",\"version\":1}]}",
+        );
+        df.__assign_diagnostics("[]");
+        let (hoff_4v3_send, hoff_4v3_recv) = df
+            .make_edge::<
+                _,
+                hydroflow::scheduled::handoff::VecHandoff<_>,
+            >("handoff GraphNodeId(4v3)");
+        let (hoff_6v3_send, hoff_6v3_recv) = df
+            .make_edge::<
+                _,
+                hydroflow::scheduled::handoff::VecHandoff<_>,
+            >("handoff GraphNodeId(6v3)");
+        let mut sg_1v1_node_7v1_stream = {
+            #[inline(always)]
+            fn check_stream<
+                Stream: hydroflow::futures::stream::Stream<Item = Item>,
+                Item,
+            >(
+                stream: Stream,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<impl hydroflow::futures::stream::Stream<Item = Item>>,
+            > {
+                ::std::boxed::Box::pin(stream)
+            }
+            check_stream(input)
+        };
+        let sg_1v1_node_2v1_uniquedata = df
+            .add_state(
+                ::std::cell::RefCell::new(
+                    hydroflow::lang::monotonic_map::MonotonicMap::<
+                        _,
+                        ::std::collections::HashSet<_>,
+                    >::default(),
+                ),
+            );
+        df.add_subgraph_stratified(
+            "Subgraph GraphSubgraphId(1v1)",
+            0,
+            var_expr!(),
+            var_expr!(hoff_4v3_send, hoff_6v3_send),
+            move |context, var_args!(), var_args!(hoff_4v3_send, hoff_6v3_send)| {
+                let hoff_4v3_send = hydroflow::pusherator::for_each::ForEach::new(|v| {
+                    hoff_4v3_send.give(Some(v));
+                });
+                let hoff_6v3_send = hydroflow::pusherator::for_each::ForEach::new(|v| {
+                    hoff_6v3_send.give(Some(v));
+                });
+                let op_7v1 = std::iter::from_fn(|| {
+                    match hydroflow::futures::stream::Stream::poll_next(
+                        sg_1v1_node_7v1_stream.as_mut(),
+                        &mut std::task::Context::from_waker(&context.waker()),
+                    ) {
+                        std::task::Poll::Ready(maybe) => maybe,
+                        std::task::Poll::Pending => None,
+                    }
+                });
+                let op_7v1 = {
+                    #[inline(always)]
+                    pub fn check_op_7v1<Input: ::std::iter::Iterator<Item = Item>, Item>(
+                        input: Input,
+                    ) -> impl ::std::iter::Iterator<Item = Item> {
+                        input
+                    }
+                    check_op_7v1(op_7v1)
+                };
+                let op_2v1 = op_7v1
+                    .filter(|item| {
+                        let mut borrow = context
+                            .state_ref(sg_1v1_node_2v1_uniquedata)
+                            .borrow_mut();
+                        let set = borrow
+                            .try_insert_with(
+                                (context.current_tick(), context.current_stratum()),
+                                ::std::collections::HashSet::new,
+                            );
+                        if !set.contains(item) {
+                            set.insert(::std::clone::Clone::clone(item));
+                            true
+                        } else {
+                            false
+                        }
+                    });
+                let op_2v1 = {
+                    #[inline(always)]
+                    pub fn check_op_2v1<Input: ::std::iter::Iterator<Item = Item>, Item>(
+                        input: Input,
+                    ) -> impl ::std::iter::Iterator<Item = Item> {
+                        input
+                    }
+                    check_op_2v1(op_2v1)
+                };
+                let op_3v1 = hydroflow::pusherator::tee::Tee::new(
+                    hoff_6v3_send,
+                    hoff_4v3_send,
+                );
+                let op_3v1 = {
+                    #[inline(always)]
+                    pub fn check_op_3v1<
+                        Input: hydroflow::pusherator::Pusherator<Item = Item>,
+                        Item,
+                    >(
+                        input: Input,
+                    ) -> impl hydroflow::pusherator::Pusherator<Item = Item> {
+                        input
+                    }
+                    check_op_3v1(op_3v1)
+                };
+                #[inline(always)]
+                fn check_pivot_run<
+                    Pull: ::std::iter::Iterator<Item = Item>,
+                    Push: hydroflow::pusherator::Pusherator<Item = Item>,
+                    Item,
+                >(pull: Pull, push: Push) {
+                    hydroflow::pusherator::pivot::Pivot::new(pull, push).run();
+                }
+                check_pivot_run(op_2v1, op_3v1);
+            },
+        );
+        let sg_2v1_node_9v1_joindata_lhs = df
+            .add_state(
+                std::cell::RefCell::new(
+                    hydroflow::lang::monotonic_map::MonotonicMap::new_init(
+                        hydroflow::lang::clear::ClearDefault(
+                            hydroflow::compiled::pull::HalfJoinState::default(),
+                        ),
+                    ),
+                ),
+            );
+        let sg_2v1_node_9v1_joindata_rhs = df
+            .add_state(
+                std::cell::RefCell::new(
+                    hydroflow::lang::monotonic_map::MonotonicMap::new_init(
+                        hydroflow::lang::clear::ClearDefault(
+                            hydroflow::compiled::pull::HalfJoinState::default(),
+                        ),
+                    ),
+                ),
+            );
+        let sg_2v1_node_5v1_uniquedata = df
+            .add_state(
+                ::std::cell::RefCell::new(
+                    hydroflow::lang::monotonic_map::MonotonicMap::<
+                        _,
+                        ::std::collections::HashSet<_>,
+                    >::default(),
+                ),
+            );
+        df.add_subgraph_stratified(
+            "Subgraph GraphSubgraphId(2v1)",
+            0,
+            var_expr!(hoff_4v3_recv, hoff_6v3_recv),
+            var_expr!(),
+            move |context, var_args!(hoff_4v3_recv, hoff_6v3_recv), var_args!()| {
+                let mut hoff_4v3_recv = hoff_4v3_recv.borrow_mut_swap();
+                let hoff_4v3_recv = hoff_4v3_recv.drain(..);
+                let mut hoff_6v3_recv = hoff_6v3_recv.borrow_mut_swap();
+                let hoff_6v3_recv = hoff_6v3_recv.drain(..);
+                let op_11v1 = hoff_6v3_recv.map(|_v: (_, _)| ((_v.0,), (_v.1,)));
+                let op_11v1 = {
+                    #[inline(always)]
+                    pub fn check_op_11v1<
+                        Input: ::std::iter::Iterator<Item = Item>,
+                        Item,
+                    >(input: Input) -> impl ::std::iter::Iterator<Item = Item> {
+                        input
+                    }
+                    check_op_11v1(op_11v1)
+                };
+                let op_12v1 = hoff_4v3_recv.map(|_v: (_, _)| ((_v.1,), (_v.0,)));
+                let op_12v1 = {
+                    #[inline(always)]
+                    pub fn check_op_12v1<
+                        Input: ::std::iter::Iterator<Item = Item>,
+                        Item,
+                    >(input: Input) -> impl ::std::iter::Iterator<Item = Item> {
+                        input
+                    }
+                    check_op_12v1(op_12v1)
+                };
+                let mut sg_2v1_node_9v1_joindata_lhs_borrow = context
+                    .state_ref(sg_2v1_node_9v1_joindata_lhs)
+                    .borrow_mut();
+                let mut sg_2v1_node_9v1_joindata_rhs_borrow = context
+                    .state_ref(sg_2v1_node_9v1_joindata_rhs)
+                    .borrow_mut();
+                let op_9v1 = {
+                    /// Limit error propagation by bounding locally, erasing output iterator type.
+                    #[inline(always)]
+                    fn check_inputs<'a, K, I1, V1, I2, V2>(
+                        lhs: I1,
+                        rhs: I2,
+                        lhs_state: &'a mut hydroflow::compiled::pull::HalfJoinState<
+                            K,
+                            V1,
+                            V2,
+                        >,
+                        rhs_state: &'a mut hydroflow::compiled::pull::HalfJoinState<
+                            K,
+                            V2,
+                            V1,
+                        >,
+                    ) -> impl 'a + Iterator<Item = (K, (V1, V2))>
+                    where
+                        K: Eq + std::hash::Hash + Clone,
+                        V1: Eq + Clone,
+                        V2: Eq + Clone,
+                        I1: 'a + Iterator<Item = (K, V1)>,
+                        I2: 'a + Iterator<Item = (K, V2)>,
+                    {
+                        hydroflow::compiled::pull::SymmetricHashJoin::new_from_mut(
+                            lhs,
+                            rhs,
+                            lhs_state,
+                            rhs_state,
+                        )
+                    }
+                    check_inputs(
+                        op_11v1,
+                        op_12v1,
+                        &mut sg_2v1_node_9v1_joindata_lhs_borrow
+                            .try_insert_with(context.current_tick(), Default::default)
+                            .0,
+                        &mut sg_2v1_node_9v1_joindata_rhs_borrow
+                            .try_insert_with(context.current_tick(), Default::default)
+                            .0,
+                    )
+                };
+                let op_9v1 = {
+                    #[inline(always)]
+                    pub fn check_op_9v1<Input: ::std::iter::Iterator<Item = Item>, Item>(
+                        input: Input,
+                    ) -> impl ::std::iter::Iterator<Item = Item> {
+                        input
+                    }
+                    check_op_9v1(op_9v1)
+                };
+                let op_10v1 = op_9v1
+                    .map(|kv: ((_,), ((_,), (_,)))| (kv.0.0, kv.1.0.0, kv.1.1.0));
+                let op_10v1 = {
+                    #[inline(always)]
+                    pub fn check_op_10v1<
+                        Input: ::std::iter::Iterator<Item = Item>,
+                        Item,
+                    >(input: Input) -> impl ::std::iter::Iterator<Item = Item> {
+                        input
+                    }
+                    check_op_10v1(op_10v1)
+                };
+                let op_13v1 = op_10v1.map(|row: (_, _, _)| (row.0,));
+                let op_13v1 = {
+                    #[inline(always)]
+                    pub fn check_op_13v1<
+                        Input: ::std::iter::Iterator<Item = Item>,
+                        Item,
+                    >(input: Input) -> impl ::std::iter::Iterator<Item = Item> {
+                        input
+                    }
+                    check_op_13v1(op_13v1)
+                };
+                let op_5v1 = op_13v1
+                    .filter(|item| {
+                        let mut borrow = context
+                            .state_ref(sg_2v1_node_5v1_uniquedata)
+                            .borrow_mut();
+                        let set = borrow
+                            .try_insert_with(
+                                (context.current_tick(), context.current_stratum()),
+                                ::std::collections::HashSet::new,
+                            );
+                        if !set.contains(item) {
+                            set.insert(::std::clone::Clone::clone(item));
+                            true
+                        } else {
+                            false
+                        }
+                    });
+                let op_5v1 = {
+                    #[inline(always)]
+                    pub fn check_op_5v1<Input: ::std::iter::Iterator<Item = Item>, Item>(
+                        input: Input,
+                    ) -> impl ::std::iter::Iterator<Item = Item> {
+                        input
+                    }
+                    check_op_5v1(op_5v1)
+                };
+                let op_8v1 = hydroflow::pusherator::for_each::ForEach::new(|v| {
+                    out.send(v).unwrap()
+                });
+                let op_8v1 = {
+                    #[inline(always)]
+                    pub fn check_op_8v1<
+                        Input: hydroflow::pusherator::Pusherator<Item = Item>,
+                        Item,
+                    >(
+                        input: Input,
+                    ) -> impl hydroflow::pusherator::Pusherator<Item = Item> {
+                        input
+                    }
+                    check_op_8v1(op_8v1)
+                };
+                #[inline(always)]
+                fn check_pivot_run<
+                    Pull: ::std::iter::Iterator<Item = Item>,
+                    Push: hydroflow::pusherator::Pusherator<Item = Item>,
+                    Item,
+                >(pull: Pull, push: Push) {
+                    hydroflow::pusherator::pivot::Pivot::new(pull, push).run();
+                }
+                check_pivot_run(op_5v1, op_8v1);
+            },
+        );
+        df
+    }
+}
+

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__wildcard_fields@surface_graph.snap.new
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__wildcard_fields@surface_graph.snap.new
@@ -1,0 +1,27 @@
+---
+source: hydroflow_datalog_core/src/lib.rs
+assertion_line: 731
+expression: flat_graph_ref.surface_syntax_string()
+---
+2v1 = unique :: < 'tick > ();
+3v1 = tee ();
+5v1 = unique :: < 'tick > ();
+7v1 = source_stream (input);
+8v1 = for_each (| v | out . send (v) . unwrap ());
+9v1 = join :: < 'tick , 'tick > ();
+10v1 = map (| kv : ((_ ,) , ((_ ,) , (_ ,))) | (kv . 0 . 0 , kv . 1 . 0 . 0 , kv . 1 . 1 . 0 ,));
+11v1 = map (| _v : (_ , _ ,) | ((_v . 0 ,) , (_v . 1 ,)));
+12v1 = map (| _v : (_ , _ ,) | ((_v . 1 ,) , (_v . 0 ,)));
+13v1 = map (| row : (_ , _ , _ ,) | (row . 0 ,));
+
+2v1 -> 3v1;
+7v1 -> 2v1;
+13v1 -> 5v1;
+5v1 -> 8v1;
+9v1 -> 10v1;
+11v1 -> 9v1;
+3v1 -> 11v1;
+12v1 -> 9v1;
+3v1 -> 12v1;
+10v1 -> 13v1;
+


### PR DESCRIPTION
Be more careful about the semantics of `count` and wildcard columns
Previously, rows that only differed on wildcards would not be counted correctly (they would be deduplicated in join because join currently uses set semantics). This also changes the syntax for `count` to clarify that we are not counting the unique number of anything, but instead are counting how many rows are in the group.
