### PR TITLE
chore: fix lint, format errors for latest nightly version (without updating pinned)

### DIFF
--- a/benches/benches/fork_join.rs
+++ b/benches/benches/fork_join.rs
@@ -54,11 +54,7 @@ fn benchmark_hydroflow(c: &mut Criterion) {
                     send1,
                     send2,
                     |_ctx, recv1, recv2, send1, send2| {
-                        for v in recv1
-                            .take_inner()
-                            .into_iter()
-                            .chain(recv2.take_inner().into_iter())
-                        {
+                        for v in recv1.take_inner().into_iter().chain(recv2.take_inner()) {
                             if v % 2 == 0 {
                                 send1.give(Some(v));
                             } else {

--- a/hydroflow/examples/shopping/driver.rs
+++ b/hydroflow/examples/shopping/driver.rs
@@ -153,7 +153,7 @@ pub(crate) async fn run_driver(opts: Opts) {
             let addr1 = ipv4_resolve("localhost:23430").unwrap();
             let addr2 = ipv4_resolve("localhost:23431").unwrap();
             let addr3 = ipv4_resolve("localhost:23432").unwrap();
-            let server_addrs = vec![addr1, addr2, addr3];
+            let server_addrs = [addr1, addr2, addr3];
 
             // define the server addresses for gossip
             let gossip_addr1 = ipv4_resolve("localhost:23440").unwrap();

--- a/hydroflow/examples/three_clique/main.rs
+++ b/hydroflow/examples/three_clique/main.rs
@@ -36,7 +36,7 @@ pub fn main() {
 
         // post-process: sort fields of each tuple by node ID
         triangle -> map(|(x, y, z)| {
-            let mut v = vec![x, y, z];
+            let mut v = [x, y, z];
             v.sort();
             (v[0], v[1], v[2])
         }) -> for_each(|e| println!("three_clique found: {:?}", e));

--- a/hydroflow/src/scheduled/net/mod.rs
+++ b/hydroflow/src/scheduled/net/mod.rs
@@ -123,7 +123,7 @@ impl Hydroflow {
 
             // TODO(mingwei): queue may grow unbounded? Subtle rate matching concern.
             // TODO(mingwei): put into state system.
-            message_queue.extend(recv.take_inner().into_iter());
+            message_queue.extend(recv.take_inner());
             while !message_queue.is_empty() {
                 if let std::task::Poll::Ready(Ok(())) = Pin::new(&mut writer).poll_ready(&mut cx) {
                     let v = message_queue.pop_front().unwrap();

--- a/hydroflow/src/scheduled/state.rs
+++ b/hydroflow/src/scheduled/state.rs
@@ -12,12 +12,9 @@ pub struct StateHandle<T> {
     pub(crate) state_id: StateId,
     pub(crate) _phantom: PhantomData<*mut T>,
 }
+impl<T> Copy for StateHandle<T> {}
 impl<T> Clone for StateHandle<T> {
     fn clone(&self) -> Self {
-        Self {
-            state_id: self.state_id,
-            _phantom: PhantomData,
-        }
+        *self
     }
 }
-impl<T> Copy for StateHandle<T> {}

--- a/hydroflow/tests/test.rs
+++ b/hydroflow/tests/test.rs
@@ -181,7 +181,7 @@ fn test_cycle() {
         union_rhs,
         union_out,
         |_ctx, recv1, recv2, send| {
-            for v in (recv1.take_inner().into_iter()).chain(recv2.take_inner().into_iter()) {
+            for v in (recv1.take_inner().into_iter()).chain(recv2.take_inner()) {
                 send.give(Some(v));
             }
         },

--- a/hydroflow_lang/build.rs
+++ b/hydroflow_lang/build.rs
@@ -33,8 +33,12 @@ fn generate_op_docs() -> Result<()> {
             .map_err(|syn_err| Error::new(ErrorKind::InvalidData, syn_err))?;
 
         for item in op_parsed.items {
-            let Item::Const(item_const) = item else { continue; };
-            let Expr::Struct(expr_struct) = *item_const.expr else { continue; };
+            let Item::Const(item_const) = item else {
+                continue;
+            };
+            let Expr::Struct(expr_struct) = *item_const.expr else {
+                continue;
+            };
             if identity::<Path>(parse_quote!(OperatorConstraints)) != expr_struct.path {
                 continue;
             }
@@ -44,7 +48,11 @@ fn generate_op_docs() -> Result<()> {
                 .iter()
                 .find(|&field_value| identity::<Member>(parse_quote!(name)) == field_value.member)
                 .expect("Expected `name` field not found.");
-            let Expr::Lit(ExprLit { lit: Lit::Str(op_name), .. }) = &name_field.expr else {
+            let Expr::Lit(ExprLit {
+                lit: Lit::Str(op_name),
+                ..
+            }) = &name_field.expr
+            else {
                 panic!("Unexpected non-literal or non-str `name` field value.")
             };
             let op_name = op_name.value();
@@ -60,11 +68,26 @@ fn generate_op_docs() -> Result<()> {
 
             let mut in_hf_doctest = false;
             for attr in item_const.attrs.iter() {
-                let AttrStyle::Outer = attr.style else { continue; };
-                let Meta::NameValue(MetaNameValue { path, eq_token: _, value }) = &attr.meta else { continue; };
-                let Some("doc") = path.get_ident().map(Ident::to_string).as_deref() else { continue; };
-                let Expr::Lit(ExprLit { attrs: _, lit }) = value else { continue; };
-                let Lit::Str(doc_lit_str) = lit else { continue; };
+                let AttrStyle::Outer = attr.style else {
+                    continue;
+                };
+                let Meta::NameValue(MetaNameValue {
+                    path,
+                    eq_token: _,
+                    value,
+                }) = &attr.meta
+                else {
+                    continue;
+                };
+                let Some("doc") = path.get_ident().map(Ident::to_string).as_deref() else {
+                    continue;
+                };
+                let Expr::Lit(ExprLit { attrs: _, lit }) = value else {
+                    continue;
+                };
+                let Lit::Str(doc_lit_str) = lit else {
+                    continue;
+                };
                 // At this point we know we have a `#[doc = "..."]`.
                 let doc_str = doc_lit_str.value();
                 let doc_str = doc_str.strip_prefix(' ').unwrap_or(&*doc_str);

--- a/hydroflow_lang/src/graph/di_mul_graph.rs
+++ b/hydroflow_lang/src/graph/di_mul_graph.rs
@@ -162,9 +162,13 @@ where
     /// Returns `None` if `vertex` is not in the graph or does not have the right degree in/out.
     pub fn remove_intermediate_vertex(&mut self, vertex: V) -> Option<(E, (E, E))> {
         let preds = self.preds.remove(vertex)?;
-        let &[pred_edge] = &*preds else { return None; };
+        let &[pred_edge] = &*preds else {
+            return None;
+        };
         let succs = self.succs.remove(vertex).unwrap();
-        let &[succ_edge] = &*succs else { return None; };
+        let &[succ_edge] = &*succs else {
+            return None;
+        };
 
         let (src, _v) = self.edges.remove(pred_edge).unwrap();
         let (_v, dst) = self.edges.remove(succ_edge).unwrap();

--- a/hydroflow_lang/src/graph/flat_graph_builder.rs
+++ b/hydroflow_lang/src/graph/flat_graph_builder.rs
@@ -322,7 +322,9 @@ impl FlatGraphBuilder {
         for (node_id, node) in self.flat_graph.nodes() {
             match node {
                 Node::Operator(operator) => {
-                    let Some(op_constraints) = find_op_op_constraints(operator) else { continue };
+                    let Some(op_constraints) = find_op_op_constraints(operator) else {
+                        continue;
+                    };
                     // Check number of args
                     if op_constraints.num_args != operator.args.len() {
                         self.diagnostics.push(Diagnostic::spanned(

--- a/hydroflow_lang/src/graph/hydroflow_graph.rs
+++ b/hydroflow_lang/src/graph/hydroflow_graph.rs
@@ -316,8 +316,12 @@ impl HydroflowGraph {
 
         // Make corresponding operator instance (if `node` is an operator).
         let op_inst_opt = 'oc: {
-            let Node::Operator(operator) = &new_node else { break 'oc None; };
-            let Some(op_constraints) = find_op_op_constraints(operator) else { break 'oc None; };
+            let Node::Operator(operator) = &new_node else {
+                break 'oc None;
+            };
+            let Some(op_constraints) = find_op_op_constraints(operator) else {
+                break 'oc None;
+            };
             let (input_port, output_port) = self.ports.get(edge_id).cloned().unwrap();
             let generics = get_operator_generics(
                 &mut Vec::new(), // TODO(mingwei) diagnostics
@@ -998,7 +1002,9 @@ impl HydroflowGraph {
         let mut sg_varname_nodes =
             SparseSecondaryMap::<GraphSubgraphId, BTreeMap<Varname, BTreeSet<GraphNodeId>>>::new();
         for (node_id, varname) in self.node_varnames.iter() {
-            let Some(sg_id) = self.node_subgraph(node_id) else { continue; };
+            let Some(sg_id) = self.node_subgraph(node_id) else {
+                continue;
+            };
             let varname_map = sg_varname_nodes.entry(sg_id).unwrap().or_default();
             varname_map
                 .entry(varname.clone())

--- a/hydroflow_lang/src/graph/ops/demux.rs
+++ b/hydroflow_lang/src/graph/ops/demux.rs
@@ -201,7 +201,7 @@ fn extract_closure_idents(arg2: &Pat) -> HashMap<Ident, usize> {
         match tt {
             TokenTree::Group(group) => {
                 let a = stack.len();
-                stack.extend(group.stream().into_iter());
+                stack.extend(group.stream());
                 let b = stack.len();
                 stack[a..b].reverse();
             }

--- a/lattices/src/seq.rs
+++ b/lattices/src/seq.rs
@@ -65,7 +65,7 @@ where
             changed = true;
         }
         // Merge intersecting indices.
-        for (self_val, other_val) in self.seq.iter_mut().zip(other.seq.into_iter()) {
+        for (self_val, other_val) in self.seq.iter_mut().zip(other.seq) {
             changed |= self_val.merge(other_val);
         }
         changed

--- a/multiplatform_test/src/lib.rs
+++ b/multiplatform_test/src/lib.rs
@@ -141,7 +141,9 @@ fn multiplatform_test_impl(
         output.extend(body);
     } else {
         let mut body_head = body.into_iter().collect::<Vec<_>>();
-        let Some(proc_macro2::TokenTree::Group(body_code)) = body_head.pop() else { panic!(); };
+        let Some(proc_macro2::TokenTree::Group(body_code)) = body_head.pop() else {
+            panic!();
+        };
 
         output.extend(body_head);
         output.extend(quote! {

--- a/pusherator/src/lib.rs
+++ b/pusherator/src/lib.rs
@@ -235,7 +235,7 @@ mod tests {
         let mut right = Vec::new();
 
         let pivot = Pivot::new(
-            a.into_iter().chain(b.into_iter()),
+            a.into_iter().chain(b),
             Partition::new(
                 |x| x % 2 == 0,
                 ForEach::new(|x| left.push(x)),


### PR DESCRIPTION
rustfmt formats let-else statements
clippy lints unnecessary vecs, unnecessary into_iter calls
In nightly version (d9c13cd45 2023-07-05)