### PR TITLE
Fix book operators build

### DIFF
--- a/hydroflow_macro/build.rs
+++ b/hydroflow_macro/build.rs
@@ -161,7 +161,11 @@ fn update_book() -> Result<(), Box<dyn Error>> {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    if book_file(FILENAME)?.is_file() {
+    // Only try to update the book if the output directory exists.
+    if book_file(FILENAME)?
+        .parent()
+        .map_or(false, |dir| dir.is_dir())
+    {
         update_book()?;
     }
     Ok(())


### PR DESCRIPTION
Wasn't building because the `.gitignore`d output file didn't exist. Instead check if that file's parent folder exists.

Fixup: a78ff9aace6771787c2b72aad83be6ad8d49a828