### PR TITLE
fix(docs): move warning about Hydro Deploy docs to the top of the intro

### DIFF
--- a/docs/docs/deploy/index.md
+++ b/docs/docs/deploy/index.md
@@ -3,6 +3,13 @@ sidebar_position: 1
 ---
 
 # Introduction
+
+:::caution
+
+Hydro Deploy is currently in alpha. Although it has already been used for large-scale distributed experiments within the Hydro research group, the API is rapidly changing and may come with some rough edges, and many pieces are not yet documented. Please reach out if you run into any issues!
+
+:::
+
 Hydro comes equipped with a built-in deployment system, **Hydro Deploy**, which allows you to deploy your Hydro app to a variety of platforms. With Hydro Deploy, you can spin up complex services with just a few lines of Python! This guide will walk you through the process of deploying your Hydro app in a variety of scenarios.
 
 Hydro Deploy focuses on managing the end-to-end lifecycle of networked services in the cloud. It is not a general-purpose deployment tool, and is not intended to replace systems like Docker Compose or Kubernetes. Instead, Hydro Deploy is designed to be used in conjunction with these tools to manage the lifecycle of your Hydro app.
@@ -14,8 +21,3 @@ Currently, Hydro Deploy is focused on _ephemeral applications_, which can be spu
 - Initializing network connections based on a user-defined topology
 - Monitoring logs from your services
 
-:::caution
-
-Hydro Deploy is currently in alpha. Although it has already been used for large-scale distributed experiments within the Hydro research group, the API is rapidly changing and may come with some rough edges. Please reach out if you run into any issues!
-
-:::


### PR DESCRIPTION
fix(docs): move warning about Hydro Deploy docs to the top of the intro
