### PR TITLE
Deduplicate `dest_sink_serde` code by using `dest_sink`'s `write_fn`

### DIFF
--- a/hydroflow/src/util/mod.rs
+++ b/hydroflow/src/util/mod.rs
@@ -25,7 +25,8 @@ use std::task::{Context, Poll};
 
 use bincode;
 use futures::Stream;
-use serde::{Deserialize, Serialize};
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
 
 /// Returns a channel as a (1) unbounded sender and (2) unbounded receiver `Stream` for use in Hydroflow.
 pub fn unbounded_channel<T>() -> (
@@ -98,7 +99,7 @@ where
 /// Serialize a message to bytes using bincode.
 pub fn serialize_to_bytes<T>(msg: T) -> bytes::Bytes
 where
-    T: Serialize + for<'a> Deserialize<'a> + Clone,
+    T: Serialize,
 {
     bytes::Bytes::from(bincode::serialize(&msg).unwrap())
 }
@@ -106,7 +107,7 @@ where
 /// Serialize a message from bytes using bincode.
 pub fn deserialize_from_bytes<T>(msg: impl AsRef<[u8]>) -> bincode::Result<T>
 where
-    T: Serialize + for<'a> Deserialize<'a> + Clone,
+    T: DeserializeOwned,
 {
     bincode::deserialize(msg.as_ref())
 }

--- a/hydroflow_lang/src/graph/ops/dest_sink.rs
+++ b/hydroflow_lang/src/graph/ops/dest_sink.rs
@@ -106,11 +106,14 @@ pub const DEST_SINK: OperatorConstraints = OperatorConstraints {
                    hydroflow,
                    op_span,
                    ident,
+                   is_pull,
                    op_name,
                    op_inst: OperatorInstance { arguments, .. },
                    ..
                },
                _| {
+        assert!(!is_pull);
+
         let sink_arg = &arguments[0];
 
         let send_ident = wc.make_ident("item_send");

--- a/hydroflow_lang/src/graph/ops/dest_sink_serde.rs
+++ b/hydroflow_lang/src/graph/ops/dest_sink_serde.rs
@@ -54,7 +54,7 @@ pub const DEST_SINK_SERDE: OperatorConstraints = OperatorConstraints {
             write_prologue,
             write_iterator,
             write_iterator_after,
-        } = (super::dest_sink::DEST_SINK.write_fn)(&wc, diagnostics)?;
+        } = (super::dest_sink::DEST_SINK.write_fn)(wc, diagnostics)?;
 
         let write_iterator = quote_spanned! {op_span=>
             ::std::debug_assert!(#root::tokio::runtime::Handle::try_current().is_ok(), #missing_runtime_msg);


### PR DESCRIPTION
Also loosens some bounds in `hydroflow::util::{serialize_to_bytes, deserialize_from_bytes}`

First commit working towards backpressure