### PR TITLE
lattice2: Add `NaiveCompare`, fix `Ord` & `SetUnion` bugs

### DIFF
--- a/hydroflow/src/lang/collections.rs
+++ b/hydroflow/src/lang/collections.rs
@@ -494,6 +494,11 @@ impl<T, const N: usize> IntoIterator for Array<T, N> {
         IntoIterator::into_iter(self.0)
     }
 }
+impl<T, const N: usize> From<[T; N]> for Array<T, N> {
+    fn from(value: [T; N]) -> Self {
+        Self(value)
+    }
+}
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MaskedArray<T, const N: usize> {

--- a/hydroflow/src/lang/lattice/set_union.rs
+++ b/hydroflow/src/lang/lattice/set_union.rs
@@ -79,7 +79,7 @@ where
     ) -> Option<Ordering> {
         match this.len().cmp(&other.len()) {
             Ordering::Greater => {
-                if this.keys().all(|key| other.get(key).is_some()) {
+                if other.keys().all(|key| this.get(key).is_some()) {
                     Some(Ordering::Greater)
                 } else {
                     None
@@ -93,7 +93,7 @@ where
                 }
             }
             Ordering::Less => {
-                if other.keys().all(|key| this.get(key).is_some()) {
+                if this.keys().all(|key| other.get(key).is_some()) {
                     Some(Ordering::Less)
                 } else {
                     None

--- a/hydroflow/src/lang/lattice2/ord.rs
+++ b/hydroflow/src/lang/lattice2/ord.rs
@@ -35,6 +35,15 @@ impl<T> ConvertFrom<Max<T>> for Max<T> {
     }
 }
 
+impl<T> Compare<Max<T>> for Max<T>
+where
+    T: Ord,
+{
+    fn compare(&self, other: &Max<T>) -> Option<std::cmp::Ordering> {
+        Some(Ord::cmp(&self.0, &other.0))
+    }
+}
+
 #[repr(transparent)]
 #[derive(Default, PartialEq, PartialOrd, Eq, Ord)]
 /// A totally ordered min lattice. Merging takes the smaller value.
@@ -71,6 +80,6 @@ where
     T: Ord,
 {
     fn compare(&self, other: &Min<T>) -> Option<std::cmp::Ordering> {
-        Some(Ord::cmp(&self.0, &other.0))
+        Some(Ord::cmp(&self.0, &other.0).reverse())
     }
 }


### PR DESCRIPTION
- Fix `Min` compare reversed
- Impl compare for `Max`
- Fix `SetUnion` compare logical error (long standing old bug)
- Add `NaiveCompare` trait based on merge fn
- Improve `SetUnion` tests