### PR TITLE
fix: fix ConvertFrom for bottom to actually convert the type

### DIFF
--- a/lattices/src/bottom.rs
+++ b/lattices/src/bottom.rs
@@ -55,11 +55,7 @@ where
     Inner: ConvertFrom<Other>,
 {
     fn from(other: Bottom<Other>) -> Self {
-        if let Some(other) = other.0 {
-            Bottom::new(ConvertFrom::from(other))
-        } else {
-            Bottom::default()
-        }
+        Self(other.0.map(Inner::from))
     }
 }
 


### PR DESCRIPTION
This came up when trying to merge a `Top<Bottom<SetUnionSingletonSet>` into a `Top<Bottom<SetUnionHashSet>>`