### PR TITLE
fix(cli): skip installing the wheel when cross-building for Linux ARM

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -107,15 +107,6 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: auto
           args: --release --out dist
-      - uses: uraimo/run-on-arch-action@master
-        name: Install built wheel
-        with:
-          arch: ${{ matrix.platform.arch }}
-          distro: alpine_latest
-          install: |
-            apk add py3-pip
-          run: |
-            pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links hydro_cli/dist/ --force-reinstall
       - name: "Upload wheels"
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
fix(cli): skip installing the wheel when cross-building for Linux ARM
