### PR TITLE
Improve error message when key is not found in a demux

### DIFF
--- a/hydroflow_cli_integration/src/lib.rs
+++ b/hydroflow_cli_integration/src/lib.rs
@@ -450,7 +450,7 @@ impl<T, S: Sink<T, Error = io::Error> + Send + Sync> Sink<(u32, T)> for DemuxDra
                 .sinks
                 .get_mut()
                 .get_mut(&item.0)
-                .unwrap()
+                .expect(format!("No sink in this demux for key {}", item.0).as_str())
                 .as_mut(),
             item.1,
         )


### PR DESCRIPTION
Improve error message when key is not found in a demux
