### PR TITLE
add Hello World hydroflow example

### DIFF
--- a/hydroflow/examples/hello_world/README.md
+++ b/hydroflow/examples/hello_world/README.md
@@ -1,0 +1,6 @@
+# Hello World
+
+To run:
+```
+cargo run -p hydroflow --example hello_world
+```

--- a/hydroflow/examples/hello_world/main.rs
+++ b/hydroflow/examples/hello_world/main.rs
@@ -1,0 +1,9 @@
+use hydroflow::hydroflow_syntax;
+
+pub fn main() {
+    let mut df = hydroflow_syntax! {
+        source_iter(["Hello World"]) -> for_each(|string| println!("{}", string));
+    };
+
+    df.run_available();
+}


### PR DESCRIPTION
Add a very simple example to the examples folder for two reasons.

The first is that the current simplest example we have is 'graph reachability' which is somewhat simple from a hydroflow standpoint but relatively conceptually heavy. Traditionally there would be a 'hello world' example that does almost nothing as a real from-nothing starting point.

The second reason is that I often find myself editing graph reachability to run some simple hydroflow program to use cargo expand or to profile with, if I could edit this simpler program instead it would save me some minor annoyances.