### PR TITLE
Cleanup `hydroflow` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,18 +684,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crdts"
-version = "7.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e30e1170960eddf5392c448ff5b190a49cfcb28d6c79f789f2b4e30b571f8f8"
-dependencies = [
- "num",
- "quickcheck",
- "serde",
- "tiny-keccak",
-]
-
-[[package]]
 name = "criterion"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,12 +787,6 @@ checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "ctrlc"
@@ -960,16 +942,6 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-
-[[package]]
-name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "log",
- "regex",
-]
 
 [[package]]
 name = "errno"
@@ -1304,7 +1276,6 @@ dependencies = [
 name = "hydroflow"
 version = "0.0.0"
 dependencies = [
- "async-trait",
  "bincode",
  "byteorder",
  "bytes",
@@ -1312,7 +1283,6 @@ dependencies = [
  "clap 4.2.1",
  "colored",
  "core_affinity",
- "crdts",
  "criterion",
  "futures",
  "getrandom 0.2.9",
@@ -1333,7 +1303,6 @@ dependencies = [
  "rustc-hash",
  "sealed",
  "serde",
- "serde-big-array",
  "serde_json",
  "slotmap",
  "smallvec",
@@ -1829,42 +1798,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
- "serde",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
-dependencies = [
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1872,30 +1805,6 @@ checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
-dependencies = [
- "autocfg",
- "num-bigint",
- "num-integer",
- "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -2306,18 +2215,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quickcheck"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
-dependencies = [
- "env_logger",
- "log",
- "rand 0.7.3",
- "rand_core 0.5.1",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2683,15 +2580,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-big-array"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3016,15 +2904,6 @@ name = "timely_logging"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9046af28827ac831479d245eb8afd9522599a3cbb22d6c42a82cb9e4ccdf858"
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
 
 [[package]]
 name = "tiny_http"

--- a/hydroflow/Cargo.toml
+++ b/hydroflow/Cargo.toml
@@ -13,15 +13,13 @@ async = [ "dep:futures" ]
 macros = [ "hydroflow_macro", "hydroflow_datalog" ]
 hydroflow_macro = [ "dep:hydroflow_macro" ]
 hydroflow_datalog = [ "dep:hydroflow_datalog" ]
-cli_integration = [ "dep:hydroflow_cli_integration", "dep:async-trait" ]
+cli_integration = [ "dep:hydroflow_cli_integration" ]
 kvs_bench = []
 
 [dependencies]
-async-trait = { version = "0.1", optional = true }
 bincode = "1.3"
 byteorder = "1.4.3"
 bytes = "1.1.0"
-crdts = "7.2.0"
 futures = { version = "0.3", optional = true }
 hydroflow_cli_integration = { optional = true, path = "../hydroflow_cli_integration", version = "0.0.0" }
 hydroflow_datalog = { optional = true, path = "../hydroflow_datalog", version = "0.0.0" }
@@ -29,17 +27,13 @@ hydroflow_lang = { path = "../hydroflow_lang", version = "0.0.0" }
 hydroflow_macro = { optional = true, path = "../hydroflow_macro", version = "0.0.0" }
 lattices = { path = "../lattices", version = "0.0.0" }
 pusherator = { path = "../pusherator", version = "0.0.0" }
-rand_distr = "0.4.3"
 ref-cast = "1.0"
-regex = "1"
 rustc-hash = "1.1.0"
 sealed = "0.5"
 serde = { version = "1", features = [ "derive" ] }
-serde-big-array = "0.5.0"
 serde_json = "1"
 slotmap = "1.0"
 smallvec = "1.10.0"
-static_assertions = "1.1.0"
 tokio-stream = { version = "0.1.10", features = [ "io-util", "sync" ] }
 variadics = { path = "../variadics", version = "0.0.1" }
 
@@ -63,16 +57,19 @@ clap = { version = "4.1.8", features = [ "derive" ] }
 colored = "2.0"
 core_affinity = "0.5.10"
 futures = { version = "0.3" }
+hdrhistogram = "7"
 insta = "1.7.1"
 itertools = "0.10.3"
 multiplatform_test = { path = "../multiplatform_test", version = "0.0.0" }
 wasm-bindgen-test-macro = "0.3.34"
 wasm-bindgen-test = "0.3.34"
 rand = {version = "0.8.4", features = ["small_rng"]}
+rand_distr = "0.4.3"
+regex = "1"
+static_assertions = "1.1.0"
 textnonce = "1.0.0"
 time = "0.3"
 trybuild = "1.0.80"
-hdrhistogram = "7"
 zipf = "7.0.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/hydroflow/src/lang/lattice/dom_pair.rs
+++ b/hydroflow/src/lang/lattice/dom_pair.rs
@@ -2,9 +2,6 @@ use std::cmp::Ordering;
 
 use super::bottom::BottomRepr;
 use super::{Compare, Convert, Debottom, Lattice, LatticeRepr, Merge, Top};
-
-use crate::lang::tag;
-
 pub struct DomPair<La: Lattice, Lb: Lattice> {
     _phantom: std::marker::PhantomData<(La, Lb)>,
 }
@@ -115,7 +112,10 @@ impl<Ra: Top, Rb: Top> Top for DomPairRepr<Ra, Rb> {
     }
 }
 
+#[cfg(test)]
 fn __assert_merges() {
+    use crate::lang::tag;
+
     use static_assertions::{assert_impl_all, assert_not_impl_any};
 
     use super::set_union::SetUnionRepr;

--- a/hydroflow/src/lang/lattice/map_union.rs
+++ b/hydroflow/src/lang/lattice/map_union.rs
@@ -174,6 +174,7 @@ where
 //     }
 // }
 
+#[cfg(test)]
 fn __assert_merges() {
     use static_assertions::{assert_impl_all, assert_not_impl_any};
 

--- a/hydroflow/src/lang/lattice/pair.rs
+++ b/hydroflow/src/lang/lattice/pair.rs
@@ -2,7 +2,6 @@ use std::cmp::Ordering;
 
 use crate::lang::lattice::bottom::BottomRepr;
 use crate::lang::lattice::{Compare, Convert, Debottom, Lattice, LatticeRepr, Merge, Top};
-use crate::lang::tag;
 
 pub struct Pair<La: Lattice, Lb: Lattice> {
     _phantom: std::marker::PhantomData<(La, Lb)>,
@@ -90,7 +89,10 @@ impl<Ra: Top, Rb: Top> Top for PairRepr<Ra, Rb> {
     }
 }
 
+#[cfg(test)]
 fn __assert_merges() {
+    use crate::lang::tag;
+
     use static_assertions::{assert_impl_all, assert_not_impl_any};
 
     use super::set_union::SetUnionRepr;

--- a/hydroflow/src/lang/lattice/set_union.rs
+++ b/hydroflow/src/lang/lattice/set_union.rs
@@ -123,6 +123,7 @@ impl<T: Clone> Debottom for SetUnionRepr<tag::OPTION, T> {
     }
 }
 
+#[cfg(test)]
 fn __assert_merges() {
     use static_assertions::{assert_impl_all, assert_not_impl_any};
 

--- a/hydroflow/src/lib.rs
+++ b/hydroflow/src/lib.rs
@@ -20,7 +20,6 @@ pub use pusherator;
 pub use rustc_hash;
 pub use serde;
 pub use serde_json;
-pub use static_assertions;
 pub use tokio;
 pub use tokio_stream;
 pub use tokio_util;


### PR DESCRIPTION
- Remove unused `async-trait`, `crdts`, `serde-big-array`
- Move `rand_distr`, `regex`, `static_assertions` to `dev-dependencies`