### PR TITLE
fix(cli): use auto manylinux for aarch64-linux CLI builds

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -105,7 +105,7 @@ jobs:
         with:
           working-directory: hydro_cli
           target: ${{ matrix.platform.target }}
-          manylinux: musllinux_1_2
+          manylinux: auto
           args: --release --out dist
       - uses: uraimo/run-on-arch-action@master
         name: Install built wheel


### PR DESCRIPTION
fix(cli): use auto manylinux for aarch64-linux CLI builds


Should fix the failing builds on main
