### PR TITLE
feat(lattices)!: Add bottom collapsing, implement `IsBot` for all lattice types

### DIFF
--- a/lattices/src/collections.rs
+++ b/lattices/src/collections.rs
@@ -3,7 +3,7 @@
 use std::borrow::Borrow;
 use std::hash::Hash;
 
-use crate::cc_traits::{
+use cc_traits::{
     covariant_item_mut, covariant_item_ref, covariant_key_ref, Collection, CollectionMut,
     CollectionRef, Get, GetKeyValue, GetKeyValueMut, GetMut, Iter, IterMut, Keyed, KeyedRef, Len,
     MapIter, MapIterMut,
@@ -405,6 +405,225 @@ impl<K, V> MapIterMut for SingletonMap<K, V> {
 
     fn iter_mut(&mut self) -> Self::IterMut<'_> {
         std::iter::once((&self.0, &mut self.1))
+    }
+}
+
+/// A wrapper around `Option`, representing either a singleton or empty set.
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct OptionSet<T>(pub Option<T>);
+impl<T> Default for OptionSet<T> {
+    fn default() -> Self {
+        Self(None)
+    }
+}
+impl<T> IntoIterator for OptionSet<T> {
+    type Item = T;
+    type IntoIter = std::option::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+impl<T, U> From<U> for OptionSet<T>
+where
+    U: Into<Option<T>>,
+{
+    fn from(value: U) -> Self {
+        Self(value.into())
+    }
+}
+impl<T> Collection for OptionSet<T> {
+    type Item = T;
+}
+impl<T> Len for OptionSet<T> {
+    fn len(&self) -> usize {
+        self.0.is_some() as usize
+    }
+}
+impl<T> CollectionRef for OptionSet<T> {
+    type ItemRef<'a> = &'a Self::Item
+    where
+        Self: 'a;
+
+    covariant_item_ref!();
+}
+impl<'a, Q, T> Get<&'a Q> for OptionSet<T>
+where
+    T: Borrow<Q>,
+    Q: Eq + ?Sized,
+{
+    fn get(&self, key: &'a Q) -> Option<Self::ItemRef<'_>> {
+        self.0.as_ref().filter(|inner| key == (**inner).borrow())
+    }
+}
+impl<T> CollectionMut for OptionSet<T> {
+    type ItemMut<'a> = &'a mut T
+    where
+        Self: 'a;
+
+    covariant_item_mut!();
+}
+impl<'a, Q, T> GetMut<&'a Q> for OptionSet<T>
+where
+    T: Borrow<Q>,
+    Q: Eq + ?Sized,
+{
+    fn get_mut(&mut self, key: &'a Q) -> Option<Self::ItemMut<'_>> {
+        self.0.as_mut().filter(|inner| key == (**inner).borrow())
+    }
+}
+impl<T> Iter for OptionSet<T> {
+    type Iter<'a> = std::option::Iter<'a, T>
+	where
+		Self: 'a;
+
+    fn iter(&self) -> Self::Iter<'_> {
+        self.0.iter()
+    }
+}
+impl<T> IterMut for OptionSet<T> {
+    type IterMut<'a> = std::option::IterMut<'a, T>
+    where
+        Self: 'a;
+
+    fn iter_mut(&mut self) -> Self::IterMut<'_> {
+        self.0.iter_mut()
+    }
+}
+
+/// A key-value entry wrapper around `Option<(K, V)>` representing a singleton or empty map.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct OptionMap<K, V>(pub Option<(K, V)>);
+impl<K, V> Default for OptionMap<K, V> {
+    fn default() -> Self {
+        Self(None)
+    }
+}
+impl<K, V> IntoIterator for OptionMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = std::option::IntoIter<(K, V)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+impl<K, V, U> From<U> for OptionMap<K, V>
+where
+    U: Into<Option<(K, V)>>,
+{
+    fn from(kv: U) -> Self {
+        Self(kv.into())
+    }
+}
+impl<K, V> Collection for OptionMap<K, V> {
+    type Item = V;
+}
+impl<K, V> Len for OptionMap<K, V> {
+    fn len(&self) -> usize {
+        self.0.is_some() as usize
+    }
+}
+impl<K, V> CollectionRef for OptionMap<K, V> {
+    type ItemRef<'a> = &'a Self::Item
+    where
+        Self: 'a;
+
+    covariant_item_ref!();
+}
+impl<'a, Q, K, V> Get<&'a Q> for OptionMap<K, V>
+where
+    K: Borrow<Q>,
+    Q: Eq + ?Sized,
+{
+    fn get(&self, key: &'a Q) -> Option<Self::ItemRef<'_>> {
+        self.0
+            .as_ref()
+            .filter(|(k, _v)| key == k.borrow())
+            .map(|(_k, v)| v)
+    }
+}
+impl<K, V> CollectionMut for OptionMap<K, V> {
+    type ItemMut<'a> = &'a mut Self::Item
+    where
+        Self: 'a;
+
+    covariant_item_mut!();
+}
+impl<'a, Q, K, V> GetMut<&'a Q> for OptionMap<K, V>
+where
+    K: Borrow<Q>,
+    Q: Eq + ?Sized,
+{
+    fn get_mut(&mut self, key: &'a Q) -> Option<Self::ItemMut<'_>> {
+        self.0
+            .as_mut()
+            .filter(|(k, _v)| key == k.borrow())
+            .map(|(_k, v)| v)
+    }
+}
+impl<K, V> Keyed for OptionMap<K, V> {
+    type Key = K;
+}
+impl<K, V> KeyedRef for OptionMap<K, V> {
+    type KeyRef<'a> = &'a Self::Key
+	where
+		Self: 'a;
+
+    covariant_key_ref!();
+}
+impl<'a, Q, K, V> GetKeyValue<&'a Q> for OptionMap<K, V>
+where
+    K: Borrow<Q>,
+    Q: Eq + ?Sized,
+{
+    fn get_key_value(&self, key: &'a Q) -> Option<(Self::KeyRef<'_>, Self::ItemRef<'_>)> {
+        self.0
+            .as_ref()
+            .filter(|(k, _v)| key == k.borrow())
+            .map(|(k, v)| (k, v))
+    }
+}
+impl<'a, Q, K, V> GetKeyValueMut<&'a Q> for OptionMap<K, V>
+where
+    K: Borrow<Q>,
+    Q: Eq + ?Sized,
+{
+    fn get_key_value_mut(&mut self, key: &'a Q) -> Option<(Self::KeyRef<'_>, Self::ItemMut<'_>)> {
+        self.0
+            .as_mut()
+            .filter(|(k, _v)| key == k.borrow())
+            .map(|(k, v)| (&*k, v))
+    }
+}
+impl<K, V> Iter for OptionMap<K, V> {
+    type Iter<'a> = std::option::IntoIter<&'a V>
+	where
+		Self: 'a;
+
+    fn iter(&self) -> Self::Iter<'_> {
+        self.0.as_ref().map(|(_k, v)| v).into_iter()
+    }
+}
+// impl<K, V> SimpleKeyedRef for OptionMap<K, V> {
+//     simple_keyed_ref!();
+// }
+impl<K, V> MapIter for OptionMap<K, V> {
+    type Iter<'a> = std::option::IntoIter<(&'a K, &'a V)>
+	where
+		Self: 'a;
+
+    fn iter(&self) -> Self::Iter<'_> {
+        self.0.as_ref().map(|(k, v)| (k, v)).into_iter()
+    }
+}
+impl<K, V> MapIterMut for OptionMap<K, V> {
+    type IterMut<'a> = std::option::IntoIter<(&'a K, &'a mut V)>
+	where
+		Self: 'a;
+
+    fn iter_mut(&mut self) -> Self::IterMut<'_> {
+        self.0.as_mut().map(|(k, v)| (&*k, v)).into_iter()
     }
 }
 

--- a/lattices/src/conflict.rs
+++ b/lattices/src/conflict.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering::{self, *};
 
-use crate::{IsTop, LatticeFrom, LatticeOrd, Merge};
+use crate::{IsBot, IsTop, LatticeFrom, LatticeOrd, Merge};
 
 /// A `Conflict` lattice, stores a single instance of `T` and goes to a "conflict" state (`None`)
 /// if inequal `T` instances are merged together.
@@ -91,6 +91,12 @@ where
     }
 }
 
+impl<T> IsBot for Conflict<T> {
+    fn is_bot(&self) -> bool {
+        false
+    }
+}
+
 impl<T> IsTop for Conflict<T> {
     fn is_top(&self) -> bool {
         self.0.is_none()
@@ -100,10 +106,7 @@ impl<T> IsTop for Conflict<T> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test::{
-        check_all, check_lattice_ord, check_lattice_properties, check_lattice_top,
-        check_partial_ord_properties,
-    };
+    use crate::test::check_all;
     use crate::WithBot;
 
     #[test]
@@ -113,11 +116,7 @@ mod test {
             Conflict::new_from("bar"),
             Conflict::new(None),
         ];
-        check_lattice_ord(items);
-        check_partial_ord_properties(items);
-        check_lattice_properties(items);
-        // check_lattice_bot(items);
-        check_lattice_top(items);
+        check_all(items);
     }
 
     #[test]
@@ -129,6 +128,5 @@ mod test {
             WithBot::new(None),
         ];
         check_all(items);
-        check_lattice_top(items);
     }
 }

--- a/lattices/src/lib.rs
+++ b/lattices/src/lib.rs
@@ -29,6 +29,12 @@ pub use vec_union::VecUnion;
 pub use with_bot::WithBot;
 pub use with_top::WithTop;
 
+/// Alias trait for lattice types.
+#[sealed]
+pub trait Lattice: Sized + Merge<Self> + LatticeOrd + NaiveLatticeOrd + IsBot + IsTop {}
+#[sealed]
+impl<T> Lattice for T where T: Sized + Merge<Self> + LatticeOrd + NaiveLatticeOrd + IsBot + IsTop {}
+
 /// Trait for lattice merge (AKA "join" or "least upper bound").
 pub trait Merge<Other> {
     /// Merge `other` into the `self` lattice.
@@ -99,12 +105,16 @@ pub trait LatticeFrom<Other> {
 /// Trait to check if a lattice instance is bottom (⊥).
 pub trait IsBot {
     /// Returns if `self` is lattice bottom (⊥).
+    ///
+    /// Must be consistent with equality, any element equal to bottom is also considered to be bottom.
     fn is_bot(&self) -> bool;
 }
 
 /// Trait to check if a lattice instance is top (⊤) and therefore cannot change any futher.
 pub trait IsTop {
     /// Returns if `self` is lattice top (⊤).
+    ///
+    /// Must be consistent with equality, any element equal to top is also considered to be top.
     fn is_top(&self) -> bool;
 }
 
@@ -116,7 +126,7 @@ pub trait IsTop {
 /// lower bound (GLB or "meet") of bottom.
 pub trait Atomize: Merge<Self::Atom> {
     /// The type of atoms for this lattice.
-    type Atom: 'static;
+    type Atom: 'static + IsBot;
 
     /// The iter type iterating the antichain atoms.
     type AtomIter: 'static + Iterator<Item = Self::Atom>;

--- a/lattices/src/ord.rs
+++ b/lattices/src/ord.rs
@@ -233,7 +233,7 @@ mod test {
     use std::cmp::Ordering::*;
 
     use super::*;
-    use crate::test::{check_all, check_lattice_top};
+    use crate::test::check_all;
 
     #[test]
     fn ordering() {
@@ -266,7 +266,6 @@ mod test {
             Max::new(i32::MAX),
         ];
         check_all(items);
-        check_lattice_top(items);
     }
 
     #[test]
@@ -278,6 +277,5 @@ mod test {
             Min::new(i32::MAX),
         ];
         check_all(items);
-        check_lattice_top(items);
     }
 }

--- a/lattices/src/pair.rs
+++ b/lattices/src/pair.rs
@@ -131,7 +131,7 @@ mod test {
 
     use super::*;
     use crate::set_union::SetUnionHashSet;
-    use crate::test::{check_all, check_lattice_top};
+    use crate::test::check_all;
     use crate::WithTop;
 
     #[test]
@@ -176,6 +176,5 @@ mod test {
         }
 
         check_all(&test_vec);
-        check_lattice_top(&test_vec);
     }
 }

--- a/lattices/src/set_union.rs
+++ b/lattices/src/set_union.rs
@@ -4,8 +4,8 @@ use std::cmp::Ordering::{self, *};
 use std::collections::{BTreeSet, HashSet};
 
 use crate::cc_traits::{Iter, Len, Set};
-use crate::collections::{ArraySet, SingletonSet};
-use crate::{Atomize, IsBot, LatticeFrom, LatticeOrd, Merge};
+use crate::collections::{ArraySet, OptionSet, SingletonSet};
+use crate::{Atomize, IsBot, IsTop, LatticeFrom, LatticeOrd, Merge};
 
 /// Set-union lattice.
 ///
@@ -123,22 +123,28 @@ where
     }
 }
 
+impl<Set> IsTop for SetUnion<Set> {
+    fn is_top(&self) -> bool {
+        false
+    }
+}
+
 impl<Set, Item> Atomize for SetUnion<Set>
 where
     Set: Len + IntoIterator<Item = Item> + Extend<Item>,
     Set::IntoIter: 'static,
     Item: 'static,
 {
-    type Atom = SetUnionOption<Item>;
+    type Atom = SetUnionOptionSet<Item>;
 
     // TODO: use impl trait.
     type AtomIter = Box<dyn Iterator<Item = Self::Atom>>;
 
     fn atomize(self) -> Self::AtomIter {
         if self.0.is_empty() {
-            Box::new(std::iter::once(SetUnionOption::default()))
+            Box::new(std::iter::once(SetUnionOptionSet::default()))
         } else {
-            Box::new(self.0.into_iter().map(SetUnionOption::new_from))
+            Box::new(self.0.into_iter().map(SetUnionOptionSet::new_from))
         }
     }
 }
@@ -159,7 +165,7 @@ pub type SetUnionArray<Item, const N: usize> = SetUnion<ArraySet<Item, N>>;
 pub type SetUnionSingletonSet<Item> = SetUnion<SingletonSet<Item>>;
 
 /// [`Option`]-backed [`SetUnion`] lattice.
-pub type SetUnionOption<Item> = SetUnion<Option<Item>>;
+pub type SetUnionOptionSet<Item> = SetUnion<OptionSet<Item>>;
 
 #[cfg(test)]
 mod test {

--- a/lattices/src/test.rs
+++ b/lattices/src/test.rs
@@ -2,17 +2,16 @@
 
 use std::fmt::Debug;
 
-use crate::{Atomize, IsBot, IsTop, LatticeOrd, Merge, NaiveLatticeOrd};
+use crate::{Atomize, IsBot, IsTop, Lattice, LatticeOrd, Merge, NaiveLatticeOrd};
 
 /// Helper which calls [`check_lattice_ord`], [`check_partial_ord_properties`],
 /// [`check_lattice_properties`], and [`check_lattice_bot`].
-pub fn check_all<T: LatticeOrd + NaiveLatticeOrd + Merge<T> + IsBot + Clone + Eq + Debug>(
-    items: &[T],
-) {
+pub fn check_all<T: Lattice + Clone + Eq + Debug>(items: &[T]) {
     check_lattice_ord(items);
     check_partial_ord_properties(items);
     check_lattice_properties(items);
     check_lattice_bot(items);
+    check_lattice_top(items);
 }
 
 /// Check that the lattice's `PartialOrd` implementation agrees with the `NaiveLatticeOrd` partial
@@ -140,24 +139,24 @@ pub fn check_lattice_properties<T: Merge<T> + Clone + Eq + Debug>(items: &[T]) {
 }
 
 /// Checks that the item which is bot is less than (or equal to) all other items.
-pub fn check_lattice_bot<T: IsBot + LatticeOrd>(items: &[T]) {
-    let bot = items
-        .iter()
-        .find(|&x| IsBot::is_bot(x))
-        .expect("Expected `items` to contain bottom.");
+pub fn check_lattice_bot<T: IsBot + LatticeOrd + Debug>(items: &[T]) {
+    let Some(bot) = items.iter().find(|&x| IsBot::is_bot(x)) else {
+        return;
+    };
     for x in items {
         assert!(bot <= x);
+        assert_eq!(bot == x, x.is_bot(), "{:?}", x);
     }
 }
 
 /// Checks that the item which is top is greater than (or equal to) all other items.
-pub fn check_lattice_top<T: IsTop + LatticeOrd>(items: &[T]) {
-    let top = items
-        .iter()
-        .find(|&x| IsTop::is_top(x))
-        .expect("Expected `items` to contain top.");
+pub fn check_lattice_top<T: IsTop + LatticeOrd + Debug>(items: &[T]) {
+    let Some(top) = items.iter().find(|&x| IsTop::is_top(x)) else {
+        return;
+    };
     for x in items {
         assert!(x <= top);
+        assert_eq!(top == x, x.is_top(), "{:?}", x);
     }
 }
 

--- a/lattices/src/vec_union.rs
+++ b/lattices/src/vec_union.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering::{self, *};
 
 use cc_traits::Iter;
 
-use crate::{IsBot, LatticeFrom, LatticeOrd, Merge};
+use crate::{IsBot, IsTop, LatticeFrom, LatticeOrd, Merge};
 
 /// Vec-union compound lattice.
 ///
@@ -139,6 +139,12 @@ impl<LatSelf, LatOther> LatticeOrd<VecUnion<LatOther>> for VecUnion<LatSelf> whe
 impl<Lat> IsBot for VecUnion<Lat> {
     fn is_bot(&self) -> bool {
         self.vec.is_empty()
+    }
+}
+
+impl<Lat> IsTop for VecUnion<Lat> {
+    fn is_top(&self) -> bool {
+        false
     }
 }
 

--- a/lattices/src/with_top.rs
+++ b/lattices/src/with_top.rs
@@ -115,9 +115,12 @@ where
     }
 }
 
-impl<Inner> IsTop for WithTop<Inner> {
+impl<Inner> IsTop for WithTop<Inner>
+where
+    Inner: IsTop,
+{
     fn is_top(&self) -> bool {
-        self.0.is_none()
+        self.0.as_ref().map_or(true, IsTop::is_top)
     }
 }
 


### PR DESCRIPTION
* `WithBot(Some(BOTTOM))` and `WithBot(None)` are now considered to be equal. Also, `MapUnion({})` and `MapUnion({key: BOTTOM})` are considered to be equal.
* `check_lattice_bot/top` now check that `is_bot` and `is_top` must be consistent between all equal elements

BREAKING CHANGE:
* `Set/MapUnionOption` renamed to `Set/MapUnionOptionSet/Map`
* `MapUnion` and `WithBot` containing nested bottom value is now considered to be bottom as well.