### PR TITLE
refactor(lattices)!: Rename `Seq` -> `VecUnion`

### DIFF
--- a/lattices/README.md
+++ b/lattices/README.md
@@ -27,12 +27,12 @@ Take a look at the [`lattice` rustdocs](https://hydro-project.github.io/hydroflo
 
 `lattices` provides implementations of common lattice types:
 * [`Min<T>`] and [`Max<T>`] - totally-orderd lattices.
-* [`set_union::SetUnion`] - set-union lattice of scalar values.
-* [`map_union::MapUnion`] - scalar keys with nested lattice values.
+* [`set_union::SetUnion<T>`] - set-union lattice of scalar values.
+* [`map_union::MapUnion<K, Lat>`] - scalar keys with nested lattice values.
+* [`VecUnion<Lat>`] - growing `Vec` of nested lattices, like `MapUnion<<usize, Lat>>` but without missing entries.
 * [`WithBot<Lat>`] - wraps a lattice in `Option` with `None` as the new bottom value.
 * [`WithTop<Lat>`] - wraps a lattice in `Option` with `None` as the new _top_ value.
 * [`Pair<LatA, LatB>`] - product of two nested lattices.
-* [`Seq<Lat>`] - growing `Vec` of nested lattices, like `MapUnion<<usize, Lat>>` but without missing entries.
 * [`DomPair<LatKey, LatVal>`]* - a versioned pair where the `LatKey` dominates the `LatVal`.
 * [`Conflict<T>`]* - adds a "conflict" top to domain `T`. Merging inequal `T`s results in top.
 * [`Point<T, *>`]* - a single "point lattice" value which cannot be merged with any inequal value.

--- a/lattices/src/lib.rs
+++ b/lattices/src/lib.rs
@@ -13,10 +13,10 @@ pub mod map_union;
 mod ord;
 mod pair;
 mod point;
-mod seq;
 pub mod set_union;
 pub mod test;
 mod unit;
+mod vec_union;
 mod with_bot;
 mod with_top;
 
@@ -25,7 +25,7 @@ pub use dom_pair::DomPair;
 pub use ord::{Max, Min};
 pub use pair::Pair;
 pub use point::Point;
-pub use seq::Seq;
+pub use vec_union::VecUnion;
 pub use with_bot::WithBot;
 pub use with_top::WithTop;
 

--- a/lattices/src/vec_union.rs
+++ b/lattices/src/vec_union.rs
@@ -4,108 +4,108 @@ use cc_traits::Iter;
 
 use crate::{IsBot, LatticeFrom, LatticeOrd, Merge};
 
-/// Sequence compound lattice.
+/// Vec-union compound lattice.
 ///
 /// Contains any number of `Lat` sub-lattices. Sub-lattices are indexed starting at zero, merging
 /// combines corresponding sub-lattices and keeps any excess.
 ///
 /// Similar to [`MapUnion<<usize, Lat>>`](super::map_union::MapUnion) but requires the key indices
-/// start at `0` and have no gaps.
+/// start with `0`, `1`, `2`, etc: i.e. integers starting at zero with no gaps.
 #[derive(Clone, Debug, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Seq<Lat> {
-    seq: Vec<Lat>,
+pub struct VecUnion<Lat> {
+    vec: Vec<Lat>,
 }
 
-impl<Lat> Seq<Lat> {
-    /// Create a new `Seq` from a `Vec` of `Lat` instances.
-    pub fn new(seq: Vec<Lat>) -> Self {
-        Self { seq }
+impl<Lat> VecUnion<Lat> {
+    /// Create a new `VecUnion` from a `Vec` of `Lat` instances.
+    pub fn new(vec: Vec<Lat>) -> Self {
+        Self { vec }
     }
 
-    /// Create a new `Seq` from an `Into<Vec<Lat>>`.
-    pub fn new_from(seq: impl Into<Vec<Lat>>) -> Self {
-        Self::new(seq.into())
+    /// Create a new `VecUnion` from an `Into<Vec<Lat>>`.
+    pub fn new_from(vec: impl Into<Vec<Lat>>) -> Self {
+        Self::new(vec.into())
     }
 
     /// Reveal the inner value as a shared reference.
     pub fn as_reveal_ref(&self) -> &Vec<Lat> {
-        &self.seq
+        &self.vec
     }
 
     /// Reveal the inner value as an exclusive reference.
     pub fn as_reveal_mut(&mut self) -> &mut Vec<Lat> {
-        &mut self.seq
+        &mut self.vec
     }
 
     /// Gets the inner by value, consuming self.
     pub fn into_reveal(self) -> Vec<Lat> {
-        self.seq
+        self.vec
     }
 }
 
-impl<Lat> Default for Seq<Lat> {
+impl<Lat> Default for VecUnion<Lat> {
     fn default() -> Self {
         Self {
-            seq: Default::default(),
+            vec: Default::default(),
         }
     }
 }
 
-impl<LatSelf, LatOther> Merge<Seq<LatOther>> for Seq<LatSelf>
+impl<LatSelf, LatOther> Merge<VecUnion<LatOther>> for VecUnion<LatSelf>
 where
     LatSelf: Merge<LatOther> + LatticeFrom<LatOther>,
 {
-    fn merge(&mut self, mut other: Seq<LatOther>) -> bool {
+    fn merge(&mut self, mut other: VecUnion<LatOther>) -> bool {
         let mut changed = false;
         // Extend `self` if `other` is longer.
-        if self.seq.len() < other.seq.len() {
-            self.seq
-                .extend(other.seq.drain(self.seq.len()..).map(LatSelf::lattice_from));
+        if self.vec.len() < other.vec.len() {
+            self.vec
+                .extend(other.vec.drain(self.vec.len()..).map(LatSelf::lattice_from));
             changed = true;
         }
         // Merge intersecting indices.
-        for (self_val, other_val) in self.seq.iter_mut().zip(other.seq) {
+        for (self_val, other_val) in self.vec.iter_mut().zip(other.vec) {
             changed |= self_val.merge(other_val);
         }
         changed
     }
 }
 
-impl<LatSelf, LatOther> LatticeFrom<Seq<LatOther>> for Seq<LatSelf>
+impl<LatSelf, LatOther> LatticeFrom<VecUnion<LatOther>> for VecUnion<LatSelf>
 where
     LatSelf: LatticeFrom<LatOther>,
 {
-    fn lattice_from(other: Seq<LatOther>) -> Self {
-        Self::new(other.seq.into_iter().map(LatSelf::lattice_from).collect())
+    fn lattice_from(other: VecUnion<LatOther>) -> Self {
+        Self::new(other.vec.into_iter().map(LatSelf::lattice_from).collect())
     }
 }
 
-impl<LatSelf, LatOther> PartialEq<Seq<LatOther>> for Seq<LatSelf>
+impl<LatSelf, LatOther> PartialEq<VecUnion<LatOther>> for VecUnion<LatSelf>
 where
     LatSelf: PartialEq<LatOther>,
 {
-    fn eq(&self, other: &Seq<LatOther>) -> bool {
-        if self.seq.len() != other.seq.len() {
+    fn eq(&self, other: &VecUnion<LatOther>) -> bool {
+        if self.vec.len() != other.vec.len() {
             return false;
         }
         return self
-            .seq
+            .vec
             .iter()
-            .zip(other.seq.iter())
+            .zip(other.vec.iter())
             .all(|(val_self, val_other)| val_self == val_other);
     }
 }
 
-impl<LatSelf, LatOther> PartialOrd<Seq<LatOther>> for Seq<LatSelf>
+impl<LatSelf, LatOther> PartialOrd<VecUnion<LatOther>> for VecUnion<LatSelf>
 where
     LatSelf: PartialOrd<LatOther>,
 {
-    fn partial_cmp(&self, other: &Seq<LatOther>) -> Option<Ordering> {
-        let (self_len, other_len) = (self.seq.len(), other.seq.len());
+    fn partial_cmp(&self, other: &VecUnion<LatOther>) -> Option<Ordering> {
+        let (self_len, other_len) = (self.vec.len(), other.vec.len());
         let mut self_any_greater = other_len < self_len;
         let mut other_any_greater = self_len < other_len;
-        for (self_val, other_val) in self.seq.iter().zip(other.seq.iter()) {
+        for (self_val, other_val) in self.vec.iter().zip(other.vec.iter()) {
             match self_val.partial_cmp(other_val) {
                 None => {
                     return None;
@@ -131,14 +131,14 @@ where
         }
     }
 }
-impl<LatSelf, LatOther> LatticeOrd<Seq<LatOther>> for Seq<LatSelf> where
-    Self: PartialOrd<Seq<LatOther>>
+impl<LatSelf, LatOther> LatticeOrd<VecUnion<LatOther>> for VecUnion<LatSelf> where
+    Self: PartialOrd<VecUnion<LatOther>>
 {
 }
 
-impl<Lat> IsBot for Seq<Lat> {
+impl<Lat> IsBot for VecUnion<Lat> {
     fn is_bot(&self) -> bool {
-        self.seq.is_empty()
+        self.vec.is_empty()
     }
 }
 
@@ -153,29 +153,31 @@ mod test {
 
     #[test]
     fn basic() {
-        let mut my_seq_a = Seq::<Max<usize>>::default();
-        let my_seq_b = Seq::new(vec![Max::new(9), Max::new(4), Max::new(5)]);
-        let my_seq_c = Seq::new(vec![Max::new(2), Max::new(5)]);
+        let mut my_vec_a = VecUnion::<Max<usize>>::default();
+        let my_vec_b = VecUnion::new(vec![Max::new(9), Max::new(4), Max::new(5)]);
+        let my_vec_c = VecUnion::new(vec![Max::new(2), Max::new(5)]);
 
-        assert!(my_seq_a.merge(my_seq_b.clone()));
-        assert!(!my_seq_a.merge(my_seq_b));
-        assert!(my_seq_a.merge(my_seq_c.clone()));
-        assert!(!my_seq_a.merge(my_seq_c));
+        assert!(my_vec_a.merge(my_vec_b.clone()));
+        assert!(!my_vec_a.merge(my_vec_b));
+        assert!(my_vec_a.merge(my_vec_c.clone()));
+        assert!(!my_vec_a.merge(my_vec_c));
     }
 
     #[test]
     fn consistency() {
-        let mut test_vec = vec![Seq::new(vec![] as Vec<SetUnionHashSet<_>>)];
+        let mut test_vec = vec![VecUnion::new(vec![] as Vec<SetUnionHashSet<_>>)];
 
         let vals = [vec![], vec![0], vec![1], vec![0, 1]]
             .map(HashSet::from_iter)
             .map(SetUnionHashSet::new);
 
         test_vec.extend(
-            cartesian_power::<_, 1>(&vals).map(|row| Seq::new(row.into_iter().cloned().collect())),
+            cartesian_power::<_, 1>(&vals)
+                .map(|row| VecUnion::new(row.into_iter().cloned().collect())),
         );
         test_vec.extend(
-            cartesian_power::<_, 2>(&vals).map(|row| Seq::new(row.into_iter().cloned().collect())),
+            cartesian_power::<_, 2>(&vals)
+                .map(|row| VecUnion::new(row.into_iter().cloned().collect())),
         );
 
         check_all(&test_vec);


### PR DESCRIPTION
BREAKING CHANGE: Renames public struct `Seq` -> `VecUnion`