### PR TITLE
feat(multiplatform_test)!: `hydroflow`, `logging`/`tracing` features

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "rust-analyzer.runnableEnv": [
+        {
+            // Set output levels for `tracing` logging.
+            "env": {
+                "RUST_LOG": "debug,hydroflow=trace"
+            }
+        }
+    ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,6 +953,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1261,6 +1274,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hydro_cli"
 version = "0.2.0"
 dependencies = [
@@ -1352,7 +1371,6 @@ dependencies = [
  "trybuild",
  "variadics",
  "wasm-bindgen-test",
- "wasm-bindgen-test-macro",
  "zipf",
 ]
 
@@ -1703,6 +1721,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,8 +1790,13 @@ dependencies = [
 name = "multiplatform_test"
 version = "0.0.0"
 dependencies = [
+ "env_logger",
+ "log",
  "proc-macro2",
  "quote",
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -1810,6 +1842,16 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1905,6 +1947,12 @@ name = "os_str_bytes"
 version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -2407,6 +2455,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,6 +2696,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-escape"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2858,6 +2924,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if 1.0.0",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3059,7 +3135,19 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -3069,6 +3157,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3289,6 +3407,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "variadics"

--- a/hydroflow/Cargo.toml
+++ b/hydroflow/Cargo.toml
@@ -60,7 +60,6 @@ futures = { version = "0.3" }
 hdrhistogram = "7"
 insta = "1.7.1"
 multiplatform_test = { path = "../multiplatform_test", version = "0.0.0" }
-wasm-bindgen-test-macro = "0.3.34"
 wasm-bindgen-test = "0.3.34"
 rand = {version = "0.8.4", features = ["small_rng"]}
 rand_distr = "0.4.3"

--- a/multiplatform_test/Cargo.toml
+++ b/multiplatform_test/Cargo.toml
@@ -13,3 +13,10 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
+
+[dev-dependencies]
+env_logger = "0.10"
+log = "0.4"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = [ "env-filter" ] }
+wasm-bindgen-test = "0.3"

--- a/multiplatform_test/README.md
+++ b/multiplatform_test/README.md
@@ -1,8 +1,8 @@
-# multiplatform_test
+# `multiplatform_test`
 
 Provides a proc-macro that expands to testing on platforms relevant to
 Hydroflow. By default, expands to testing on the host (using the normal
-`#[test]` attribute) and wasm (using `#[wasm_bindgen_test]`.
+`#[test]` attribute) and wasm (using `#[wasm_bindgen_test]`).
 
 For example, the test
 
@@ -19,7 +19,7 @@ Expands to
 
 ```rust
 #[test]
-#[wasm_bindgen_test_macro::wasm_bindgen_test]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn my_test() {
   // ...
 }
@@ -27,28 +27,39 @@ fn my_test() {
 
 ## Installation
 
-Because the `multiplaform_test` macro expands to `wasm_bindgen_test_macro`, you
-will also need to depend on the
-[`wasm_bindgen_test_macro`](https://crates.io/crates/wasm-bindgen-test-macro/)
-crate.
+```toml
+[dependencies]
+multiplatform_test = * # replace with version.
+```
+
+If you're using `wasm` naturally you will need to add the [`wasm_bindgen_test`](https://crates.io/crates/wasm-bindgen-test-macro/)
+crate as a dependency.
 
 ## Usage
 
 ### Specifying platforms
+
+There are many platforms which can be specified:
+* `test` - Adds a standard [`#[test]` attribute](https://doc.rust-lang.org/reference/attributes/testing.html#the-test-attribute).
+* `tokio` - Adds a [`#[tokio::test]` attribute](https://docs.rs/tokio/latest/tokio/attr.test.html).
+* `async_std` - Adds an [`#[async_std::test]` attribute](https://docs.rs/async-std/latest/async_std/attr.test.html).
+* `hydroflow` - Adds a [`#[hydroflow::test]` attribute](https://docs.rs/hydroflow/latest/hydroflow/attr.test.html).
+* `wasm` - Adds a [`#[wasm_bindgen_test::wasm_bindgen_test]` attribute](https://docs.rs/wasm-bindgen-test/0.3.36/wasm_bindgen_test/attr.wasm_bindgen_test.html).
+* `env_logging` - Registers [`env_logger`](https://docs.rs/env_logger/latest/env_logger/) for [`log`ging](https://docs.rs/log/latest/log/).
+* `env_tracing` - Registers a [`FmtSubscriber`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/index.html#reexport.FmtSubscriber) with an [`EnvFilter`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) for [`tracing`](https://docs.rs/tracing/latest/tracing/).
 
 You can test on a subset of platforms by passing in the platforms in parens:
 
 ```rust
 use multiplatform_test::multiplatform_test;
 
-#[multiplatform_test(default)]  // Only test on the default #[test] platform
+#[multiplatform_test(test)]  // Only test on the standard `#[test]` platform, but enables logging
 fn my_test() {
   // ...
 }
 ```
 
 expands to
-
 
 ```rust
 use multiplatform_test::multiplatform_test;

--- a/multiplatform_test/src/lib.rs
+++ b/multiplatform_test/src/lib.rs
@@ -1,16 +1,84 @@
+#![doc = include_str!("../README.md")]
+
 use std::iter::Iterator;
 
 use proc_macro::TokenStream;
-use quote::quote;
+use quote::{quote, quote_spanned};
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 enum Platform {
     Default,
+    Tokio,
+    AsyncStd,
+    Hydroflow,
     Wasm,
+    EnvLogging,
+    EnvTracing,
+}
+impl Platform {
+    // All platforms.
+    const ALL: [Self; 7] = [
+        Self::Default,
+        Self::Tokio,
+        Self::AsyncStd,
+        Self::Hydroflow,
+        Self::Wasm,
+        Self::EnvLogging,
+        Self::EnvTracing,
+    ];
+    // Default when no platforms are specified.
+    const DEFAULT: [Self; 2] = [Self::Default, Self::Wasm];
+
+    /// Name of platform ident in attribute.
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Default => "test",
+            Self::Tokio => "tokio",
+            Self::AsyncStd => "async_std",
+            Self::Hydroflow => "hydroflow",
+            Self::Wasm => "wasm",
+            Self::EnvLogging => "env_logging",
+            Self::EnvTracing => "env_tracing",
+        }
+    }
+
+    /// Generate the attribute for this platform (if any).
+    fn make_attribute(self) -> proc_macro2::TokenStream {
+        // Fully specify crate names so that the consumer does not need to add another
+        // use statement. They still need to depend on the crate in their `Cargo.toml`,
+        // though.
+        // TODO(mingwei): use `proc_macro_crate::crate_name(...)` to handle renames.
+        match self {
+            Platform::Default => quote! { #[test] },
+            Platform::Tokio => quote! { #[tokio::test ] },
+            Platform::AsyncStd => quote! { #[async_std::test] },
+            Platform::Hydroflow => quote! { #[hydroflow::test] },
+            Platform::Wasm => {
+                quote! { #[wasm_bindgen_test::wasm_bindgen_test] }
+            }
+            Platform::EnvLogging | Platform::EnvTracing => Default::default(),
+        }
+    }
+
+    /// Generate the initialization code statements for this platform (if any).
+    fn make_init_code(self) -> proc_macro2::TokenStream {
+        match self {
+            Platform::EnvLogging => quote! {
+                let _ = env_logger::builder().is_test(true).try_init();
+            },
+            Platform::EnvTracing => quote! {
+                let subscriber = tracing_subscriber::FmtSubscriber::builder()
+                    .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+                    .with_test_writer()
+                    .finish();
+                let _ = tracing::subscriber::set_global_default(subscriber);
+            },
+            _ => Default::default(),
+        }
+    }
 }
 
-const DEFAULT_PLATFORMS: [Platform; 2] = [Platform::Default, Platform::Wasm];
-
+/// See the [crate] docs for usage information.
 #[proc_macro_attribute]
 pub fn multiplatform_test(attr: TokenStream, body: TokenStream) -> TokenStream {
     let ts = multiplatform_test_impl(
@@ -28,46 +96,62 @@ fn multiplatform_test_impl(
     let mut platforms = Vec::<Platform>::new();
 
     while let Some(token) = attr.next() {
-        let platform = match &token {
-            proc_macro2::TokenTree::Ident(i) => match i.to_string().as_str() {
-                "default" => Platform::Default,
-                "wasm" => Platform::Wasm,
-                other => panic!(
-                    "unknown platform {}; want platform in [default, wasm]",
-                    other
-                ),
-            },
-            _ => panic!("malformed #[multiplatform_test] attribute; expected identifier"),
+        let proc_macro2::TokenTree::Ident(i) = &token else {
+            return quote_spanned! {token.span()=>
+                compile_error!("malformed #[multiplatform_test] attribute; expected identifier.");
+            };
+        };
+        let name = i.to_string();
+        let Some(&platform) = Platform::ALL
+            .iter()
+            .find(|platform| name == platform.name())
+        else {
+            let msg = proc_macro2::Literal::string(&*format!(
+                "unknown platform {}; expected one of [{}]",
+                name,
+                Platform::ALL.map(Platform::name).join(", "),
+            ));
+            return quote_spanned! {token.span()=> compile_error!(#msg); };
         };
         platforms.push(platform);
 
         match &attr.next() {
             Some(proc_macro2::TokenTree::Punct(op)) if op.as_char() == ',' => {}
-            Some(_) => panic!("malformed `#[multiplatform_test]` attribute; expected `,`"),
+            Some(other) => {
+                return quote_spanned! {other.span()=>
+                    compile_error!("malformed `#[multiplatform_test]` attribute; expected `,`.");
+                };
+            }
             None => break,
         }
     }
-
-    let mut output = Vec::<proc_macro2::TokenStream>::new();
-
     if platforms.is_empty() {
-        platforms.extend(DEFAULT_PLATFORMS.iter());
+        platforms.extend(Platform::DEFAULT.iter());
     }
+
+    let mut output = proc_macro2::TokenStream::new();
+    let mut init_code = proc_macro2::TokenStream::new();
 
     for p in platforms {
-        let tokens = match p {
-            Platform::Default => quote! { #[test] },
-            // Fully specify wasm_bindgen_test so that the consumer does not need to add another
-            // use statement. They still need to depend on the wasm_bindgen_test_macro crate,
-            // though.
-            Platform::Wasm => quote! { #[wasm_bindgen_test_macro::wasm_bindgen_test] },
-        };
-        output.push(tokens);
+        output.extend(p.make_attribute());
+        init_code.extend(p.make_init_code());
     }
 
-    output.push(body);
+    if init_code.is_empty() {
+        output.extend(body);
+    } else {
+        let mut body_head = body.into_iter().collect::<Vec<_>>();
+        let Some(proc_macro2::TokenTree::Group(body_code)) = body_head.pop() else { panic!(); };
 
-    output.into_iter().collect()
+        output.extend(body_head);
+        output.extend(quote! {
+            {
+                { #init_code };
+                #body_code
+            }
+        });
+    }
+    output
 }
 
 #[cfg(test)]
@@ -76,12 +160,12 @@ mod tests {
 
     #[test]
     fn test_default_platforms() {
-        let test_fn = quote! { fn test() { } };
+        let test_fn: proc_macro2::TokenStream = quote! { fn test() { } };
         let attrs = proc_macro2::TokenStream::new();
-        let got = multiplatform_test_impl(attrs, test_fn);
+        let got: proc_macro2::TokenStream = multiplatform_test_impl(attrs, test_fn);
         let want = quote! {
             #[test]
-            #[wasm_bindgen_test_macro::wasm_bindgen_test]
+            #[wasm_bindgen_test::wasm_bindgen_test]
             fn test() { }
         };
 
@@ -91,7 +175,7 @@ mod tests {
     #[test]
     fn test_host_platform() {
         let test_fn = quote! { fn test() { } };
-        let attrs = quote! { default };
+        let attrs = quote! { test };
         let got = multiplatform_test_impl(attrs, test_fn);
         let want = quote! {
             #[test]
@@ -107,7 +191,7 @@ mod tests {
         let attrs = quote! { wasm };
         let got = multiplatform_test_impl(attrs, test_fn);
         let want = quote! {
-            #[wasm_bindgen_test_macro::wasm_bindgen_test]
+            #[wasm_bindgen_test::wasm_bindgen_test]
             fn test() { }
         };
 
@@ -117,11 +201,11 @@ mod tests {
     #[test]
     fn test_host_wasm_platform() {
         let test_fn = quote! { fn test() { } };
-        let attrs = quote! { default, wasm };
+        let attrs = quote! { test, wasm };
         let got = multiplatform_test_impl(attrs, test_fn);
         let want = quote! {
             #[test]
-            #[wasm_bindgen_test_macro::wasm_bindgen_test]
+            #[wasm_bindgen_test::wasm_bindgen_test]
             fn test() { }
         };
 
@@ -129,26 +213,26 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "unknown platform")]
     fn test_unknown_platform() {
         let test_fn = quote! { fn test() { } };
         let attrs = quote! { hello };
-        multiplatform_test_impl(attrs, test_fn);
+        let got = multiplatform_test_impl(attrs, test_fn);
+        assert!(got.to_string().starts_with("compile_error !"));
     }
 
     #[test]
-    #[should_panic(expected = "expected `,`")]
     fn test_invalid_attr_nocomma_platform() {
         let test_fn = quote! { fn test() { } };
         let attrs = quote! { wasm() };
-        multiplatform_test_impl(attrs, test_fn);
+        let got = multiplatform_test_impl(attrs, test_fn);
+        assert!(got.to_string().starts_with("compile_error !"));
     }
 
     #[test]
-    #[should_panic(expected = "expected identifier")]
     fn test_invalid_attr_noident_platform() {
         let test_fn = quote! { fn test() { } };
         let attrs = quote! { () };
-        multiplatform_test_impl(attrs, test_fn);
+        let got = multiplatform_test_impl(attrs, test_fn);
+        assert!(got.to_string().starts_with("compile_error !"));
     }
 }

--- a/multiplatform_test/src/lib.rs
+++ b/multiplatform_test/src/lib.rs
@@ -106,7 +106,7 @@ fn multiplatform_test_impl(
             .iter()
             .find(|platform| name == platform.name())
         else {
-            let msg = proc_macro2::Literal::string(&*format!(
+            let msg = proc_macro2::Literal::string(&format!(
                 "unknown platform {}; expected one of [{}]",
                 name,
                 Platform::ALL.map(Platform::name).join(", "),

--- a/multiplatform_test/tests/test.rs
+++ b/multiplatform_test/tests/test.rs
@@ -1,0 +1,14 @@
+use multiplatform_test::multiplatform_test;
+
+#[multiplatform_test]
+fn test_default() {}
+
+#[multiplatform_test(test, env_tracing)]
+fn test_tracing() {
+    tracing::warn!("This is a tracing warning!");
+}
+
+#[multiplatform_test(test, env_logging)]
+fn test_logging() {
+    log::warn!("This is a logging warning!");
+}


### PR DESCRIPTION
* Adds `tokio` for `#[tokio::test]`.
* Adds `async_std` for `#[async_std::test]`.
* Adds `hydroflow` for `#[hydroflow::test]`.
* Adds `env_logging` for `env_logger` registering.
* Adds `env_tracing` for `EnvFilter` `FmtSubscriber` `tracing`.

BREAKING CHANGE: `default` is renamed to `test` (for `#[test]`)