### PR TITLE
refactor(lattices)!: Rename `ConvertFrom::from` -> `LatticeFrom::lattice_from`

### DIFF
--- a/hydroflow/examples/shopping/lattices.rs
+++ b/hydroflow/examples/shopping/lattices.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
-use hydroflow::lattices::{ConvertFrom, LatticeOrd, Merge};
+use hydroflow::lattices::{LatticeFrom, LatticeOrd, Merge};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
@@ -119,8 +119,8 @@ impl<T: Eq + std::fmt::Debug> PartialOrd<Self> for SealedSetOfIndexedValues<T> {
 }
 impl<T: Eq + std::fmt::Debug> LatticeOrd<Self> for SealedSetOfIndexedValues<T> {}
 
-impl<T> ConvertFrom<Self> for SealedSetOfIndexedValues<T> {
-    fn from(other: Self) -> Self {
+impl<T> LatticeFrom<Self> for SealedSetOfIndexedValues<T> {
+    fn lattice_from(other: Self) -> Self {
         other
     }
 }

--- a/hydroflow/src/compiled/pull/symmetric_hash_join_lattice.rs
+++ b/hydroflow/src/compiled/pull/symmetric_hash_join_lattice.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::Entry;
 use std::collections::hash_set;
 
 use lattices::map_union::MapUnion;
-use lattices::{ConvertFrom, Merge};
+use lattices::{LatticeFrom, Merge};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::util::clear::Clear;
@@ -31,14 +31,14 @@ where
 {
     fn build<LatticeDelta>(&mut self, k: K, v: LatticeDelta) -> bool
     where
-        Lattice: Merge<LatticeDelta> + ConvertFrom<LatticeDelta>,
+        Lattice: Merge<LatticeDelta> + LatticeFrom<LatticeDelta>,
     {
         let entry = self.table.0.entry(k);
 
         match entry {
             Entry::Occupied(mut e) => e.get_mut().merge(v),
             Entry::Vacant(e) => {
-                e.insert(ConvertFrom::from(v));
+                e.insert(LatticeFrom::lattice_from(v));
                 true
             }
         }
@@ -93,8 +93,8 @@ where
     where
         I1: Iterator<Item = (K, LhsDelta)>,
         I2: Iterator<Item = (K, RhsDelta)>,
-        LhsLattice: Merge<LhsDelta> + ConvertFrom<LhsDelta>,
-        RhsLattice: Merge<RhsDelta> + ConvertFrom<RhsDelta>,
+        LhsLattice: Merge<LhsDelta> + LatticeFrom<LhsDelta>,
+        RhsLattice: Merge<RhsDelta> + LatticeFrom<RhsDelta>,
     {
         for (k, v1) in lhs {
             if state_lhs.build(k.clone(), v1) {

--- a/hydroflow_lang/src/graph/ops/lattice_batch.rs
+++ b/hydroflow_lang/src/graph/ops/lattice_batch.rs
@@ -94,7 +94,7 @@ pub const LATTICE_BATCH: OperatorConstraints = OperatorConstraints {
                             if let Some(lattice) = &mut *lattice {
                                 #root::lattices::Merge::merge(lattice, i);
                             } else {
-                                *lattice = Some(#root::lattices::ConvertFrom::from(i));
+                                *lattice = Some(#root::lattices::LatticeFrom::lattice_from(i));
                             };
                         }
                     }
@@ -129,7 +129,7 @@ pub const LATTICE_BATCH: OperatorConstraints = OperatorConstraints {
                         if let Some(lattice) = &mut *lattice {
                             #root::lattices::Merge::merge(&mut *lattice, x);
                         } else {
-                            *lattice = Some(#root::lattices::ConvertFrom::from(x));
+                            *lattice = Some(#root::lattices::LatticeFrom::lattice_from(x));
                         };
                     });
                 },

--- a/hydroflow_lang/src/graph/ops/lattice_join.rs
+++ b/hydroflow_lang/src/graph/ops/lattice_join.rs
@@ -185,8 +185,8 @@ pub const LATTICE_JOIN: OperatorConstraints = OperatorConstraints {
                 ) -> impl 'a + Iterator<Item = (Key, (Lhs, Rhs))>
                 where
                     Key: Eq + std::hash::Hash + Clone,
-                    Lhs: #root::lattices::Merge<LhsDelta> + Clone + #root::lattices::ConvertFrom<LhsDelta>,
-                    Rhs: #root::lattices::Merge<RhsDelta> + Clone + #root::lattices::ConvertFrom<RhsDelta>,
+                    Lhs: #root::lattices::Merge<LhsDelta> + Clone + #root::lattices::LatticeFrom<LhsDelta>,
+                    Rhs: #root::lattices::Merge<RhsDelta> + Clone + #root::lattices::LatticeFrom<RhsDelta>,
                     I1: Iterator<Item = (Key, LhsDelta)>,
                     I2: Iterator<Item = (Key, RhsDelta)>,
                 {

--- a/lattices/README.md
+++ b/lattices/README.md
@@ -73,10 +73,10 @@ Implementors should use the [`test::check_partial_ord_properties`] method to che
 `PartialOrd` implementation, and should use the [`test::check_lattice_ord`] to ensure the partial
 order agrees with the `Merge`-derived `NaiveLatticeOrd` order.
 
-### `ConvertFrom`
+### `LatticeFrom`
 
-[`ConvertFrom`] is equivalent to the [`std::convert::From`] trait but with some extra
-lattice-specific semantics. `ConvertFrom` should be implemented only between different
-representations of the same lattice type, e.g. between [`set_union::SetUnionBTreeSet`] and [`set_union::SetUnionHashSet`].
-For compound lattice (lattices with nested lattice types), the `ConvertFrom` implementation should
-be recursive for those nested lattices.
+[`LatticeFrom`] is equivalent to the [`std::convert::From`] trait but specific to lattices.
+`LatticeFrom` should be implemented only between different representations of the same lattice
+type, e.g. between [`set_union::SetUnionBTreeSet`] and [`set_union::SetUnionHashSet`]. For compound
+lattice (lattices with nested lattice types), the `LatticeFrom` implementation should be recursive
+for those nested lattices.

--- a/lattices/src/dom_pair.rs
+++ b/lattices/src/dom_pair.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering::{self, *};
 
-use super::{ConvertFrom, Merge};
+use super::{LatticeFrom, Merge};
 use crate::LatticeOrd;
 
 /// Dominating pair compound lattice.
@@ -39,8 +39,8 @@ impl<Key, Val> DomPair<Key, Val> {
 impl<KeySelf, KeyOther, ValSelf, ValOther> Merge<DomPair<KeyOther, ValOther>>
     for DomPair<KeySelf, ValSelf>
 where
-    KeySelf: Merge<KeyOther> + ConvertFrom<KeyOther> + PartialOrd<KeyOther>,
-    ValSelf: Merge<ValOther> + ConvertFrom<ValOther>,
+    KeySelf: Merge<KeyOther> + LatticeFrom<KeyOther> + PartialOrd<KeyOther>,
+    ValSelf: Merge<ValOther> + LatticeFrom<ValOther>,
 {
     fn merge(&mut self, other: DomPair<KeyOther, ValOther>) -> bool {
         match self.key.partial_cmp(&other.key) {
@@ -51,7 +51,7 @@ where
             }
             Some(Equal) => self.val.merge(other.val),
             Some(Less) => {
-                *self = ConvertFrom::from(other);
+                *self = LatticeFrom::lattice_from(other);
                 true
             }
             Some(Greater) => false,
@@ -59,16 +59,16 @@ where
     }
 }
 
-impl<KeySelf, KeyOther, ValSelf, ValOther> ConvertFrom<DomPair<KeyOther, ValOther>>
+impl<KeySelf, KeyOther, ValSelf, ValOther> LatticeFrom<DomPair<KeyOther, ValOther>>
     for DomPair<KeySelf, ValSelf>
 where
-    KeySelf: ConvertFrom<KeyOther>,
-    ValSelf: ConvertFrom<ValOther>,
+    KeySelf: LatticeFrom<KeyOther>,
+    ValSelf: LatticeFrom<ValOther>,
 {
-    fn from(other: DomPair<KeyOther, ValOther>) -> Self {
+    fn lattice_from(other: DomPair<KeyOther, ValOther>) -> Self {
         Self {
-            key: ConvertFrom::from(other.key),
-            val: ConvertFrom::from(other.val),
+            key: LatticeFrom::lattice_from(other.key),
+            val: LatticeFrom::lattice_from(other.val),
         }
     }
 }

--- a/lattices/src/lib.rs
+++ b/lattices/src/lib.rs
@@ -88,7 +88,7 @@ where
 ///
 /// This should only be implemented between different representations of the same lattice type.
 /// This should recursively convert nested lattice types, but not non-lattice ("scalar") types.
-pub trait ConvertFrom<Other> {
+pub trait LatticeFrom<Other> {
     /// Convert from the `Other` lattice into `Self`.
-    fn from(other: Other) -> Self;
+    fn lattice_from(other: Other) -> Self;
 }

--- a/lattices/src/ord.rs
+++ b/lattices/src/ord.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use super::{ConvertFrom, Merge};
+use super::{LatticeFrom, Merge};
 use crate::LatticeOrd;
 
 /// A totally ordered max lattice. Merging returns the larger value.
@@ -34,8 +34,8 @@ where
     }
 }
 
-impl<T> ConvertFrom<Max<T>> for Max<T> {
-    fn from(other: Max<T>) -> Self {
+impl<T> LatticeFrom<Max<T>> for Max<T> {
+    fn lattice_from(other: Max<T>) -> Self {
         other
     }
 }
@@ -76,8 +76,8 @@ where
     }
 }
 
-impl<T> ConvertFrom<Min<T>> for Min<T> {
-    fn from(other: Min<T>) -> Self {
+impl<T> LatticeFrom<Min<T>> for Min<T> {
+    fn lattice_from(other: Min<T>) -> Self {
         other
     }
 }

--- a/lattices/src/pair.rs
+++ b/lattices/src/pair.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering::{self, *};
 
-use super::{ConvertFrom, Merge};
+use super::{LatticeFrom, Merge};
 use crate::LatticeOrd;
 
 /// Pair compound lattice.
@@ -39,16 +39,16 @@ where
     }
 }
 
-impl<LatASelf, LatAOther, LatBSelf, LatBOther> ConvertFrom<Pair<LatAOther, LatBOther>>
+impl<LatASelf, LatAOther, LatBSelf, LatBOther> LatticeFrom<Pair<LatAOther, LatBOther>>
     for Pair<LatASelf, LatBSelf>
 where
-    LatASelf: ConvertFrom<LatAOther>,
-    LatBSelf: ConvertFrom<LatBOther>,
+    LatASelf: LatticeFrom<LatAOther>,
+    LatBSelf: LatticeFrom<LatBOther>,
 {
-    fn from(other: Pair<LatAOther, LatBOther>) -> Self {
+    fn lattice_from(other: Pair<LatAOther, LatBOther>) -> Self {
         Self {
-            a: ConvertFrom::from(other.a),
-            b: ConvertFrom::from(other.b),
+            a: LatticeFrom::lattice_from(other.a),
+            b: LatticeFrom::lattice_from(other.b),
         }
     }
 }

--- a/lattices/src/point.rs
+++ b/lattices/src/point.rs
@@ -1,4 +1,4 @@
-use super::{ConvertFrom, Merge};
+use super::{LatticeFrom, Merge};
 use crate::LatticeOrd;
 
 /// A `Point` lattice, corresponding to a single instance of `T`.
@@ -37,8 +37,8 @@ where
     }
 }
 
-impl<T> ConvertFrom<Point<T>> for Point<T> {
-    fn from(other: Point<T>) -> Self {
+impl<T> LatticeFrom<Point<T>> for Point<T> {
+    fn lattice_from(other: Point<T>) -> Self {
         other
     }
 }

--- a/lattices/src/seq.rs
+++ b/lattices/src/seq.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering::{self, *};
 
 use cc_traits::Iter;
 
-use crate::{ConvertFrom, LatticeOrd, Merge};
+use crate::{LatticeFrom, LatticeOrd, Merge};
 
 /// Sequence compound lattice.
 ///
@@ -39,14 +39,14 @@ impl<Lat> Default for Seq<Lat> {
 
 impl<LatSelf, LatOther> Merge<Seq<LatOther>> for Seq<LatSelf>
 where
-    LatSelf: Merge<LatOther> + ConvertFrom<LatOther>,
+    LatSelf: Merge<LatOther> + LatticeFrom<LatOther>,
 {
     fn merge(&mut self, mut other: Seq<LatOther>) -> bool {
         let mut changed = false;
         // Extend `self` if `other` is longer.
         if self.seq.len() < other.seq.len() {
             self.seq
-                .extend(other.seq.drain(self.seq.len()..).map(LatSelf::from));
+                .extend(other.seq.drain(self.seq.len()..).map(LatSelf::lattice_from));
             changed = true;
         }
         // Merge intersecting indices.
@@ -57,12 +57,12 @@ where
     }
 }
 
-impl<LatSelf, LatOther> ConvertFrom<Seq<LatOther>> for Seq<LatSelf>
+impl<LatSelf, LatOther> LatticeFrom<Seq<LatOther>> for Seq<LatSelf>
 where
-    LatSelf: ConvertFrom<LatOther>,
+    LatSelf: LatticeFrom<LatOther>,
 {
-    fn from(other: Seq<LatOther>) -> Self {
-        Self::new(other.seq.into_iter().map(LatSelf::from).collect())
+    fn lattice_from(other: Seq<LatOther>) -> Self {
+        Self::new(other.seq.into_iter().map(LatSelf::lattice_from).collect())
     }
 }
 

--- a/lattices/src/set_union.rs
+++ b/lattices/src/set_union.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeSet, HashSet};
 
 use crate::cc_traits::{Iter, Len, Set};
 use crate::collections::{ArraySet, SingletonSet};
-use crate::{ConvertFrom, LatticeOrd, Merge};
+use crate::{LatticeFrom, LatticeOrd, Merge};
 
 /// Set-union lattice.
 ///
@@ -38,12 +38,12 @@ where
     }
 }
 
-impl<SetSelf, SetOther, Item> ConvertFrom<SetUnion<SetOther>> for SetUnion<SetSelf>
+impl<SetSelf, SetOther, Item> LatticeFrom<SetUnion<SetOther>> for SetUnion<SetSelf>
 where
     SetSelf: FromIterator<Item>,
     SetOther: IntoIterator<Item = Item>,
 {
-    fn from(other: SetUnion<SetOther>) -> Self {
+    fn lattice_from(other: SetUnion<SetOther>) -> Self {
         Self(other.0.into_iter().collect())
     }
 }

--- a/lattices/src/with_bot.rs
+++ b/lattices/src/with_bot.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 use std::cmp::Ordering::*;
 
-use super::{ConvertFrom, Merge};
+use super::{LatticeFrom, Merge};
 use crate::LatticeOrd;
 
 /// Wraps a lattice in [`Option`], treating [`None`] as a new bottom element which compares as less
@@ -35,14 +35,14 @@ impl<Inner> Default for WithBot<Inner> {
 
 impl<Inner, Other> Merge<WithBot<Other>> for WithBot<Inner>
 where
-    Inner: Merge<Other> + ConvertFrom<Other>,
+    Inner: Merge<Other> + LatticeFrom<Other>,
 {
     fn merge(&mut self, other: WithBot<Other>) -> bool {
         match (&mut self.0, other.0) {
             (None, None) => false,
             (Some(_), None) => false,
             (this @ None, Some(other_inner)) => {
-                *this = Some(ConvertFrom::from(other_inner));
+                *this = Some(LatticeFrom::lattice_from(other_inner));
                 true
             }
             (Some(self_inner), Some(other_inner)) => self_inner.merge(other_inner),
@@ -50,12 +50,12 @@ where
     }
 }
 
-impl<Inner, Other> ConvertFrom<WithBot<Other>> for WithBot<Inner>
+impl<Inner, Other> LatticeFrom<WithBot<Other>> for WithBot<Inner>
 where
-    Inner: ConvertFrom<Other>,
+    Inner: LatticeFrom<Other>,
 {
-    fn from(other: WithBot<Other>) -> Self {
-        Self(other.0.map(Inner::from))
+    fn lattice_from(other: WithBot<Other>) -> Self {
+        Self(other.0.map(Inner::lattice_from))
     }
 }
 

--- a/lattices/src/with_top.rs
+++ b/lattices/src/with_top.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 use std::cmp::Ordering::*;
 
-use super::{ConvertFrom, Merge};
+use super::{LatticeFrom, Merge};
 use crate::LatticeOrd;
 
 /// Wraps a lattice in [`Option`], treating [`None`] as a new top element which compares as greater
@@ -27,7 +27,7 @@ impl<Inner> WithTop<Inner> {
 
 impl<Inner, Other> Merge<WithTop<Other>> for WithTop<Inner>
 where
-    Inner: Merge<Other> + ConvertFrom<Other>,
+    Inner: Merge<Other> + LatticeFrom<Other>,
 {
     fn merge(&mut self, other: WithTop<Other>) -> bool {
         match (&mut self.0, other.0) {
@@ -42,12 +42,12 @@ where
     }
 }
 
-impl<Inner, Other> ConvertFrom<WithTop<Other>> for WithTop<Inner>
+impl<Inner, Other> LatticeFrom<WithTop<Other>> for WithTop<Inner>
 where
-    Inner: ConvertFrom<Other>,
+    Inner: LatticeFrom<Other>,
 {
-    fn from(other: WithTop<Other>) -> Self {
-        Self(other.0.map(Inner::from))
+    fn lattice_from(other: WithTop<Other>) -> Self {
+        Self(other.0.map(Inner::lattice_from))
     }
 }
 


### PR DESCRIPTION
BREAKING CHANGE: `ConvertFrom::from` renamed to `LatticeFrom::lattice_from` to better reflect its usage.