### PR TITLE
docs: remove pattern deref from inspect, filter examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ for an interactive demo.
 ```rust
 source_iter(0..10)
   -> map(|n| n * n)
-  -> filter(|&n| n > 10)
+  -> filter(|n| *n > 10)
   -> foo;
 
 foo = map(|n| (n..=n+1))

--- a/docs/src/pages/playground.js
+++ b/docs/src/pages/playground.js
@@ -50,7 +50,7 @@ source_iter(0..10) -> for_each(|n| println!("Hello {}", n));`,
 // https://hydro.run/docs/hydroflow/quickstart/example_2_simple
 source_iter(0..10)
   -> map(|n| n * n)
-  -> filter(|&n| n > 10)
+  -> filter(|n| *n > 10)
   -> map(|n| (n..=n+1))
   -> flatten()
   -> for_each(|n| println!("Howdy {}", n));`,

--- a/hydroflow/examples/example_2_simple_1.rs
+++ b/hydroflow/examples/example_2_simple_1.rs
@@ -4,7 +4,7 @@ pub fn main() {
     let mut flow = hydroflow_syntax! {
         source_iter(0..10)
             -> map(|n| n * n)
-            -> filter(|&n| n > 10)
+            -> filter(|n| *n > 10)
             -> map(|n| (n..=n+1))
             -> flatten()
             -> for_each(|n| println!("Howdy {}", n));

--- a/hydroflow_lang/src/graph/ops/inspect.rs
+++ b/hydroflow_lang/src/graph/ops/inspect.rs
@@ -16,7 +16,7 @@ use super::{
 ///
 /// ```hydroflow
 /// source_iter([1, 2, 3, 4])
-///     -> inspect(|&x| println!("{}", x))
+///     -> inspect(|x| println!("{}", x))
 ///     -> assert([1, 2, 3, 4]);
 /// ```
 pub const INSPECT: OperatorConstraints = OperatorConstraints {


### PR DESCRIPTION
`*` derefs are easier for Rust beginners to comprehend.