### PR TITLE
add smallvec for multiset join

### DIFF
--- a/hydroflow/Cargo.toml
+++ b/hydroflow/Cargo.toml
@@ -36,6 +36,7 @@ async-trait = { version = "0.1", optional = true }
 crdts = "7.2.0"
 rand_distr = "0.4.3"
 serde-big-array = "0.5.0"
+smallvec = "1.10.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.16", features = [ "full" ] }

--- a/hydroflow/src/compiled/pull/half_join_state/multiset.rs
+++ b/hydroflow/src/compiled/pull/half_join_state/multiset.rs
@@ -5,9 +5,7 @@ use std::collections::{hash_map::Entry, VecDeque};
 
 type HashMap<K, V> = rustc_hash::FxHashMap<K, V>;
 
-use smallvec::smallvec;
-use smallvec::SmallVec;
-
+use smallvec::{smallvec, SmallVec};
 #[derive(Debug)]
 pub struct HalfMultisetJoinState<Key, ValBuild, ValProbe> {
     // Here a smallvec with inline storage of 1 is chosen.

--- a/hydroflow/src/compiled/pull/half_join_state/multiset.rs
+++ b/hydroflow/src/compiled/pull/half_join_state/multiset.rs
@@ -5,10 +5,18 @@ use std::collections::{hash_map::Entry, VecDeque};
 
 type HashMap<K, V> = rustc_hash::FxHashMap<K, V>;
 
+use smallvec::smallvec;
+use smallvec::SmallVec;
+
 #[derive(Debug)]
 pub struct HalfMultisetJoinState<Key, ValBuild, ValProbe> {
+    // Here a smallvec with inline storage of 1 is chosen.
+    // The rationale for this decision is that, I speculate, that joins possibly have a bimodal distribution with regards to how much key contention they have.
+    // That is, I think that there are many joins that have 1 value per key on LHS/RHS, and there are also a large category of joins that have multiple values per key.
+    // For the category of joins that have multiple values per key, it's not clear why they would only have 2, 3, 4, or N specific number of values per key. So there's no good number to set the smallvec storage to.
+    // Instead we can just focus on the first group of joins that have 1 value per key and get benefit there without hurting the other group too much with excessive memory usage.
     /// Table to probe, vec val contains all matches.
-    table: HashMap<Key, Vec<ValBuild>>,
+    table: HashMap<Key, SmallVec<[ValBuild; 1]>>,
     /// Not-yet emitted matches.
     current_matches: VecDeque<(Key, ValProbe, ValBuild)>,
 }
@@ -43,7 +51,7 @@ where
                 vec.push(v.clone());
             }
             Entry::Vacant(e) => {
-                e.insert(vec![v.clone()]);
+                e.insert(smallvec![v.clone()]);
             }
         };
 

--- a/hydroflow/src/compiled/pull/half_join_state/set.rs
+++ b/hydroflow/src/compiled/pull/half_join_state/set.rs
@@ -5,10 +5,18 @@ use std::collections::{hash_map::Entry, VecDeque};
 
 type HashMap<K, V> = rustc_hash::FxHashMap<K, V>;
 
+use smallvec::smallvec;
+use smallvec::SmallVec;
+
 #[derive(Debug)]
 pub struct HalfSetJoinState<Key, ValBuild, ValProbe> {
+    // Here a smallvec with inline storage of 1 is chosen.
+    // The rationale for this decision is that, I speculate, that joins possibly have a bimodal distribution with regards to how much key contention they have.
+    // That is, I think that there are many joins that have 1 value per key on LHS/RHS, and there are also a large category of joins that have multiple values per key.
+    // For the category of joins that have multiple values per key, it's not clear why they would only have 2, 3, 4, or N specific number of values per key. So there's no good number to set the smallvec storage to.
+    // Instead we can just focus on the first group of joins that have 1 value per key and get benefit there without hurting the other group too much with excessive memory usage.
     /// Table to probe, vec val contains all matches.
-    table: HashMap<Key, Vec<ValBuild>>,
+    table: HashMap<Key, SmallVec<[ValBuild; 1]>>,
     /// Not-yet emitted matches.
     current_matches: VecDeque<(Key, ValProbe, ValBuild)>,
 }
@@ -46,7 +54,7 @@ where
                 }
             }
             Entry::Vacant(e) => {
-                e.insert(vec![v.clone()]);
+                e.insert(smallvec![v.clone()]);
                 return true;
             }
         };

--- a/hydroflow/src/compiled/pull/half_join_state/set.rs
+++ b/hydroflow/src/compiled/pull/half_join_state/set.rs
@@ -5,8 +5,7 @@ use std::collections::{hash_map::Entry, VecDeque};
 
 type HashMap<K, V> = rustc_hash::FxHashMap<K, V>;
 
-use smallvec::smallvec;
-use smallvec::SmallVec;
+use smallvec::{smallvec, SmallVec};
 
 #[derive(Debug)]
 pub struct HalfSetJoinState<Key, ValBuild, ValProbe> {


### PR DESCRIPTION
joins are a nested structure, they are hash maps with vecs in them. We already re-added Clear impls everywhere to avoid freeing the hash table memory, but when clear() is called it still deletes all the values in the hash map, which causes the vecs to drop and free their memory. If we use a smallvec instead then, at least for the paxos case, most of the allocations never happen and also none of the subsequent frees happen either. This results in a pretty decent speedup for the paxos test.