### PR TITLE
set lto = fat in release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ strip = true      # Strip symbols from the binary
 # doesn't make things that much smaller, `strip` is far more important for binary size. Use "3" for
 # performance.
 opt-level = 3
+lto = "fat"
 
 [profile.profile]
 inherits = "release"


### PR DESCRIPTION
This caused a 25% perf improvement in the paxos benchmark, but it seems to cause some slowdowns in the micro benchmarks. I think that the more complex a benchmark gets, the more likely it is to benefit from this. So, I think those slowdowns are more a reflection of a bad benchmark than this change causing slowdowns in general.

Additionally, this change seems to remove the performance penalty for introducing the additional function calls to tag operators for better profiles.

This change will slow down build times a little bit.