### PR TITLE
Fix hang in Hydro CLI tests due to change in `repeat_iter` semantics

### DIFF
--- a/hydro_cli_examples/examples/dedalus_sender/main.rs
+++ b/hydro_cli_examples/examples/dedalus_sender/main.rs
@@ -28,7 +28,7 @@ async fn main() {
 
     let df = datalog!(
         r#"
-        .input repeated `repeat_iter(to_repeat.iter().cloned())`
+        .input repeated `repeat_iter_external(to_repeat.iter().cloned())`
         .input periodic `source_stream(periodic) -> map(|_| ())`
         .input peers `repeat_iter(peers.clone()) -> map(|p| (p,))`
         .async broadcast `map(|(node_id, v)| (node_id, serialize_to_bytes(v))) -> dest_sink(broadcast_sink)` `null::<(String,)>()`


### PR DESCRIPTION
Fix hang in Hydro CLI tests due to change in `repeat_iter` semantics

Fixes #580
