### PR TITLE
feat(hydroflow): add `iter_batches_stream` util to break up iterator into per-tick batches

### DIFF
--- a/hydroflow/tests/surface_codegen.rs
+++ b/hydroflow/tests/surface_codegen.rs
@@ -769,3 +769,20 @@ pub fn test_assert_failures() {
     })
     .is_err());
 }
+
+#[multiplatform_test]
+pub fn test_iter_stream_batches() {
+    const ITEMS: usize = 100;
+    const BATCH: usize = 5;
+    let stream = hydroflow::util::iter_batches_stream(0..ITEMS, BATCH);
+
+    // expect 5 items per tick.
+    let expected: Vec<_> = (0..ITEMS).map(|n| (n / BATCH, n)).collect();
+
+    let mut df = hydroflow_syntax! {
+        source_stream(stream)
+            -> map(|x| (context.current_tick(), x))
+            -> assert_eq(expected);
+    };
+    df.run_available();
+}

--- a/hydroflow_lang/src/graph/ops/assert_eq.rs
+++ b/hydroflow_lang/src/graph/ops/assert_eq.rs
@@ -59,14 +59,14 @@ pub const ASSERT_EQ: OperatorConstraints = OperatorConstraints {
         let args = &op_inst.arguments[0];
 
         let inspect_fn = parse_quote_spanned! {op_span=>
-            |x| {
+            |__item| {
                 // This is to help constrain the types so that type inference works nicely.
-                fn __constrain_types<T>(array: &impl std::ops::Index<usize, Output = T>, index: usize) -> &T {
+                fn __constrain_types<T>(array: &impl ::std::ops::Index<usize, Output = T>, index: usize) -> &T {
                     &array[index]
                 }
 
-                let __index = #context.state_ref(#assert_index_ident).take();
-                assert_eq!(__constrain_types(&#args, __index), x);
+                let __index = #context.state_ref(#assert_index_ident).get();
+                ::std::assert_eq!(__constrain_types(&#args, __index), __item, "Item (right) at index {} does not equal expected (left).", __index);
                 #context.state_ref(#assert_index_ident).set(__index + 1);
             }
         };


### PR DESCRIPTION
* Also tightens up a bit of `assert_eq`'s code