### PR TITLE
fix: livelock in deadlock detector #810

### DIFF
--- a/hydroflow/examples/deadlock_detector/peer.rs
+++ b/hydroflow/examples/deadlock_detector/peer.rs
@@ -31,10 +31,10 @@ pub(crate) async fn run_detector(opts: Opts, peer_list: Vec<String>) {
         inbound_chan = source_stream(inbound) -> map(deserialize_msg::<Message>);
 
         // setup gossip channel to all peers. gen_bool chooses True with the odds passed in.
-        gossip_join = cross_join::<'static>()
+        gossip_join = cross_join::<'tick>()
             -> filter(|_| gen_bool(0.8)) -> outbound_chan;
-        gossip = map(identity) -> [0]gossip_join;
-        peers[1] -> [1]gossip_join;
+        gossip = map(identity) -> persist() -> [0]gossip_join;
+        peers[1] -> persist() -> [1]gossip_join;
         peers[2] -> for_each(|s| println!("Peer: {:?}", s));
 
         // prompt for input


### PR DESCRIPTION
replace 'static join with explicit persist operators that replay. workaround for #519 