### PR TITLE
refactor(lattices): Change `Atomize` to require returning empty iff lattice is bottom

### DIFF
--- a/lattices/src/lib.rs
+++ b/lattices/src/lib.rs
@@ -133,7 +133,8 @@ pub trait Atomize: Merge<Self::Atom> {
 
     /// Atomize self: convert into an iter of atoms.
     ///
-    /// Must always return at least one value.
+    /// The returned iterator should be empty if and only if `self.is_bot()` is true.
+    /// All atoms in the returned iterator should have `self.is_bot()` be false.
     ///
     /// Returned values must merge to reform a value equal to the original `self`.
     fn atomize(self) -> Self::AtomIter;

--- a/lattices/src/map_union.rs
+++ b/lattices/src/map_union.rs
@@ -233,14 +233,10 @@ where
     type AtomIter = Box<dyn Iterator<Item = Self::Atom>>;
 
     fn atomize(self) -> Self::AtomIter {
-        if self.0.is_empty() {
-            Box::new(std::iter::once(MapUnionOptionMap::default()))
-        } else {
-            Box::new(self.0.into_iter().flat_map(|(k, val)| {
-                val.atomize()
-                    .map(move |v| MapUnionOptionMap::new_from((k.clone(), v)))
-            }))
-        }
+        Box::new(self.0.into_iter().flat_map(|(k, val)| {
+            val.atomize()
+                .map(move |v| MapUnionOptionMap::new_from((k.clone(), v)))
+        }))
     }
 }
 

--- a/lattices/src/set_union.rs
+++ b/lattices/src/set_union.rs
@@ -141,11 +141,7 @@ where
     type AtomIter = Box<dyn Iterator<Item = Self::Atom>>;
 
     fn atomize(self) -> Self::AtomIter {
-        if self.0.is_empty() {
-            Box::new(std::iter::once(SetUnionOptionSet::default()))
-        } else {
-            Box::new(self.0.into_iter().map(SetUnionOptionSet::new_from))
-        }
+        Box::new(self.0.into_iter().map(SetUnionOptionSet::new_from))
     }
 }
 


### PR DESCRIPTION
Previously was the opposite, `Atomize` always had to return non-empty.

Not breaking since `Atomize` has not yet been published.