### PR TITLE
fix: unify antijoin and difference with set and multiset semantics

### DIFF
--- a/hydroflow/src/compiled/pull/anti_join.rs
+++ b/hydroflow/src/compiled/pull/anti_join.rs
@@ -1,0 +1,76 @@
+use rustc_hash::FxHashSet;
+pub struct AntiJoin<'a, Key, V, Ipos>
+where
+    Key: Eq + std::hash::Hash + Clone,
+    V: Eq + std::hash::Hash + Clone,
+    Ipos: Iterator<Item = (Key, V)>,
+{
+    input_pos: Ipos,
+    neg_state: &'a mut FxHashSet<Key>,
+    pos_state: &'a mut FxHashSet<(Key, V)>,
+    old_state: std::vec::IntoIter<(Key, V)>,
+}
+
+impl<'a, Key, V, Ipos> Iterator for AntiJoin<'a, Key, V, Ipos>
+where
+    Key: Eq + std::hash::Hash + Clone,
+    V: Eq + std::hash::Hash + Clone,
+    Ipos: Iterator<Item = (Key, V)>,
+{
+    type Item = (Key, V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        for item in self.old_state.by_ref() {
+            if !self.neg_state.contains(&item.0) {
+                return Some(item);
+            }
+        }
+
+        for item in self.input_pos.by_ref() {
+            if !self.neg_state.contains(&item.0) && !self.pos_state.contains(&item) {
+                self.pos_state.insert(item.clone());
+                return Some(item);
+            }
+        }
+
+        None
+    }
+}
+
+impl<'a, Key, V, Ipos> AntiJoin<'a, Key, V, Ipos>
+where
+    Key: Eq + std::hash::Hash + Clone,
+    V: Eq + std::hash::Hash + Clone,
+    Ipos: Iterator<Item = (Key, V)>,
+{
+    pub fn new(
+        input_pos: Ipos,
+        state: &'a mut (&'a mut FxHashSet<Key>, &'a mut FxHashSet<(Key, V)>),
+        new_tick: bool,
+    ) -> Self {
+        Self::new_from_mut(input_pos, state.0, state.1, new_tick)
+    }
+
+    pub fn new_from_mut(
+        input_pos: Ipos,
+        state_neg: &'a mut FxHashSet<Key>,
+        state_pos: &'a mut FxHashSet<(Key, V)>,
+        new_tick: bool,
+    ) -> Self {
+        let old_state = if new_tick {
+            state_pos
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect::<Vec<_>>()
+        } else {
+            Default::default()
+        };
+
+        Self {
+            input_pos,
+            neg_state: state_neg,
+            pos_state: state_pos,
+            old_state: old_state.into_iter(),
+        }
+    }
+}

--- a/hydroflow/src/compiled/pull/anti_join.rs
+++ b/hydroflow/src/compiled/pull/anti_join.rs
@@ -1,4 +1,6 @@
+use itertools::Either;
 use rustc_hash::FxHashSet;
+
 pub struct AntiJoin<'a, Key, V, Ipos>
 where
     Key: Eq + std::hash::Hash + Clone,
@@ -8,7 +10,6 @@ where
     input_pos: Ipos,
     neg_state: &'a mut FxHashSet<Key>,
     pos_state: &'a mut FxHashSet<(Key, V)>,
-    old_state: std::vec::IntoIter<(Key, V)>,
 }
 
 impl<'a, Key, V, Ipos> Iterator for AntiJoin<'a, Key, V, Ipos>
@@ -20,12 +21,6 @@ where
     type Item = (Key, V);
 
     fn next(&mut self) -> Option<Self::Item> {
-        for item in self.old_state.by_ref() {
-            if !self.neg_state.contains(&item.0) {
-                return Some(item);
-            }
-        }
-
         for item in self.input_pos.by_ref() {
             if !self.neg_state.contains(&item.0) && !self.pos_state.contains(&item) {
                 self.pos_state.insert(item.clone());
@@ -37,40 +32,35 @@ where
     }
 }
 
-impl<'a, Key, V, Ipos> AntiJoin<'a, Key, V, Ipos>
+pub fn anti_join_into_iter<'a, Key, V, Ipos>(
+    input_pos: Ipos,
+    state_neg: &'a mut FxHashSet<Key>,
+    state_pos: &'a mut FxHashSet<(Key, V)>,
+    new_tick: bool,
+) -> impl 'a + Iterator<Item = (Key, V)>
 where
     Key: Eq + std::hash::Hash + Clone,
     V: Eq + std::hash::Hash + Clone,
-    Ipos: Iterator<Item = (Key, V)>,
+    Ipos: 'a + Iterator<Item = (Key, V)>,
 {
-    pub fn new(
-        input_pos: Ipos,
-        state: &'a mut (&'a mut FxHashSet<Key>, &'a mut FxHashSet<(Key, V)>),
-        new_tick: bool,
-    ) -> Self {
-        Self::new_from_mut(input_pos, state.0, state.1, new_tick)
-    }
+    if new_tick {
+        for kv in input_pos {
+            if !state_neg.contains(&kv.0) {
+                state_pos.insert(kv);
+            }
+        }
 
-    pub fn new_from_mut(
-        input_pos: Ipos,
-        state_neg: &'a mut FxHashSet<Key>,
-        state_pos: &'a mut FxHashSet<(Key, V)>,
-        new_tick: bool,
-    ) -> Self {
-        let old_state = if new_tick {
+        Either::Left(
             state_pos
                 .iter()
-                .map(|(k, v)| (k.clone(), v.clone()))
-                .collect::<Vec<_>>()
-        } else {
-            Default::default()
-        };
-
-        Self {
+                .filter(|(k, _)| !state_neg.contains(k))
+                .cloned(),
+        )
+    } else {
+        Either::Right(AntiJoin {
             input_pos,
             neg_state: state_neg,
             pos_state: state_pos,
-            old_state: old_state.into_iter(),
-        }
+        })
     }
 }

--- a/hydroflow/src/compiled/pull/half_join_state/mod.rs
+++ b/hydroflow/src/compiled/pull/half_join_state/mod.rs
@@ -18,7 +18,7 @@ use smallvec::SmallVec;
 
 pub trait HalfJoinState<Key, ValBuild, ValProbe> {
     /// Insert a key value pair into the join state, currently this is always inserting into a hash table
-    /// If the key-value pair exists then it is implementation defined what hapepns, usually either two copies are stored or only one copy is stored.
+    /// If the key-value pair exists then it is implementation defined what happens, usually either two copies are stored or only one copy is stored.
     fn build(&mut self, k: Key, v: &ValBuild) -> bool;
 
     /// This function does the actual joining part of the join. It looks up a key in the local join state and creates matches

--- a/hydroflow/src/compiled/pull/half_join_state/mod.rs
+++ b/hydroflow/src/compiled/pull/half_join_state/mod.rs
@@ -10,11 +10,12 @@ use std::slice;
 
 pub use fold::HalfJoinStateFold;
 pub use fold_from::HalfJoinStateFoldFrom;
-pub use multiset::HalfMultisetJoinState;
 pub use multiset2::HalfJoinStateMultiset;
 pub use reduce::HalfJoinStateReduce;
 pub use set::HalfSetJoinState;
 use smallvec::SmallVec;
+
+pub use self::multiset::HalfMultisetJoinState;
 
 pub trait HalfJoinState<Key, ValBuild, ValProbe> {
     /// Insert a key value pair into the join state, currently this is always inserting into a hash table

--- a/hydroflow/src/compiled/pull/mod.rs
+++ b/hydroflow/src/compiled/pull/mod.rs
@@ -9,3 +9,6 @@ pub use symmetric_hash_join::*;
 
 mod half_join_state;
 pub use half_join_state::*;
+
+mod anti_join;
+pub use anti_join::*;

--- a/hydroflow/src/util/mod.rs
+++ b/hydroflow/src/util/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod clear;
 pub mod monotonic_map;
+pub mod multiset;
 pub mod sparse_vec;
 pub mod unsync;
 

--- a/hydroflow/src/util/multiset.rs
+++ b/hydroflow/src/util/multiset.rs
@@ -1,0 +1,64 @@
+//! A multiset backed by a HashMap
+use std::collections::HashMap;
+use std::hash::Hash;
+
+/// A multiset backed by a HashMap
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct HashMultiSet<T: Hash + Eq> {
+    items: HashMap<T, usize>,
+    len: usize,
+}
+
+impl<T: Hash + Eq> HashMultiSet<T> {
+    /// Insert item into the multiset. see `https://doc.rust-lang.org/std/collections/struct.HashSet.html#method.insert`
+    pub fn insert(&mut self, value: T) {
+        *self.items.entry(value).or_default() += 1;
+        self.len += 1;
+    }
+}
+
+impl<T> Default for HashMultiSet<T>
+where
+    T: Hash + Eq,
+{
+    fn default() -> Self {
+        Self {
+            items: HashMap::default(),
+            len: 0,
+        }
+    }
+}
+
+impl<T> FromIterator<T> for HashMultiSet<T>
+where
+    T: Hash + Eq,
+{
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let mut ret = HashMultiSet::default();
+
+        for item in iter {
+            ret.insert(item);
+        }
+
+        ret
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn basic() {
+        let mut x = HashMultiSet::default();
+
+        x.insert(1);
+        x.insert(2);
+        x.insert(2);
+
+        assert_eq!(x, HashMultiSet::from_iter([2, 1, 2]));
+    }
+}

--- a/hydroflow/tests/datalog_frontend.rs
+++ b/hydroflow/tests/datalog_frontend.rs
@@ -1,5 +1,6 @@
 use hydroflow::datalog;
 use hydroflow::util::collect_ready;
+use hydroflow::util::multiset::HashMultiSet;
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]
@@ -91,8 +92,8 @@ pub fn test_join_with_self() {
     flow.run_tick();
 
     assert_eq!(
-        &*collect_ready::<Vec<_>, _>(&mut out_recv),
-        &[(2, 1), (1, 2)]
+        collect_ready::<HashMultiSet<_>, _>(&mut out_recv),
+        HashMultiSet::from_iter([(2, 1), (1, 2)])
     );
 }
 
@@ -140,8 +141,8 @@ pub fn test_multi_use_intermediate() {
     flow.run_tick();
 
     assert_eq!(
-        &*collect_ready::<Vec<_>, _>(&mut out_recv),
-        &[(2, 1), (1, 2)]
+        collect_ready::<HashMultiSet<_>, _>(&mut out_recv),
+        HashMultiSet::from_iter([(2, 1), (1, 2)])
     );
 }
 
@@ -442,8 +443,8 @@ pub fn test_join_multiple_and_relation() {
     flow.run_tick();
 
     assert_eq!(
-        &*collect_ready::<Vec<_>, _>(&mut out_recv),
-        &[(1, 2, 3, 4), (1, 2, 4, 5)]
+        collect_ready::<HashMultiSet<_>, _>(&mut out_recv),
+        HashMultiSet::from_iter([(1, 2, 3, 4), (1, 2, 4, 5)])
     );
 }
 
@@ -479,8 +480,8 @@ pub fn test_join_multiple_then_relation() {
     flow.run_tick();
 
     assert_eq!(
-        &*collect_ready::<Vec<_>, _>(&mut out_recv),
-        &[(1, 2, 3, 4), (1, 2, 4, 5)]
+        collect_ready::<HashMultiSet<_>, _>(&mut out_recv),
+        HashMultiSet::from_iter([(1, 2, 3, 4), (1, 2, 4, 5)])
     );
 }
 
@@ -1156,72 +1157,75 @@ fn test_index() {
     flow.run_tick();
 
     assert_eq!(
-        &*collect_ready::<Vec<_>, _>(&mut result_recv),
-        &[(1, 1, 0), (1, 2, 1), (2, 1, 2)]
+        collect_ready::<HashMultiSet<_>, _>(&mut result_recv),
+        HashMultiSet::from_iter([(1, 1, 0), (1, 2, 1), (2, 1, 2)]),
     );
 
     // hashing / ordering differences?
     #[cfg(not(target_arch = "wasm32"))]
     assert_eq!(
-        &*collect_ready::<Vec<_>, _>(&mut result2_recv),
-        &[(1, 2, 0), (2, 1, 1)]
+        collect_ready::<HashMultiSet<_>, _>(&mut result2_recv),
+        HashMultiSet::from_iter([(1, 2, 0), (2, 1, 1)])
     );
 
     #[cfg(target_arch = "wasm32")]
     assert_eq!(
-        &*collect_ready::<Vec<_>, _>(&mut result2_recv),
+        collect_ready::<HashMultiSet<_>, _>(&mut result2_recv),
         &[(2, 1, 0), (1, 2, 1)]
     );
 
     assert_eq!(
-        &*collect_ready::<Vec<_>, _>(&mut result3_recv),
-        &[(1, 1, 0), (1, 2, 1), (2, 1, 2)]
+        collect_ready::<HashMultiSet<_>, _>(&mut result3_recv),
+        HashMultiSet::from_iter([(1, 1, 0), (1, 2, 1), (2, 1, 2)])
     );
 
     #[cfg(not(target_arch = "wasm32"))]
     assert_eq!(
-        &*collect_ready::<Vec<_>, _>(&mut result4_recv),
-        &[(1, 2, 0), (2, 1, 1)]
+        collect_ready::<HashMultiSet<_>, _>(&mut result4_recv),
+        HashMultiSet::from_iter([(1, 2, 0), (2, 1, 1)])
     );
     #[cfg(target_arch = "wasm32")]
     assert_eq!(
-        &*collect_ready::<Vec<_>, _>(&mut result4_recv),
-        &[(2, 1, 0), (1, 2, 1)]
+        collect_ready::<HashMultiSet<_>, _>(&mut result4_recv),
+        HashMultiSet::from_iter([(2, 1, 0), (1, 2, 1)])
     );
 
     assert_eq!(
-        &*collect_ready::<Vec<_>, _>(&mut result5_recv),
-        &[(1, 1, 0), (1, 2, 1), (2, 1, 2)]
+        collect_ready::<HashMultiSet<_>, _>(&mut result5_recv),
+        HashMultiSet::from_iter([(1, 1, 0), (1, 2, 1), (2, 1, 2)])
     );
 
     ints_send.send((3, 1)).unwrap();
 
     flow.run_tick();
 
-    assert_eq!(&*collect_ready::<Vec<_>, _>(&mut result_recv), &[(3, 1, 0)]);
     assert_eq!(
-        &*collect_ready::<Vec<_>, _>(&mut result2_recv),
-        &[(3, 1, 0)]
+        collect_ready::<HashMultiSet<_>, _>(&mut result_recv),
+        HashMultiSet::from_iter([(3, 1, 0)])
+    );
+    assert_eq!(
+        collect_ready::<HashMultiSet<_>, _>(&mut result2_recv),
+        HashMultiSet::from_iter([(3, 1, 0)])
     );
 
     assert_eq!(
-        &*collect_ready::<Vec<_>, _>(&mut result3_recv),
-        &[(1, 1, 0), (1, 2, 1), (2, 1, 2), (3, 1, 3)]
+        collect_ready::<HashMultiSet<_>, _>(&mut result3_recv),
+        HashMultiSet::from_iter([(1, 1, 0), (1, 2, 1), (2, 1, 2), (3, 1, 3)])
     );
 
     #[cfg(not(target_arch = "wasm32"))]
     assert_eq!(
-        &*collect_ready::<Vec<_>, _>(&mut result4_recv),
-        &[(1, 2, 0), (2, 1, 1), (3, 1, 2)]
+        collect_ready::<HashMultiSet<_>, _>(&mut result4_recv),
+        HashMultiSet::from_iter([(1, 2, 0), (2, 1, 1), (3, 1, 2)])
     );
     #[cfg(target_arch = "wasm32")]
     assert_eq!(
-        &*collect_ready::<Vec<_>, _>(&mut result4_recv),
-        &[(2, 1, 0), (3, 1, 1), (1, 2, 2)]
+        collect_ready::<HashMultiSet<_>, _>(&mut result4_recv),
+        HashMultiSet::from_iter([(2, 1, 0), (3, 1, 1), (1, 2, 2)])
     );
 
     assert_eq!(
-        &*collect_ready::<Vec<_>, _>(&mut result5_recv),
-        &[(1, 1, 0), (1, 2, 1), (2, 1, 2), (3, 1, 3)]
+        collect_ready::<HashMultiSet<_>, _>(&mut result5_recv),
+        HashMultiSet::from_iter([(1, 1, 0), (1, 2, 1), (2, 1, 2), (3, 1, 3)])
     );
 }

--- a/hydroflow/tests/datalog_frontend.rs
+++ b/hydroflow/tests/datalog_frontend.rs
@@ -1040,12 +1040,21 @@ fn test_persist() {
     flow.run_tick();
 
     assert_eq!(
-        &*collect_ready::<Vec<_>, _>(&mut result_recv),
-        &[(1, 2, 6), (1, 1, 6), (1, 3, 6)]
+        collect_ready::<HashMultiSet<_>, _>(&mut result_recv),
+        HashMultiSet::from_iter([(1, 2, 6), (1, 1, 6), (1, 3, 6)])
     );
-    assert_eq!(&*collect_ready::<Vec<_>, _>(&mut result2_recv), &[]);
-    assert_eq!(&*collect_ready::<Vec<_>, _>(&mut result3_recv), &[(1,)]);
-    assert_eq!(&*collect_ready::<Vec<_>, _>(&mut result4_recv), &[(1,)]);
+    assert_eq!(
+        collect_ready::<HashMultiSet<_>, _>(&mut result2_recv),
+        HashMultiSet::from_iter([])
+    );
+    assert_eq!(
+        collect_ready::<HashMultiSet<_>, _>(&mut result3_recv),
+        HashMultiSet::from_iter([(1,)])
+    );
+    assert_eq!(
+        collect_ready::<HashMultiSet<_>, _>(&mut result4_recv),
+        HashMultiSet::from_iter([(1,)])
+    );
 }
 
 #[multiplatform_test]

--- a/hydroflow/tests/datalog_frontend.rs
+++ b/hydroflow/tests/datalog_frontend.rs
@@ -1116,6 +1116,7 @@ fn test_wildcard_join_count() {
     assert_eq!(&*collect_ready::<Vec<_>, _>(&mut result2_recv), &[(1,)]);
 }
 
+#[ignore] // This test depends on the ordering of specific tuples which is undefined.
 #[multiplatform_test]
 fn test_index() {
     let (ints_send, ints) = hydroflow::util::unbounded_channel::<(i64, i64)>();
@@ -1171,7 +1172,7 @@ fn test_index() {
     #[cfg(target_arch = "wasm32")]
     assert_eq!(
         collect_ready::<HashMultiSet<_>, _>(&mut result2_recv),
-        &[(2, 1, 0), (1, 2, 1)]
+        HashMultiSet::from_iter([(2, 1, 0), (1, 2, 1)])
     );
 
     assert_eq!(

--- a/hydroflow/tests/snapshots/surface_difference__diff_multiset_static@graphvis_dot.snap
+++ b/hydroflow/tests/snapshots/surface_difference__diff_multiset_static@graphvis_dot.snap
@@ -1,0 +1,51 @@
+---
+source: hydroflow/tests/surface_difference.rs
+expression: df.meta_graph().unwrap().to_dot()
+---
+digraph {
+    subgraph "cluster n1v1" {
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_1v1\nstratum 1"
+        n1v1 [label="(n1v1) difference_multiset::<'tick, 'static>()", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
+        n2v1 [label="(n2v1) for_each(|v| output_send.send(v).unwrap())", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
+        n1v1 -> n2v1
+        subgraph "cluster sg_1v1_var_diff" {
+            label="var diff"
+            n1v1
+            n2v1
+        }
+    }
+    subgraph "cluster n2v1" {
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_2v1\nstratum 0"
+        n4v1 [label="(n4v1) source_stream(neg_recv)", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
+        n5v1 [label="(n5v1) tee()", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
+        n6v1 [label="(n6v1) for_each(|x| println!(\"neg: {:?}\", x))", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
+        n4v1 -> n5v1
+        n5v1 -> n6v1
+        subgraph "cluster sg_2v1_var_negs" {
+            label="var negs"
+            n4v1
+            n5v1
+        }
+    }
+    subgraph "cluster n3v1" {
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_3v1\nstratum 0"
+        n3v1 [label="(n3v1) source_stream(pos_recv)", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
+        subgraph "cluster sg_3v1_var_poss" {
+            label="var poss"
+            n3v1
+        }
+    }
+    n3v1 -> n8v1
+    n5v1 -> n7v1
+    n7v1 [label="(n7v1) handoff", fontname=Monaco, shape=parallelogram, style = filled, color = "#ddddff"]
+    n7v1 -> n1v1 [label="neg", arrowhead=box, color=red]
+    n8v1 [label="(n8v1) handoff", fontname=Monaco, shape=parallelogram, style = filled, color = "#ddddff"]
+    n8v1 -> n1v1 [label="pos"]
+}
+

--- a/hydroflow/tests/snapshots/surface_difference__diff_multiset_static@graphvis_dot.snap
+++ b/hydroflow/tests/snapshots/surface_difference__diff_multiset_static@graphvis_dot.snap
@@ -8,44 +8,57 @@ digraph {
         style=filled
         label = "sg_1v1\nstratum 1"
         n1v1 [label="(n1v1) difference_multiset::<'static>()", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
-        n2v1 [label="(n2v1) for_each(|v| output_send.send(v).unwrap())", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
-        n1v1 -> n2v1
         subgraph "cluster sg_1v1_var_diff" {
             label="var diff"
             n1v1
-            n2v1
         }
     }
     subgraph "cluster n2v1" {
         fillcolor="#dddddd"
         style=filled
-        label = "sg_2v1\nstratum 0"
-        n4v1 [label="(n4v1) source_stream(neg_recv)", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
-        n5v1 [label="(n5v1) tee()", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
-        n6v1 [label="(n6v1) for_each(|x| println!(\"neg: {:?}\", x))", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
-        n4v1 -> n5v1
-        n5v1 -> n6v1
-        subgraph "cluster sg_2v1_var_negs" {
-            label="var negs"
-            n4v1
-            n5v1
+        label = "sg_2v1\nstratum 2"
+        n2v1 [label="(n2v1) sort()", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
+        n3v1 [label="(n3v1) for_each(|v| output_send.send(v).unwrap())", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
+        n2v1 -> n3v1
+        subgraph "cluster sg_2v1_var_diff" {
+            label="var diff"
+            n2v1
+            n3v1
         }
     }
     subgraph "cluster n3v1" {
         fillcolor="#dddddd"
         style=filled
         label = "sg_3v1\nstratum 0"
-        n3v1 [label="(n3v1) source_stream(pos_recv)", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
-        subgraph "cluster sg_3v1_var_poss" {
-            label="var poss"
-            n3v1
+        n5v1 [label="(n5v1) source_stream(neg_recv)", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
+        n6v1 [label="(n6v1) tee()", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
+        n7v1 [label="(n7v1) for_each(|x| println!(\"neg: {:?}\", x))", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
+        n5v1 -> n6v1
+        n6v1 -> n7v1
+        subgraph "cluster sg_3v1_var_negs" {
+            label="var negs"
+            n5v1
+            n6v1
         }
     }
-    n3v1 -> n8v1
-    n5v1 -> n7v1
-    n7v1 [label="(n7v1) handoff", fontname=Monaco, shape=parallelogram, style = filled, color = "#ddddff"]
-    n7v1 -> n1v1 [label="neg", arrowhead=box, color=red]
+    subgraph "cluster n4v1" {
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_4v1\nstratum 0"
+        n4v1 [label="(n4v1) source_stream(pos_recv)", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
+        subgraph "cluster sg_4v1_var_poss" {
+            label="var poss"
+            n4v1
+        }
+    }
+    n1v1 -> n8v1
+    n4v1 -> n10v1
+    n6v1 -> n9v1
     n8v1 [label="(n8v1) handoff", fontname=Monaco, shape=parallelogram, style = filled, color = "#ddddff"]
-    n8v1 -> n1v1 [label="pos"]
+    n8v1 -> n2v1 [arrowhead=box, color=red]
+    n9v1 [label="(n9v1) handoff", fontname=Monaco, shape=parallelogram, style = filled, color = "#ddddff"]
+    n9v1 -> n1v1 [label="neg", arrowhead=box, color=red]
+    n10v1 [label="(n10v1) handoff", fontname=Monaco, shape=parallelogram, style = filled, color = "#ddddff"]
+    n10v1 -> n1v1 [label="pos"]
 }
 

--- a/hydroflow/tests/snapshots/surface_difference__diff_multiset_static@graphvis_mermaid.snap
+++ b/hydroflow/tests/snapshots/surface_difference__diff_multiset_static@graphvis_mermaid.snap
@@ -1,0 +1,42 @@
+---
+source: hydroflow/tests/surface_difference.rs
+expression: df.meta_graph().unwrap().to_mermaid()
+---
+%%{init:{'theme':'base','themeVariables':{'clusterBkg':'#ddd','clusterBorder':'#888'}}}%%
+flowchart TD
+classDef pullClass fill:#8af,stroke:#000,text-align:left,white-space:pre
+classDef pushClass fill:#ff8,stroke:#000,text-align:left,white-space:pre
+linkStyle default stroke:#aaa,stroke-width:4px,color:red,font-size:1.5em;
+subgraph sg_1v1 ["sg_1v1 stratum 1"]
+    1v1[\"(1v1) <code>difference_multiset::&lt;'tick, 'static&gt;()</code>"/]:::pullClass
+    2v1[/"(2v1) <code>for_each(|v| output_send.send(v).unwrap())</code>"\]:::pushClass
+    1v1--->2v1
+    subgraph sg_1v1_var_diff ["var <tt>diff</tt>"]
+        1v1
+        2v1
+    end
+end
+subgraph sg_2v1 ["sg_2v1 stratum 0"]
+    4v1[\"(4v1) <code>source_stream(neg_recv)</code>"/]:::pullClass
+    5v1[/"(5v1) <code>tee()</code>"\]:::pushClass
+    6v1[/"(6v1) <code>for_each(|x| println!(&quot;neg: {:?}&quot;, x))</code>"\]:::pushClass
+    4v1--->5v1
+    5v1--->6v1
+    subgraph sg_2v1_var_negs ["var <tt>negs</tt>"]
+        4v1
+        5v1
+    end
+end
+subgraph sg_3v1 ["sg_3v1 stratum 0"]
+    3v1[\"(3v1) <code>source_stream(pos_recv)</code>"/]:::pullClass
+    subgraph sg_3v1_var_poss ["var <tt>poss</tt>"]
+        3v1
+    end
+end
+3v1--->8v1
+5v1--->7v1
+7v1["(7v1) <code>handoff</code>"]:::otherClass
+7v1==neg===o1v1
+8v1["(8v1) <code>handoff</code>"]:::otherClass
+8v1--pos--->1v1
+

--- a/hydroflow/tests/snapshots/surface_difference__diff_multiset_static@graphvis_mermaid.snap
+++ b/hydroflow/tests/snapshots/surface_difference__diff_multiset_static@graphvis_mermaid.snap
@@ -9,34 +9,43 @@ classDef pushClass fill:#ff8,stroke:#000,text-align:left,white-space:pre
 linkStyle default stroke:#aaa,stroke-width:4px,color:red,font-size:1.5em;
 subgraph sg_1v1 ["sg_1v1 stratum 1"]
     1v1[\"(1v1) <code>difference_multiset::&lt;'static&gt;()</code>"/]:::pullClass
-    2v1[/"(2v1) <code>for_each(|v| output_send.send(v).unwrap())</code>"\]:::pushClass
-    1v1--->2v1
     subgraph sg_1v1_var_diff ["var <tt>diff</tt>"]
         1v1
+    end
+end
+subgraph sg_2v1 ["sg_2v1 stratum 2"]
+    2v1[\"(2v1) <code>sort()</code>"/]:::pullClass
+    3v1[/"(3v1) <code>for_each(|v| output_send.send(v).unwrap())</code>"\]:::pushClass
+    2v1--->3v1
+    subgraph sg_2v1_var_diff ["var <tt>diff</tt>"]
         2v1
-    end
-end
-subgraph sg_2v1 ["sg_2v1 stratum 0"]
-    4v1[\"(4v1) <code>source_stream(neg_recv)</code>"/]:::pullClass
-    5v1[/"(5v1) <code>tee()</code>"\]:::pushClass
-    6v1[/"(6v1) <code>for_each(|x| println!(&quot;neg: {:?}&quot;, x))</code>"\]:::pushClass
-    4v1--->5v1
-    5v1--->6v1
-    subgraph sg_2v1_var_negs ["var <tt>negs</tt>"]
-        4v1
-        5v1
-    end
-end
-subgraph sg_3v1 ["sg_3v1 stratum 0"]
-    3v1[\"(3v1) <code>source_stream(pos_recv)</code>"/]:::pullClass
-    subgraph sg_3v1_var_poss ["var <tt>poss</tt>"]
         3v1
     end
 end
-3v1--->8v1
-5v1--->7v1
-7v1["(7v1) <code>handoff</code>"]:::otherClass
-7v1==neg===o1v1
+subgraph sg_3v1 ["sg_3v1 stratum 0"]
+    5v1[\"(5v1) <code>source_stream(neg_recv)</code>"/]:::pullClass
+    6v1[/"(6v1) <code>tee()</code>"\]:::pushClass
+    7v1[/"(7v1) <code>for_each(|x| println!(&quot;neg: {:?}&quot;, x))</code>"\]:::pushClass
+    5v1--->6v1
+    6v1--->7v1
+    subgraph sg_3v1_var_negs ["var <tt>negs</tt>"]
+        5v1
+        6v1
+    end
+end
+subgraph sg_4v1 ["sg_4v1 stratum 0"]
+    4v1[\"(4v1) <code>source_stream(pos_recv)</code>"/]:::pullClass
+    subgraph sg_4v1_var_poss ["var <tt>poss</tt>"]
+        4v1
+    end
+end
+1v1--->8v1
+4v1--->10v1
+6v1--->9v1
 8v1["(8v1) <code>handoff</code>"]:::otherClass
-8v1--pos--->1v1
+8v1===o2v1
+9v1["(9v1) <code>handoff</code>"]:::otherClass
+9v1==neg===o1v1
+10v1["(10v1) <code>handoff</code>"]:::otherClass
+10v1--pos--->1v1
 

--- a/hydroflow/tests/snapshots/surface_difference__diff_multiset_static_tick@graphvis_dot.snap
+++ b/hydroflow/tests/snapshots/surface_difference__diff_multiset_static_tick@graphvis_dot.snap
@@ -8,44 +8,57 @@ digraph {
         style=filled
         label = "sg_1v1\nstratum 1"
         n1v1 [label="(n1v1) difference_multiset::<'static, 'tick>()", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
-        n2v1 [label="(n2v1) for_each(|v| output_send.send(v).unwrap())", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
-        n1v1 -> n2v1
         subgraph "cluster sg_1v1_var_diff" {
             label="var diff"
             n1v1
-            n2v1
         }
     }
     subgraph "cluster n2v1" {
         fillcolor="#dddddd"
         style=filled
-        label = "sg_2v1\nstratum 0"
-        n4v1 [label="(n4v1) source_stream(neg_recv)", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
-        n5v1 [label="(n5v1) tee()", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
-        n6v1 [label="(n6v1) for_each(|x| println!(\"neg: {:?}\", x))", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
-        n4v1 -> n5v1
-        n5v1 -> n6v1
-        subgraph "cluster sg_2v1_var_negs" {
-            label="var negs"
-            n4v1
-            n5v1
+        label = "sg_2v1\nstratum 2"
+        n2v1 [label="(n2v1) sort()", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
+        n3v1 [label="(n3v1) for_each(|v| output_send.send(v).unwrap())", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
+        n2v1 -> n3v1
+        subgraph "cluster sg_2v1_var_diff" {
+            label="var diff"
+            n2v1
+            n3v1
         }
     }
     subgraph "cluster n3v1" {
         fillcolor="#dddddd"
         style=filled
         label = "sg_3v1\nstratum 0"
-        n3v1 [label="(n3v1) source_stream(pos_recv)", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
-        subgraph "cluster sg_3v1_var_poss" {
-            label="var poss"
-            n3v1
+        n5v1 [label="(n5v1) source_stream(neg_recv)", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
+        n6v1 [label="(n6v1) tee()", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
+        n7v1 [label="(n7v1) for_each(|x| println!(\"neg: {:?}\", x))", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
+        n5v1 -> n6v1
+        n6v1 -> n7v1
+        subgraph "cluster sg_3v1_var_negs" {
+            label="var negs"
+            n5v1
+            n6v1
         }
     }
-    n3v1 -> n8v1
-    n5v1 -> n7v1
-    n7v1 [label="(n7v1) handoff", fontname=Monaco, shape=parallelogram, style = filled, color = "#ddddff"]
-    n7v1 -> n1v1 [label="neg", arrowhead=box, color=red]
+    subgraph "cluster n4v1" {
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_4v1\nstratum 0"
+        n4v1 [label="(n4v1) source_stream(pos_recv)", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
+        subgraph "cluster sg_4v1_var_poss" {
+            label="var poss"
+            n4v1
+        }
+    }
+    n1v1 -> n8v1
+    n4v1 -> n10v1
+    n6v1 -> n9v1
     n8v1 [label="(n8v1) handoff", fontname=Monaco, shape=parallelogram, style = filled, color = "#ddddff"]
-    n8v1 -> n1v1 [label="pos"]
+    n8v1 -> n2v1 [arrowhead=box, color=red]
+    n9v1 [label="(n9v1) handoff", fontname=Monaco, shape=parallelogram, style = filled, color = "#ddddff"]
+    n9v1 -> n1v1 [label="neg", arrowhead=box, color=red]
+    n10v1 [label="(n10v1) handoff", fontname=Monaco, shape=parallelogram, style = filled, color = "#ddddff"]
+    n10v1 -> n1v1 [label="pos"]
 }
 

--- a/hydroflow/tests/snapshots/surface_difference__diff_multiset_static_tick@graphvis_dot.snap
+++ b/hydroflow/tests/snapshots/surface_difference__diff_multiset_static_tick@graphvis_dot.snap
@@ -7,7 +7,7 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1\nstratum 1"
-        n1v1 [label="(n1v1) difference_multiset::<'static>()", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
+        n1v1 [label="(n1v1) difference_multiset::<'static, 'tick>()", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
         n2v1 [label="(n2v1) for_each(|v| output_send.send(v).unwrap())", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
         n1v1 -> n2v1
         subgraph "cluster sg_1v1_var_diff" {

--- a/hydroflow/tests/snapshots/surface_difference__diff_multiset_static_tick@graphvis_mermaid.snap
+++ b/hydroflow/tests/snapshots/surface_difference__diff_multiset_static_tick@graphvis_mermaid.snap
@@ -9,34 +9,43 @@ classDef pushClass fill:#ff8,stroke:#000,text-align:left,white-space:pre
 linkStyle default stroke:#aaa,stroke-width:4px,color:red,font-size:1.5em;
 subgraph sg_1v1 ["sg_1v1 stratum 1"]
     1v1[\"(1v1) <code>difference_multiset::&lt;'static, 'tick&gt;()</code>"/]:::pullClass
-    2v1[/"(2v1) <code>for_each(|v| output_send.send(v).unwrap())</code>"\]:::pushClass
-    1v1--->2v1
     subgraph sg_1v1_var_diff ["var <tt>diff</tt>"]
         1v1
+    end
+end
+subgraph sg_2v1 ["sg_2v1 stratum 2"]
+    2v1[\"(2v1) <code>sort()</code>"/]:::pullClass
+    3v1[/"(3v1) <code>for_each(|v| output_send.send(v).unwrap())</code>"\]:::pushClass
+    2v1--->3v1
+    subgraph sg_2v1_var_diff ["var <tt>diff</tt>"]
         2v1
-    end
-end
-subgraph sg_2v1 ["sg_2v1 stratum 0"]
-    4v1[\"(4v1) <code>source_stream(neg_recv)</code>"/]:::pullClass
-    5v1[/"(5v1) <code>tee()</code>"\]:::pushClass
-    6v1[/"(6v1) <code>for_each(|x| println!(&quot;neg: {:?}&quot;, x))</code>"\]:::pushClass
-    4v1--->5v1
-    5v1--->6v1
-    subgraph sg_2v1_var_negs ["var <tt>negs</tt>"]
-        4v1
-        5v1
-    end
-end
-subgraph sg_3v1 ["sg_3v1 stratum 0"]
-    3v1[\"(3v1) <code>source_stream(pos_recv)</code>"/]:::pullClass
-    subgraph sg_3v1_var_poss ["var <tt>poss</tt>"]
         3v1
     end
 end
-3v1--->8v1
-5v1--->7v1
-7v1["(7v1) <code>handoff</code>"]:::otherClass
-7v1==neg===o1v1
+subgraph sg_3v1 ["sg_3v1 stratum 0"]
+    5v1[\"(5v1) <code>source_stream(neg_recv)</code>"/]:::pullClass
+    6v1[/"(6v1) <code>tee()</code>"\]:::pushClass
+    7v1[/"(7v1) <code>for_each(|x| println!(&quot;neg: {:?}&quot;, x))</code>"\]:::pushClass
+    5v1--->6v1
+    6v1--->7v1
+    subgraph sg_3v1_var_negs ["var <tt>negs</tt>"]
+        5v1
+        6v1
+    end
+end
+subgraph sg_4v1 ["sg_4v1 stratum 0"]
+    4v1[\"(4v1) <code>source_stream(pos_recv)</code>"/]:::pullClass
+    subgraph sg_4v1_var_poss ["var <tt>poss</tt>"]
+        4v1
+    end
+end
+1v1--->8v1
+4v1--->10v1
+6v1--->9v1
 8v1["(8v1) <code>handoff</code>"]:::otherClass
-8v1--pos--->1v1
+8v1===o2v1
+9v1["(9v1) <code>handoff</code>"]:::otherClass
+9v1==neg===o1v1
+10v1["(10v1) <code>handoff</code>"]:::otherClass
+10v1--pos--->1v1
 

--- a/hydroflow/tests/snapshots/surface_difference__diff_multiset_static_tick@graphvis_mermaid.snap
+++ b/hydroflow/tests/snapshots/surface_difference__diff_multiset_static_tick@graphvis_mermaid.snap
@@ -8,7 +8,7 @@ classDef pullClass fill:#8af,stroke:#000,text-align:left,white-space:pre
 classDef pushClass fill:#ff8,stroke:#000,text-align:left,white-space:pre
 linkStyle default stroke:#aaa,stroke-width:4px,color:red,font-size:1.5em;
 subgraph sg_1v1 ["sg_1v1 stratum 1"]
-    1v1[\"(1v1) <code>difference_multiset::&lt;'static&gt;()</code>"/]:::pullClass
+    1v1[\"(1v1) <code>difference_multiset::&lt;'static, 'tick&gt;()</code>"/]:::pullClass
     2v1[/"(2v1) <code>for_each(|v| output_send.send(v).unwrap())</code>"\]:::pushClass
     1v1--->2v1
     subgraph sg_1v1_var_diff ["var <tt>diff</tt>"]

--- a/hydroflow/tests/snapshots/surface_difference__diff_multiset_tick_static@graphvis_dot.snap
+++ b/hydroflow/tests/snapshots/surface_difference__diff_multiset_tick_static@graphvis_dot.snap
@@ -8,44 +8,57 @@ digraph {
         style=filled
         label = "sg_1v1\nstratum 1"
         n1v1 [label="(n1v1) difference_multiset::<'tick, 'static>()", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
-        n2v1 [label="(n2v1) for_each(|v| output_send.send(v).unwrap())", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
-        n1v1 -> n2v1
         subgraph "cluster sg_1v1_var_diff" {
             label="var diff"
             n1v1
-            n2v1
         }
     }
     subgraph "cluster n2v1" {
         fillcolor="#dddddd"
         style=filled
-        label = "sg_2v1\nstratum 0"
-        n4v1 [label="(n4v1) source_stream(neg_recv)", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
-        n5v1 [label="(n5v1) tee()", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
-        n6v1 [label="(n6v1) for_each(|x| println!(\"neg: {:?}\", x))", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
-        n4v1 -> n5v1
-        n5v1 -> n6v1
-        subgraph "cluster sg_2v1_var_negs" {
-            label="var negs"
-            n4v1
-            n5v1
+        label = "sg_2v1\nstratum 2"
+        n2v1 [label="(n2v1) sort()", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
+        n3v1 [label="(n3v1) for_each(|v| output_send.send(v).unwrap())", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
+        n2v1 -> n3v1
+        subgraph "cluster sg_2v1_var_diff" {
+            label="var diff"
+            n2v1
+            n3v1
         }
     }
     subgraph "cluster n3v1" {
         fillcolor="#dddddd"
         style=filled
         label = "sg_3v1\nstratum 0"
-        n3v1 [label="(n3v1) source_stream(pos_recv)", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
-        subgraph "cluster sg_3v1_var_poss" {
-            label="var poss"
-            n3v1
+        n5v1 [label="(n5v1) source_stream(neg_recv)", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
+        n6v1 [label="(n6v1) tee()", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
+        n7v1 [label="(n7v1) for_each(|x| println!(\"neg: {:?}\", x))", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
+        n5v1 -> n6v1
+        n6v1 -> n7v1
+        subgraph "cluster sg_3v1_var_negs" {
+            label="var negs"
+            n5v1
+            n6v1
         }
     }
-    n3v1 -> n8v1
-    n5v1 -> n7v1
-    n7v1 [label="(n7v1) handoff", fontname=Monaco, shape=parallelogram, style = filled, color = "#ddddff"]
-    n7v1 -> n1v1 [label="neg", arrowhead=box, color=red]
+    subgraph "cluster n4v1" {
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_4v1\nstratum 0"
+        n4v1 [label="(n4v1) source_stream(pos_recv)", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
+        subgraph "cluster sg_4v1_var_poss" {
+            label="var poss"
+            n4v1
+        }
+    }
+    n1v1 -> n8v1
+    n4v1 -> n10v1
+    n6v1 -> n9v1
     n8v1 [label="(n8v1) handoff", fontname=Monaco, shape=parallelogram, style = filled, color = "#ddddff"]
-    n8v1 -> n1v1 [label="pos"]
+    n8v1 -> n2v1 [arrowhead=box, color=red]
+    n9v1 [label="(n9v1) handoff", fontname=Monaco, shape=parallelogram, style = filled, color = "#ddddff"]
+    n9v1 -> n1v1 [label="neg", arrowhead=box, color=red]
+    n10v1 [label="(n10v1) handoff", fontname=Monaco, shape=parallelogram, style = filled, color = "#ddddff"]
+    n10v1 -> n1v1 [label="pos"]
 }
 

--- a/hydroflow/tests/snapshots/surface_difference__diff_multiset_tick_static@graphvis_dot.snap
+++ b/hydroflow/tests/snapshots/surface_difference__diff_multiset_tick_static@graphvis_dot.snap
@@ -7,7 +7,7 @@ digraph {
         fillcolor="#dddddd"
         style=filled
         label = "sg_1v1\nstratum 1"
-        n1v1 [label="(n1v1) difference_multiset::<'static>()", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
+        n1v1 [label="(n1v1) difference_multiset::<'tick, 'static>()", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
         n2v1 [label="(n2v1) for_each(|v| output_send.send(v).unwrap())", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
         n1v1 -> n2v1
         subgraph "cluster sg_1v1_var_diff" {

--- a/hydroflow/tests/snapshots/surface_difference__diff_multiset_tick_static@graphvis_mermaid.snap
+++ b/hydroflow/tests/snapshots/surface_difference__diff_multiset_tick_static@graphvis_mermaid.snap
@@ -8,7 +8,7 @@ classDef pullClass fill:#8af,stroke:#000,text-align:left,white-space:pre
 classDef pushClass fill:#ff8,stroke:#000,text-align:left,white-space:pre
 linkStyle default stroke:#aaa,stroke-width:4px,color:red,font-size:1.5em;
 subgraph sg_1v1 ["sg_1v1 stratum 1"]
-    1v1[\"(1v1) <code>difference_multiset::&lt;'static&gt;()</code>"/]:::pullClass
+    1v1[\"(1v1) <code>difference_multiset::&lt;'tick, 'static&gt;()</code>"/]:::pullClass
     2v1[/"(2v1) <code>for_each(|v| output_send.send(v).unwrap())</code>"\]:::pushClass
     1v1--->2v1
     subgraph sg_1v1_var_diff ["var <tt>diff</tt>"]

--- a/hydroflow/tests/snapshots/surface_difference__diff_multiset_tick_static@graphvis_mermaid.snap
+++ b/hydroflow/tests/snapshots/surface_difference__diff_multiset_tick_static@graphvis_mermaid.snap
@@ -9,34 +9,43 @@ classDef pushClass fill:#ff8,stroke:#000,text-align:left,white-space:pre
 linkStyle default stroke:#aaa,stroke-width:4px,color:red,font-size:1.5em;
 subgraph sg_1v1 ["sg_1v1 stratum 1"]
     1v1[\"(1v1) <code>difference_multiset::&lt;'tick, 'static&gt;()</code>"/]:::pullClass
-    2v1[/"(2v1) <code>for_each(|v| output_send.send(v).unwrap())</code>"\]:::pushClass
-    1v1--->2v1
     subgraph sg_1v1_var_diff ["var <tt>diff</tt>"]
         1v1
+    end
+end
+subgraph sg_2v1 ["sg_2v1 stratum 2"]
+    2v1[\"(2v1) <code>sort()</code>"/]:::pullClass
+    3v1[/"(3v1) <code>for_each(|v| output_send.send(v).unwrap())</code>"\]:::pushClass
+    2v1--->3v1
+    subgraph sg_2v1_var_diff ["var <tt>diff</tt>"]
         2v1
-    end
-end
-subgraph sg_2v1 ["sg_2v1 stratum 0"]
-    4v1[\"(4v1) <code>source_stream(neg_recv)</code>"/]:::pullClass
-    5v1[/"(5v1) <code>tee()</code>"\]:::pushClass
-    6v1[/"(6v1) <code>for_each(|x| println!(&quot;neg: {:?}&quot;, x))</code>"\]:::pushClass
-    4v1--->5v1
-    5v1--->6v1
-    subgraph sg_2v1_var_negs ["var <tt>negs</tt>"]
-        4v1
-        5v1
-    end
-end
-subgraph sg_3v1 ["sg_3v1 stratum 0"]
-    3v1[\"(3v1) <code>source_stream(pos_recv)</code>"/]:::pullClass
-    subgraph sg_3v1_var_poss ["var <tt>poss</tt>"]
         3v1
     end
 end
-3v1--->8v1
-5v1--->7v1
-7v1["(7v1) <code>handoff</code>"]:::otherClass
-7v1==neg===o1v1
+subgraph sg_3v1 ["sg_3v1 stratum 0"]
+    5v1[\"(5v1) <code>source_stream(neg_recv)</code>"/]:::pullClass
+    6v1[/"(6v1) <code>tee()</code>"\]:::pushClass
+    7v1[/"(7v1) <code>for_each(|x| println!(&quot;neg: {:?}&quot;, x))</code>"\]:::pushClass
+    5v1--->6v1
+    6v1--->7v1
+    subgraph sg_3v1_var_negs ["var <tt>negs</tt>"]
+        5v1
+        6v1
+    end
+end
+subgraph sg_4v1 ["sg_4v1 stratum 0"]
+    4v1[\"(4v1) <code>source_stream(pos_recv)</code>"/]:::pullClass
+    subgraph sg_4v1_var_poss ["var <tt>poss</tt>"]
+        4v1
+    end
+end
+1v1--->8v1
+4v1--->10v1
+6v1--->9v1
 8v1["(8v1) <code>handoff</code>"]:::otherClass
-8v1--pos--->1v1
+8v1===o2v1
+9v1["(9v1) <code>handoff</code>"]:::otherClass
+9v1==neg===o1v1
+10v1["(10v1) <code>handoff</code>"]:::otherClass
+10v1--pos--->1v1
 

--- a/hydroflow/tests/snapshots/surface_difference__diff_multiset_timing@graphvis_dot.snap
+++ b/hydroflow/tests/snapshots/surface_difference__diff_multiset_timing@graphvis_dot.snap
@@ -1,0 +1,51 @@
+---
+source: hydroflow/tests/surface_difference.rs
+expression: df.meta_graph().unwrap().to_dot()
+---
+digraph {
+    subgraph "cluster n1v1" {
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_1v1\nstratum 1"
+        n1v1 [label="(n1v1) difference_multiset()", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
+        n2v1 [label="(n2v1) for_each(|x| println!(\"diff: {:?}\", x))", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
+        n1v1 -> n2v1
+        subgraph "cluster sg_1v1_var_diff" {
+            label="var diff"
+            n1v1
+            n2v1
+        }
+    }
+    subgraph "cluster n2v1" {
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_2v1\nstratum 0"
+        n4v1 [label="(n4v1) source_stream(neg_recv)", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
+        n5v1 [label="(n5v1) tee()", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
+        n6v1 [label="(n6v1) for_each(|x| println!(\"neg: {:?}\", x))", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
+        n4v1 -> n5v1
+        n5v1 -> n6v1
+        subgraph "cluster sg_2v1_var_negs" {
+            label="var negs"
+            n4v1
+            n5v1
+        }
+    }
+    subgraph "cluster n3v1" {
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_3v1\nstratum 0"
+        n3v1 [label="(n3v1) source_stream(pos_recv)", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
+        subgraph "cluster sg_3v1_var_poss" {
+            label="var poss"
+            n3v1
+        }
+    }
+    n3v1 -> n8v1
+    n5v1 -> n7v1
+    n7v1 [label="(n7v1) handoff", fontname=Monaco, shape=parallelogram, style = filled, color = "#ddddff"]
+    n7v1 -> n1v1 [label="neg", arrowhead=box, color=red]
+    n8v1 [label="(n8v1) handoff", fontname=Monaco, shape=parallelogram, style = filled, color = "#ddddff"]
+    n8v1 -> n1v1 [label="pos"]
+}
+

--- a/hydroflow/tests/snapshots/surface_difference__diff_multiset_timing@graphvis_mermaid.snap
+++ b/hydroflow/tests/snapshots/surface_difference__diff_multiset_timing@graphvis_mermaid.snap
@@ -1,0 +1,42 @@
+---
+source: hydroflow/tests/surface_difference.rs
+expression: df.meta_graph().unwrap().to_mermaid()
+---
+%%{init:{'theme':'base','themeVariables':{'clusterBkg':'#ddd','clusterBorder':'#888'}}}%%
+flowchart TD
+classDef pullClass fill:#8af,stroke:#000,text-align:left,white-space:pre
+classDef pushClass fill:#ff8,stroke:#000,text-align:left,white-space:pre
+linkStyle default stroke:#aaa,stroke-width:4px,color:red,font-size:1.5em;
+subgraph sg_1v1 ["sg_1v1 stratum 1"]
+    1v1[\"(1v1) <code>difference_multiset()</code>"/]:::pullClass
+    2v1[/"(2v1) <code>for_each(|x| println!(&quot;diff: {:?}&quot;, x))</code>"\]:::pushClass
+    1v1--->2v1
+    subgraph sg_1v1_var_diff ["var <tt>diff</tt>"]
+        1v1
+        2v1
+    end
+end
+subgraph sg_2v1 ["sg_2v1 stratum 0"]
+    4v1[\"(4v1) <code>source_stream(neg_recv)</code>"/]:::pullClass
+    5v1[/"(5v1) <code>tee()</code>"\]:::pushClass
+    6v1[/"(6v1) <code>for_each(|x| println!(&quot;neg: {:?}&quot;, x))</code>"\]:::pushClass
+    4v1--->5v1
+    5v1--->6v1
+    subgraph sg_2v1_var_negs ["var <tt>negs</tt>"]
+        4v1
+        5v1
+    end
+end
+subgraph sg_3v1 ["sg_3v1 stratum 0"]
+    3v1[\"(3v1) <code>source_stream(pos_recv)</code>"/]:::pullClass
+    subgraph sg_3v1_var_poss ["var <tt>poss</tt>"]
+        3v1
+    end
+end
+3v1--->8v1
+5v1--->7v1
+7v1["(7v1) <code>handoff</code>"]:::otherClass
+7v1==neg===o1v1
+8v1["(8v1) <code>handoff</code>"]:::otherClass
+8v1--pos--->1v1
+

--- a/hydroflow/tests/snapshots/surface_difference__diff_static@graphvis_dot.snap
+++ b/hydroflow/tests/snapshots/surface_difference__diff_static@graphvis_dot.snap
@@ -8,44 +8,57 @@ digraph {
         style=filled
         label = "sg_1v1\nstratum 1"
         n1v1 [label="(n1v1) difference::<'tick, 'static>()", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
-        n2v1 [label="(n2v1) for_each(|v| output_send.send(v).unwrap())", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
-        n1v1 -> n2v1
         subgraph "cluster sg_1v1_var_diff" {
             label="var diff"
             n1v1
-            n2v1
         }
     }
     subgraph "cluster n2v1" {
         fillcolor="#dddddd"
         style=filled
-        label = "sg_2v1\nstratum 0"
-        n4v1 [label="(n4v1) source_stream(neg_recv)", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
-        n5v1 [label="(n5v1) tee()", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
-        n6v1 [label="(n6v1) for_each(|x| println!(\"neg: {:?}\", x))", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
-        n4v1 -> n5v1
-        n5v1 -> n6v1
-        subgraph "cluster sg_2v1_var_negs" {
-            label="var negs"
-            n4v1
-            n5v1
+        label = "sg_2v1\nstratum 2"
+        n2v1 [label="(n2v1) sort()", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
+        n3v1 [label="(n3v1) for_each(|v| output_send.send(v).unwrap())", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
+        n2v1 -> n3v1
+        subgraph "cluster sg_2v1_var_diff" {
+            label="var diff"
+            n2v1
+            n3v1
         }
     }
     subgraph "cluster n3v1" {
         fillcolor="#dddddd"
         style=filled
         label = "sg_3v1\nstratum 0"
-        n3v1 [label="(n3v1) source_stream(pos_recv)", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
-        subgraph "cluster sg_3v1_var_poss" {
-            label="var poss"
-            n3v1
+        n5v1 [label="(n5v1) source_stream(neg_recv)", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
+        n6v1 [label="(n6v1) tee()", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
+        n7v1 [label="(n7v1) for_each(|x| println!(\"neg: {:?}\", x))", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
+        n5v1 -> n6v1
+        n6v1 -> n7v1
+        subgraph "cluster sg_3v1_var_negs" {
+            label="var negs"
+            n5v1
+            n6v1
         }
     }
-    n3v1 -> n8v1
-    n5v1 -> n7v1
-    n7v1 [label="(n7v1) handoff", fontname=Monaco, shape=parallelogram, style = filled, color = "#ddddff"]
-    n7v1 -> n1v1 [label="neg", arrowhead=box, color=red]
+    subgraph "cluster n4v1" {
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_4v1\nstratum 0"
+        n4v1 [label="(n4v1) source_stream(pos_recv)", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
+        subgraph "cluster sg_4v1_var_poss" {
+            label="var poss"
+            n4v1
+        }
+    }
+    n1v1 -> n8v1
+    n4v1 -> n10v1
+    n6v1 -> n9v1
     n8v1 [label="(n8v1) handoff", fontname=Monaco, shape=parallelogram, style = filled, color = "#ddddff"]
-    n8v1 -> n1v1 [label="pos"]
+    n8v1 -> n2v1 [arrowhead=box, color=red]
+    n9v1 [label="(n9v1) handoff", fontname=Monaco, shape=parallelogram, style = filled, color = "#ddddff"]
+    n9v1 -> n1v1 [label="neg", arrowhead=box, color=red]
+    n10v1 [label="(n10v1) handoff", fontname=Monaco, shape=parallelogram, style = filled, color = "#ddddff"]
+    n10v1 -> n1v1 [label="pos"]
 }
 

--- a/hydroflow/tests/snapshots/surface_difference__diff_static@graphvis_mermaid.snap
+++ b/hydroflow/tests/snapshots/surface_difference__diff_static@graphvis_mermaid.snap
@@ -9,34 +9,43 @@ classDef pushClass fill:#ff8,stroke:#000,text-align:left,white-space:pre
 linkStyle default stroke:#aaa,stroke-width:4px,color:red,font-size:1.5em;
 subgraph sg_1v1 ["sg_1v1 stratum 1"]
     1v1[\"(1v1) <code>difference::&lt;'tick, 'static&gt;()</code>"/]:::pullClass
-    2v1[/"(2v1) <code>for_each(|v| output_send.send(v).unwrap())</code>"\]:::pushClass
-    1v1--->2v1
     subgraph sg_1v1_var_diff ["var <tt>diff</tt>"]
         1v1
+    end
+end
+subgraph sg_2v1 ["sg_2v1 stratum 2"]
+    2v1[\"(2v1) <code>sort()</code>"/]:::pullClass
+    3v1[/"(3v1) <code>for_each(|v| output_send.send(v).unwrap())</code>"\]:::pushClass
+    2v1--->3v1
+    subgraph sg_2v1_var_diff ["var <tt>diff</tt>"]
         2v1
-    end
-end
-subgraph sg_2v1 ["sg_2v1 stratum 0"]
-    4v1[\"(4v1) <code>source_stream(neg_recv)</code>"/]:::pullClass
-    5v1[/"(5v1) <code>tee()</code>"\]:::pushClass
-    6v1[/"(6v1) <code>for_each(|x| println!(&quot;neg: {:?}&quot;, x))</code>"\]:::pushClass
-    4v1--->5v1
-    5v1--->6v1
-    subgraph sg_2v1_var_negs ["var <tt>negs</tt>"]
-        4v1
-        5v1
-    end
-end
-subgraph sg_3v1 ["sg_3v1 stratum 0"]
-    3v1[\"(3v1) <code>source_stream(pos_recv)</code>"/]:::pullClass
-    subgraph sg_3v1_var_poss ["var <tt>poss</tt>"]
         3v1
     end
 end
-3v1--->8v1
-5v1--->7v1
-7v1["(7v1) <code>handoff</code>"]:::otherClass
-7v1==neg===o1v1
+subgraph sg_3v1 ["sg_3v1 stratum 0"]
+    5v1[\"(5v1) <code>source_stream(neg_recv)</code>"/]:::pullClass
+    6v1[/"(6v1) <code>tee()</code>"\]:::pushClass
+    7v1[/"(7v1) <code>for_each(|x| println!(&quot;neg: {:?}&quot;, x))</code>"\]:::pushClass
+    5v1--->6v1
+    6v1--->7v1
+    subgraph sg_3v1_var_negs ["var <tt>negs</tt>"]
+        5v1
+        6v1
+    end
+end
+subgraph sg_4v1 ["sg_4v1 stratum 0"]
+    4v1[\"(4v1) <code>source_stream(pos_recv)</code>"/]:::pullClass
+    subgraph sg_4v1_var_poss ["var <tt>poss</tt>"]
+        4v1
+    end
+end
+1v1--->8v1
+4v1--->10v1
+6v1--->9v1
 8v1["(8v1) <code>handoff</code>"]:::otherClass
-8v1--pos--->1v1
+8v1===o2v1
+9v1["(9v1) <code>handoff</code>"]:::otherClass
+9v1==neg===o1v1
+10v1["(10v1) <code>handoff</code>"]:::otherClass
+10v1--pos--->1v1
 

--- a/hydroflow/tests/snapshots/surface_examples__example_6_unreachability.snap
+++ b/hydroflow/tests/snapshots/surface_examples__example_6_unreachability.snap
@@ -80,6 +80,6 @@ Received vertex: 3
 Received vertex: 6
 Received vertex: 11
 Received vertex: 12
-unreached_vertices vertex: 11
 unreached_vertices vertex: 12
+unreached_vertices vertex: 11
 

--- a/hydroflow/tests/snapshots/surface_stratum__difference_a@graphvis_dot.snap
+++ b/hydroflow/tests/snapshots/surface_stratum__difference_a@graphvis_dot.snap
@@ -15,7 +15,7 @@ digraph {
         label = "sg_2v1\nstratum 1"
         n2v1 [label="(n2v1) source_iter([1, 2, 3, 4])", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
         n1v1 [label="(n1v1) difference()", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
-        n4v1 [label="(n4v1) for_each(|x| output_inner.borrow_mut().push(x))", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
+        n4v1 [label="(n4v1) for_each(|x| output_inner.borrow_mut().insert(x))", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
         n2v1 -> n1v1 [label="pos"]
         n1v1 -> n4v1
         subgraph "cluster sg_2v1_var_a" {

--- a/hydroflow/tests/snapshots/surface_stratum__difference_a@graphvis_mermaid.snap
+++ b/hydroflow/tests/snapshots/surface_stratum__difference_a@graphvis_mermaid.snap
@@ -13,7 +13,7 @@ end
 subgraph sg_2v1 ["sg_2v1 stratum 1"]
     2v1[\"(2v1) <code>source_iter([1, 2, 3, 4])</code>"/]:::pullClass
     1v1[\"(1v1) <code>difference()</code>"/]:::pullClass
-    4v1[/"(4v1) <code>for_each(|x| output_inner.borrow_mut().push(x))</code>"\]:::pushClass
+    4v1[/"(4v1) <code>for_each(|x| output_inner.borrow_mut().insert(x))</code>"\]:::pushClass
     2v1--pos--->1v1
     1v1--->4v1
     subgraph sg_2v1_var_a ["var <tt>a</tt>"]

--- a/hydroflow/tests/snapshots/surface_stratum__difference_b@graphvis_dot.snap
+++ b/hydroflow/tests/snapshots/surface_stratum__difference_b@graphvis_dot.snap
@@ -15,7 +15,7 @@ digraph {
         label = "sg_2v1\nstratum 1"
         n1v1 [label="(n1v1) difference()", fontname=Monaco, shape=invhouse, style = filled, color = "#0022ff", fontcolor = "#ffffff"]
         n3v1 [label="(n3v1) tee()", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
-        n5v1 [label="(n5v1) for_each(|x| output_inner.borrow_mut().push(x))", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
+        n5v1 [label="(n5v1) for_each(|x| output_inner.borrow_mut().insert(x))", fontname=Monaco, shape=house, style = filled, color = "#ffff00"]
         n1v1 -> n3v1
         n3v1 -> n5v1 [label="1"]
         subgraph "cluster sg_2v1_var_a" {

--- a/hydroflow/tests/snapshots/surface_stratum__difference_b@graphvis_mermaid.snap
+++ b/hydroflow/tests/snapshots/surface_stratum__difference_b@graphvis_mermaid.snap
@@ -13,7 +13,7 @@ end
 subgraph sg_2v1 ["sg_2v1 stratum 1"]
     1v1[\"(1v1) <code>difference()</code>"/]:::pullClass
     3v1[/"(3v1) <code>tee()</code>"\]:::pushClass
-    5v1[/"(5v1) <code>for_each(|x| output_inner.borrow_mut().push(x))</code>"\]:::pushClass
+    5v1[/"(5v1) <code>for_each(|x| output_inner.borrow_mut().insert(x))</code>"\]:::pushClass
     1v1--->3v1
     3v1--1--->5v1
     subgraph sg_2v1_var_a ["var <tt>a</tt>"]

--- a/hydroflow/tests/surface_codegen.rs
+++ b/hydroflow/tests/surface_codegen.rs
@@ -204,18 +204,63 @@ pub fn test_cross_join() {
 
     let mut df = hydroflow_syntax! {
         cj = cross_join() -> for_each(|v| out_send.send(v).unwrap());
-        source_iter([1, 2, 3]) -> [0]cj;
-        source_iter(["a", "b", "c"]) -> [1]cj;
+        source_iter([1, 2, 2, 3]) -> [0]cj;
+        source_iter(["a", "b", "c", "c"]) -> [1]cj;
     };
     df.run_available();
 
-    let out: HashSet<_> = collect_ready(&mut out_recv);
-    assert_eq!(3 * 3, out.len());
-    for n in [1, 2, 3] {
-        for c in ["a", "b", "c"] {
-            assert!(out.contains(&(n, c)));
-        }
-    }
+    let mut out: Vec<_> = collect_ready(&mut out_recv);
+    out.sort();
+    assert_eq!(
+        out,
+        [
+            (1, "a"),
+            (1, "b"),
+            (1, "c"),
+            (2, "a"),
+            (2, "b"),
+            (2, "c"),
+            (3, "a"),
+            (3, "b"),
+            (3, "c")
+        ]
+    );
+}
+
+#[multiplatform_test]
+pub fn test_cross_join_multiset() {
+    let (out_send, mut out_recv) = hydroflow::util::unbounded_channel::<(usize, &str)>();
+
+    let mut df = hydroflow_syntax! {
+        cj = cross_join_multiset() -> for_each(|v| out_send.send(v).unwrap());
+        source_iter([1, 2, 2, 3]) -> [0]cj;
+        source_iter(["a", "b", "c", "c"]) -> [1]cj;
+    };
+    df.run_available();
+
+    let mut out: Vec<_> = collect_ready(&mut out_recv);
+    out.sort();
+    assert_eq!(
+        out,
+        [
+            (1, "a"),
+            (1, "b"),
+            (1, "c"),
+            (1, "c"),
+            (2, "a"),
+            (2, "a"),
+            (2, "b"),
+            (2, "b"),
+            (2, "c"),
+            (2, "c"),
+            (2, "c"),
+            (2, "c"),
+            (3, "a"),
+            (3, "b"),
+            (3, "c"),
+            (3, "c"),
+        ]
+    );
 }
 
 #[multiplatform_test]
@@ -271,6 +316,130 @@ pub fn test_anti_join() {
 }
 
 #[multiplatform_test]
+pub fn test_anti_join_static() {
+    let (pos_send, pos_recv) = hydroflow::util::unbounded_channel::<(usize, usize)>();
+    let (neg_send, neg_recv) = hydroflow::util::unbounded_channel::<usize>();
+    let (out_send, mut out_recv) = hydroflow::util::unbounded_channel::<(usize, usize)>();
+    let mut flow = hydroflow::hydroflow_syntax! {
+        pos = source_stream(pos_recv);
+        neg = source_stream(neg_recv);
+        pos -> [pos]diff_static;
+        neg -> [neg]diff_static;
+        diff_static = anti_join::<'static>() -> for_each(|x| out_send.send(x).unwrap());
+    };
+
+    for x in [(1, 2), (1, 2), (200, 3), (300, 4), (400, 5), (5, 6)] {
+        pos_send.send(x).unwrap();
+    }
+    for x in [200, 300] {
+        neg_send.send(x).unwrap();
+    }
+    flow.run_tick();
+    let out: Vec<_> = collect_ready(&mut out_recv);
+    assert_eq!(&[(1, 2), (400, 5), (5, 6)], &*out);
+
+    neg_send.send(400).unwrap();
+
+    flow.run_available();
+    let out: Vec<_> = collect_ready(&mut out_recv);
+    assert_eq!(&[(1, 2), (5, 6)], &*out);
+}
+
+#[multiplatform_test]
+pub fn test_anti_join_tick_static() {
+    let (pos_send, pos_recv) = hydroflow::util::unbounded_channel::<(usize, usize)>();
+    let (neg_send, neg_recv) = hydroflow::util::unbounded_channel::<usize>();
+    let (out_send, mut out_recv) = hydroflow::util::unbounded_channel::<(usize, usize)>();
+    let mut flow = hydroflow::hydroflow_syntax! {
+        pos = source_stream(pos_recv);
+        neg = source_stream(neg_recv);
+        pos -> [pos]diff_static;
+        neg -> [neg]diff_static;
+        diff_static = anti_join::<'tick, 'static>() -> for_each(|x| out_send.send(x).unwrap());
+    };
+
+    for x in [(1, 2), (1, 2), (200, 3), (300, 4), (400, 5), (5, 6)] {
+        pos_send.send(x).unwrap();
+    }
+    for x in [200, 300] {
+        neg_send.send(x).unwrap();
+    }
+    flow.run_tick();
+    let out: Vec<_> = collect_ready(&mut out_recv);
+    assert_eq!(&[(1, 2), (400, 5), (5, 6)], &*out);
+
+    for x in [(10, 10), (10, 10), (200, 5)] {
+        pos_send.send(x).unwrap();
+    }
+
+    flow.run_available();
+    let out: Vec<_> = collect_ready(&mut out_recv);
+    assert_eq!(&[(10, 10)], &*out);
+}
+
+#[multiplatform_test]
+pub fn test_anti_join_multiset_tick_static() {
+    let (pos_send, pos_recv) = hydroflow::util::unbounded_channel::<(usize, usize)>();
+    let (neg_send, neg_recv) = hydroflow::util::unbounded_channel::<usize>();
+    let (out_send, mut out_recv) = hydroflow::util::unbounded_channel::<(usize, usize)>();
+    let mut flow = hydroflow::hydroflow_syntax! {
+        pos = source_stream(pos_recv);
+        neg = source_stream(neg_recv);
+        pos -> [pos]diff_static;
+        neg -> [neg]diff_static;
+        diff_static = anti_join_multiset::<'tick, 'static>() -> for_each(|x| out_send.send(x).unwrap());
+    };
+
+    for x in [(1, 2), (1, 2), (200, 3), (300, 4), (400, 5), (5, 6)] {
+        pos_send.send(x).unwrap();
+    }
+    for x in [200, 300] {
+        neg_send.send(x).unwrap();
+    }
+    flow.run_tick();
+    let out: Vec<_> = collect_ready(&mut out_recv);
+    assert_eq!(&[(1, 2), (1, 2), (400, 5), (5, 6)], &*out);
+
+    for x in [(10, 10), (10, 10), (200, 5)] {
+        pos_send.send(x).unwrap();
+    }
+
+    flow.run_available();
+    let out: Vec<_> = collect_ready(&mut out_recv);
+    assert_eq!(&[(10, 10), (10, 10)], &*out);
+}
+
+#[multiplatform_test]
+pub fn test_anti_join_multiset_static() {
+    let (pos_send, pos_recv) = hydroflow::util::unbounded_channel::<(usize, usize)>();
+    let (neg_send, neg_recv) = hydroflow::util::unbounded_channel::<usize>();
+    let (out_send, mut out_recv) = hydroflow::util::unbounded_channel::<(usize, usize)>();
+    let mut flow = hydroflow::hydroflow_syntax! {
+        pos = source_stream(pos_recv);
+        neg = source_stream(neg_recv);
+        pos -> [pos]diff_static;
+        neg -> [neg]diff_static;
+        diff_static = anti_join_multiset::<'static>() -> for_each(|x| out_send.send(x).unwrap());
+    };
+
+    for x in [(1, 2), (1, 2), (200, 3), (300, 4), (400, 5), (5, 6)] {
+        pos_send.send(x).unwrap();
+    }
+    for x in [200, 300] {
+        neg_send.send(x).unwrap();
+    }
+    flow.run_tick();
+    let out: Vec<_> = collect_ready(&mut out_recv);
+    assert_eq!(&[(1, 2), (1, 2), (400, 5), (5, 6)], &*out);
+
+    neg_send.send(400).unwrap();
+
+    flow.run_available();
+    let out: Vec<_> = collect_ready(&mut out_recv);
+    assert_eq!(&[(1, 2), (1, 2), (5, 6)], &*out);
+}
+
+#[multiplatform_test]
 pub fn test_anti_join_multiset() {
     let (inp_send, inp_recv) = hydroflow::util::unbounded_channel::<(usize, usize)>();
     let (out_send, mut out_recv) = hydroflow::util::unbounded_channel::<(usize, usize)>();
@@ -293,7 +462,10 @@ pub fn test_anti_join_multiset() {
 
     flow.run_available();
     let out: Vec<_> = collect_ready(&mut out_recv);
-    assert_eq!(&[(1, 2), (1, 2), (2, 3), (3, 4), (4, 5), (5, 4), (6, 5)], &*out);
+    assert_eq!(
+        &[(1, 2), (1, 2), (2, 3), (3, 4), (4, 5), (5, 4), (6, 5)],
+        &*out
+    );
 }
 
 #[multiplatform_test]

--- a/hydroflow/tests/surface_codegen.rs
+++ b/hydroflow/tests/surface_codegen.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use hydroflow::scheduled::graph::Hydroflow;
 use hydroflow::util::collect_ready;
+use hydroflow::util::multiset::HashMultiSet;
 use hydroflow::{assert_graphvis_snapshots, hydroflow_syntax};
 use multiplatform_test::multiplatform_test;
 
@@ -285,8 +286,10 @@ pub fn test_defer_tick() {
     flow.run_tick();
 
     flow.run_available();
-    let out: Vec<_> = collect_ready(&mut out_recv);
-    assert_eq!(&[1, 2, 3, 4, 5, 6], &*out);
+    assert_eq!(
+        HashMultiSet::from_iter([1, 2, 3, 4, 5, 6]),
+        collect_ready(&mut out_recv)
+    );
 }
 
 #[multiplatform_test]

--- a/hydroflow/tests/surface_difference.rs
+++ b/hydroflow/tests/surface_difference.rs
@@ -32,6 +32,7 @@ pub fn test_diff_timing() {
     pos_send.send(2).unwrap();
     pos_send.send(3).unwrap();
     pos_send.send(4).unwrap();
+    pos_send.send(4).unwrap();
     neg_send.send(2).unwrap();
     neg_send.send(3).unwrap();
     df.run_tick();
@@ -65,6 +66,7 @@ pub fn test_diff_static() {
     assert_graphvis_snapshots!(df);
 
     pos_send.send(1).unwrap();
+    pos_send.send(1).unwrap();
     pos_send.send(2).unwrap();
 
     neg_send.send(2).unwrap();
@@ -74,10 +76,95 @@ pub fn test_diff_static() {
     assert_eq!(&[1], &*collect_ready::<Vec<_>, _>(&mut output_recv));
 
     pos_send.send(1).unwrap();
+    pos_send.send(1).unwrap();
     pos_send.send(2).unwrap();
     pos_send.send(3).unwrap();
 
     df.run_tick();
 
     assert_eq!(&[1, 3], &*collect_ready::<Vec<_>, _>(&mut output_recv));
+}
+
+
+#[multiplatform_test]
+pub fn test_diff_multiset_timing() {
+    // An edge in the input data = a pair of `usize` vertex IDs.
+    let (pos_send, pos_recv) = hydroflow::util::unbounded_channel::<usize>();
+    let (neg_send, neg_recv) = hydroflow::util::unbounded_channel::<usize>();
+
+    let mut df = hydroflow::hydroflow_syntax! {
+        diff = difference_multiset() -> for_each(|x| println!("diff: {:?}", x));
+
+        poss = source_stream(pos_recv); //-> tee();
+        poss -> [pos]diff;
+        // if you enable the comment below it produces the right answer
+        // poss -> for_each(|x| println!("pos: {:?}", x));
+
+        negs = source_stream(neg_recv) -> tee();
+        negs -> [neg]diff;
+        negs -> for_each(|x| println!("neg: {:?}", x));
+
+    };
+    assert_graphvis_snapshots!(df);
+
+    df.run_tick();
+    println!("{}x{}", df.current_tick(), df.current_stratum());
+
+    println!("A");
+
+    pos_send.send(1).unwrap();
+    pos_send.send(2).unwrap();
+    pos_send.send(3).unwrap();
+    pos_send.send(4).unwrap();
+    pos_send.send(4).unwrap();
+    neg_send.send(2).unwrap();
+    neg_send.send(3).unwrap();
+    df.run_tick();
+
+    println!("B");
+    neg_send.send(1).unwrap();
+    df.run_tick();
+}
+
+#[multiplatform_test]
+pub fn test_diff_multiset_static() {
+    // An edge in the input data = a pair of `usize` vertex IDs.
+    let (pos_send, pos_recv) = hydroflow::util::unbounded_channel::<usize>();
+    let (neg_send, neg_recv) = hydroflow::util::unbounded_channel::<usize>();
+
+    let (output_send, mut output_recv) = hydroflow::util::unbounded_channel::<usize>();
+
+    let mut df = hydroflow::hydroflow_syntax! {
+        diff = difference_multiset::<'tick, 'static>() -> for_each(|v| output_send.send(v).unwrap());
+
+        poss = source_stream(pos_recv); //-> tee();
+        poss -> [pos]diff;
+        // if you enable the comment below it produces the right answer
+        // poss -> for_each(|x| println!("pos: {:?}", x));
+
+        negs = source_stream(neg_recv) -> tee();
+        negs -> [neg]diff;
+        negs -> for_each(|x| println!("neg: {:?}", x));
+
+    };
+    assert_graphvis_snapshots!(df);
+
+    pos_send.send(1).unwrap();
+    pos_send.send(1).unwrap();
+    pos_send.send(2).unwrap();
+
+    neg_send.send(2).unwrap();
+
+    df.run_tick();
+
+    assert_eq!(&[1, 1], &*collect_ready::<Vec<_>, _>(&mut output_recv));
+
+    pos_send.send(1).unwrap();
+    pos_send.send(1).unwrap();
+    pos_send.send(2).unwrap();
+    pos_send.send(3).unwrap();
+
+    df.run_tick();
+
+    assert_eq!(&[1, 1, 3], &*collect_ready::<Vec<_>, _>(&mut output_recv));
 }

--- a/hydroflow/tests/surface_difference.rs
+++ b/hydroflow/tests/surface_difference.rs
@@ -51,7 +51,7 @@ pub fn test_diff_static() {
     let (output_send, mut output_recv) = hydroflow::util::unbounded_channel::<usize>();
 
     let mut df = hydroflow::hydroflow_syntax! {
-        diff = difference::<'tick, 'static>() -> for_each(|v| output_send.send(v).unwrap());
+        diff = difference::<'tick, 'static>() -> sort() -> for_each(|v| output_send.send(v).unwrap());
 
         poss = source_stream(pos_recv); //-> tee();
         poss -> [pos]diff;
@@ -134,7 +134,7 @@ pub fn test_diff_multiset_static() {
     let (output_send, mut output_recv) = hydroflow::util::unbounded_channel::<usize>();
 
     let mut df = hydroflow::hydroflow_syntax! {
-        diff = difference_multiset::<'static>() -> for_each(|v| output_send.send(v).unwrap());
+        diff = difference_multiset::<'static>() -> sort() -> for_each(|v| output_send.send(v).unwrap());
 
         poss = source_stream(pos_recv); //-> tee();
         poss -> [pos]diff;
@@ -180,7 +180,7 @@ pub fn test_diff_multiset_tick_static() {
     let (output_send, mut output_recv) = hydroflow::util::unbounded_channel::<usize>();
 
     let mut df = hydroflow::hydroflow_syntax! {
-        diff = difference_multiset::<'tick, 'static>() -> for_each(|v| output_send.send(v).unwrap());
+        diff = difference_multiset::<'tick, 'static>() -> sort() -> for_each(|v| output_send.send(v).unwrap());
 
         poss = source_stream(pos_recv); //-> tee();
         poss -> [pos]diff;
@@ -223,7 +223,7 @@ pub fn test_diff_multiset_static_tick() {
     let (output_send, mut output_recv) = hydroflow::util::unbounded_channel::<usize>();
 
     let mut df = hydroflow::hydroflow_syntax! {
-        diff = difference_multiset::<'static, 'tick>() -> for_each(|v| output_send.send(v).unwrap());
+        diff = difference_multiset::<'static, 'tick>() -> sort() -> for_each(|v| output_send.send(v).unwrap());
 
         poss = source_stream(pos_recv); //-> tee();
         poss -> [pos]diff;

--- a/hydroflow/tests/surface_stratum.rs
+++ b/hydroflow/tests/surface_stratum.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use hydroflow::scheduled::graph::Hydroflow;
+use hydroflow::util::multiset::HashMultiSet;
 use hydroflow::{assert_graphvis_snapshots, hydroflow_syntax};
 use multiplatform_test::multiplatform_test;
 use tokio::sync::mpsc::error::SendError;
@@ -19,19 +20,19 @@ use tokio::sync::mpsc::error::SendError;
 /// Basic difference test, test difference between two one-off iterators.
 #[multiplatform_test]
 pub fn test_difference_a() {
-    let output = <Rc<RefCell<Vec<usize>>>>::default();
+    let output = <Rc<RefCell<HashMultiSet<usize>>>>::default();
     let output_inner = Rc::clone(&output);
 
     let mut df: Hydroflow = hydroflow_syntax! {
         a = difference();
         source_iter([1, 2, 3, 4]) -> [pos]a;
         source_iter([1, 3, 5, 7]) -> [neg]a;
-        a -> for_each(|x| output_inner.borrow_mut().push(x));
+        a -> for_each(|x| output_inner.borrow_mut().insert(x));
     };
     assert_graphvis_snapshots!(df);
     df.run_available();
 
-    assert_eq!(&[2, 4], &*output.take());
+    assert_eq!(HashMultiSet::from_iter([2, 4]), output.take());
 }
 
 /// More complex different test.
@@ -40,7 +41,7 @@ pub fn test_difference_a() {
 pub fn test_difference_b() -> Result<(), SendError<&'static str>> {
     let (inp_send, inp_recv) = hydroflow::util::unbounded_channel::<&'static str>();
 
-    let output = <Rc<RefCell<Vec<&'static str>>>>::default();
+    let output = <Rc<RefCell<HashMultiSet<&'static str>>>>::default();
     let output_inner = Rc::clone(&output);
 
     let mut df: Hydroflow = hydroflow_syntax! {
@@ -48,7 +49,7 @@ pub fn test_difference_b() -> Result<(), SendError<&'static str>> {
         source_stream(inp_recv) -> [pos]a;
         b = a -> tee();
         b[0] -> defer_tick() -> [neg]a;
-        b[1] -> for_each(|x| output_inner.borrow_mut().push(x));
+        b[1] -> for_each(|x| output_inner.borrow_mut().insert(x));
     };
     assert_graphvis_snapshots!(df);
 
@@ -56,19 +57,19 @@ pub fn test_difference_b() -> Result<(), SendError<&'static str>> {
     inp_send.send("02")?;
     inp_send.send("03")?;
     df.run_tick();
-    assert_eq!(&["01", "02", "03"], &*output.take());
+    assert_eq!(HashMultiSet::from_iter(["01", "02", "03"]), output.take());
 
     inp_send.send("02")?;
     inp_send.send("11")?;
     inp_send.send("12")?;
     df.run_tick();
-    assert_eq!(&["11", "12"], &*output.take());
+    assert_eq!(HashMultiSet::from_iter(["11", "12"]), output.take());
 
     inp_send.send("02")?;
     inp_send.send("11")?;
     inp_send.send("12")?;
     df.run_tick();
-    assert_eq!(&["02"], &*output.take());
+    assert_eq!(HashMultiSet::from_iter(["02"]), output.take());
 
     Ok(())
 }

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__anti_join@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__anti_join@datalog_program.snap
@@ -381,17 +381,26 @@ fn main() {
                         ),
                     ),
                 );
-            let sg_1v1_node_17v1_persisttick = df
-                .add_state(std::cell::RefCell::new(0usize));
-            let sg_1v1_node_21v1_diffdata_handle = df
+            let sg_1v1_node_21v1_antijoindata_neg = df
                 .add_state(
-                    ::std::cell::RefCell::new(
+                    std::cell::RefCell::new(
                         hydroflow::util::monotonic_map::MonotonicMap::<
                             _,
                             hydroflow::rustc_hash::FxHashSet<_>,
                         >::default(),
                     ),
                 );
+            let sg_1v1_node_21v1_antijoindata_pos = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_1v1_node_21v1_persisttick = df
+                .add_state(std::cell::RefCell::new(0_usize));
             let sg_1v1_node_11v1_uniquedata = df
                 .add_state(
                     ::std::cell::RefCell::new(
@@ -583,9 +592,6 @@ fn main() {
                     let mut sg_1v1_node_17v1_joindata_rhs_borrow = context
                         .state_ref(sg_1v1_node_17v1_joindata_rhs)
                         .borrow_mut();
-                    let mut sg_1v1_node_17v1_persisttick_borrow = context
-                        .state_ref(sg_1v1_node_17v1_persisttick)
-                        .borrow_mut();
                     let op_17v1 = {
                         #[inline(always)]
                         fn check_inputs<'a, K, I1, V1, I2, V2>(
@@ -601,7 +607,6 @@ fn main() {
                                 V2,
                                 V1,
                             >,
-                            is_new_tick: bool,
                         ) -> impl 'a + Iterator<Item = (K, (V1, V2))>
                         where
                             K: Eq + std::hash::Hash + Clone,
@@ -610,34 +615,21 @@ fn main() {
                             I1: 'a + Iterator<Item = (K, V1)>,
                             I2: 'a + Iterator<Item = (K, V2)>,
                         {
-                            hydroflow::compiled::pull::symmetric_hash_join_into_iter(
+                            hydroflow::compiled::pull::SymmetricHashJoin::new_from_mut(
                                 lhs,
                                 rhs,
                                 lhs_state,
                                 rhs_state,
-                                is_new_tick,
                             )
                         }
-                        {
-                            let __is_new_tick = if *sg_1v1_node_17v1_persisttick_borrow
-                                < context.current_tick()
-                            {
-                                *sg_1v1_node_17v1_persisttick_borrow = context
-                                    .current_tick();
-                                true
-                            } else {
-                                false
-                            };
-                            check_inputs(
-                                op_19v1,
-                                op_20v1,
-                                &mut *sg_1v1_node_17v1_joindata_lhs_borrow
-                                    .get_mut_clear(context.current_tick()),
-                                &mut *sg_1v1_node_17v1_joindata_rhs_borrow
-                                    .get_mut_clear(context.current_tick()),
-                                __is_new_tick,
-                            )
-                        }
+                        check_inputs(
+                            op_19v1,
+                            op_20v1,
+                            &mut *sg_1v1_node_17v1_joindata_lhs_borrow
+                                .get_mut_clear(context.current_tick()),
+                            &mut *sg_1v1_node_17v1_joindata_rhs_borrow
+                                .get_mut_clear(context.current_tick()),
+                        )
                     };
                     let op_17v1 = {
                         #[allow(non_snake_case)]
@@ -735,34 +727,55 @@ fn main() {
                         }
                         op_23v1__map__loc_unknown_start_7_28_end_7_54(op_23v1)
                     };
-                    let mut sg_1v1_node_21v1_borrow = context
-                        .state_ref(sg_1v1_node_21v1_diffdata_handle)
+                    let mut sg_1v1_node_21v1_antijoindata_neg_borrow = context
+                        .state_ref(sg_1v1_node_21v1_antijoindata_neg)
+                        .borrow_mut();
+                    let mut sg_1v1_node_21v1_antijoindata_pos_borrow = context
+                        .state_ref(sg_1v1_node_21v1_antijoindata_pos)
                         .borrow_mut();
                     let op_21v1 = {
                         /// Limit error propagation by bounding locally, erasing output iterator type.
                         #[inline(always)]
                         fn check_inputs<'a, K, I1, V, I2>(
-                            input_pos: I1,
-                            input_neg: I2,
-                            borrow_state: &'a mut hydroflow::rustc_hash::FxHashSet<K>,
+                            input_neg: I1,
+                            input_pos: I2,
+                            neg_state: &'a mut hydroflow::rustc_hash::FxHashSet<K>,
+                            pos_state: &'a mut hydroflow::rustc_hash::FxHashSet<(K, V)>,
+                            is_new_tick: bool,
                         ) -> impl 'a + Iterator<Item = (K, V)>
                         where
                             K: Eq + ::std::hash::Hash + Clone,
-                            V: Eq + Clone,
-                            I1: 'a + Iterator<Item = (K, V)>,
-                            I2: 'a + Iterator<Item = K>,
+                            V: Eq + ::std::hash::Hash + Clone,
+                            I1: 'a + Iterator<Item = K>,
+                            I2: 'a + Iterator<Item = (K, V)>,
                         {
-                            borrow_state.extend(input_neg);
-                            input_pos.filter(move |x| !borrow_state.contains(&x.0))
+                            neg_state.extend(input_neg);
+                            hydroflow::compiled::pull::AntiJoin::new_from_mut(
+                                input_pos,
+                                neg_state,
+                                pos_state,
+                                is_new_tick,
+                            )
                         }
+                        let __is_new_tick = {
+                            let mut __borrow_ident = context
+                                .state_ref(sg_1v1_node_21v1_persisttick)
+                                .borrow_mut();
+                            if *__borrow_ident <= context.current_tick() {
+                                *__borrow_ident = context.current_tick();
+                                true
+                            } else {
+                                false
+                            }
+                        };
                         check_inputs(
-                            op_23v1,
                             hoff_12v3_recv,
-                            sg_1v1_node_21v1_borrow
-                                .get_mut_clear((
-                                    context.current_tick(),
-                                    context.current_stratum(),
-                                )),
+                            op_23v1,
+                            &mut *sg_1v1_node_21v1_antijoindata_neg_borrow
+                                .get_mut_clear(context.current_tick()),
+                            &mut *sg_1v1_node_21v1_antijoindata_pos_borrow
+                                .get_mut_clear(context.current_tick()),
+                            __is_new_tick,
                         )
                     };
                     let op_21v1 = {

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__anti_join@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__anti_join@datalog_program.snap
@@ -762,7 +762,7 @@ fn main() {
                                 .state_ref(sg_1v1_node_21v1_persisttick)
                                 .borrow_mut();
                             if *__borrow_ident <= context.current_tick() {
-                                *__borrow_ident = context.current_tick();
+                                *__borrow_ident = context.current_tick() + 1;
                                 true
                             } else {
                                 false

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__anti_join@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__anti_join@datalog_program.snap
@@ -631,10 +631,10 @@ fn main() {
                         }
                         {
                             let __is_new_tick = if *sg_1v1_node_17v1_persisttick_borrow
-                                < context.current_tick()
+                                <= context.current_tick()
                             {
                                 *sg_1v1_node_17v1_persisttick_borrow = context
-                                    .current_tick();
+                                    .current_tick() + 1;
                                 true
                             } else {
                                 false
@@ -769,7 +769,7 @@ fn main() {
                             I2: 'a + Iterator<Item = (K, V)>,
                         {
                             neg_state.extend(input_neg);
-                            hydroflow::compiled::pull::AntiJoin::new_from_mut(
+                            hydroflow::compiled::pull::anti_join_into_iter(
                                 input_pos,
                                 neg_state,
                                 pos_state,

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__anti_join@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__anti_join@datalog_program.snap
@@ -381,6 +381,8 @@ fn main() {
                         ),
                     ),
                 );
+            let sg_1v1_node_17v1_persisttick = df
+                .add_state(std::cell::RefCell::new(0usize));
             let sg_1v1_node_21v1_antijoindata_neg = df
                 .add_state(
                     std::cell::RefCell::new(
@@ -592,6 +594,9 @@ fn main() {
                     let mut sg_1v1_node_17v1_joindata_rhs_borrow = context
                         .state_ref(sg_1v1_node_17v1_joindata_rhs)
                         .borrow_mut();
+                    let mut sg_1v1_node_17v1_persisttick_borrow = context
+                        .state_ref(sg_1v1_node_17v1_persisttick)
+                        .borrow_mut();
                     let op_17v1 = {
                         #[inline(always)]
                         fn check_inputs<'a, K, I1, V1, I2, V2>(
@@ -607,6 +612,7 @@ fn main() {
                                 V2,
                                 V1,
                             >,
+                            is_new_tick: bool,
                         ) -> impl 'a + Iterator<Item = (K, (V1, V2))>
                         where
                             K: Eq + std::hash::Hash + Clone,
@@ -615,21 +621,34 @@ fn main() {
                             I1: 'a + Iterator<Item = (K, V1)>,
                             I2: 'a + Iterator<Item = (K, V2)>,
                         {
-                            hydroflow::compiled::pull::SymmetricHashJoin::new_from_mut(
+                            hydroflow::compiled::pull::symmetric_hash_join_into_iter(
                                 lhs,
                                 rhs,
                                 lhs_state,
                                 rhs_state,
+                                is_new_tick,
                             )
                         }
-                        check_inputs(
-                            op_19v1,
-                            op_20v1,
-                            &mut *sg_1v1_node_17v1_joindata_lhs_borrow
-                                .get_mut_clear(context.current_tick()),
-                            &mut *sg_1v1_node_17v1_joindata_rhs_borrow
-                                .get_mut_clear(context.current_tick()),
-                        )
+                        {
+                            let __is_new_tick = if *sg_1v1_node_17v1_persisttick_borrow
+                                < context.current_tick()
+                            {
+                                *sg_1v1_node_17v1_persisttick_borrow = context
+                                    .current_tick();
+                                true
+                            } else {
+                                false
+                            };
+                            check_inputs(
+                                op_19v1,
+                                op_20v1,
+                                &mut *sg_1v1_node_17v1_joindata_lhs_borrow
+                                    .get_mut_clear(context.current_tick()),
+                                &mut *sg_1v1_node_17v1_joindata_rhs_borrow
+                                    .get_mut_clear(context.current_tick()),
+                                __is_new_tick,
+                            )
+                        }
                     };
                     let op_17v1 = {
                         #[allow(non_snake_case)]

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__index@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__index@datalog_program.snap
@@ -1073,7 +1073,7 @@ fn main() {
                                 .state_ref(sg_5v1_node_23v1_persisttick)
                                 .borrow_mut();
                             if *__borrow_ident <= context.current_tick() {
-                                *__borrow_ident = context.current_tick();
+                                *__borrow_ident = context.current_tick() + 1;
                                 true
                             } else {
                                 false
@@ -1973,7 +1973,7 @@ fn main() {
                                 .state_ref(sg_7v1_node_18v1_persisttick)
                                 .borrow_mut();
                             if *__borrow_ident <= context.current_tick() {
-                                *__borrow_ident = context.current_tick();
+                                *__borrow_ident = context.current_tick() + 1;
                                 true
                             } else {
                                 false

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__index@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__index@datalog_program.snap
@@ -1061,7 +1061,7 @@ fn main() {
                             I2: 'a + Iterator<Item = (K, V)>,
                         {
                             neg_state.extend(input_neg);
-                            hydroflow::compiled::pull::AntiJoin::new_from_mut(
+                            hydroflow::compiled::pull::anti_join_into_iter(
                                 input_pos,
                                 neg_state,
                                 pos_state,
@@ -1961,7 +1961,7 @@ fn main() {
                             I2: 'a + Iterator<Item = (K, V)>,
                         {
                             neg_state.extend(input_neg);
-                            hydroflow::compiled::pull::AntiJoin::new_from_mut(
+                            hydroflow::compiled::pull::anti_join_into_iter(
                                 input_pos,
                                 neg_state,
                                 pos_state,

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__index@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__index@datalog_program.snap
@@ -900,12 +900,21 @@ fn main() {
                         >::default(),
                     ),
                 );
-            let sg_5v1_node_23v1_diffdata_handle = df
+            let sg_5v1_node_23v1_antijoindata_neg = df
                 .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::rustc_hash::FxHashSet::default(),
+                    std::cell::RefCell::new(hydroflow::rustc_hash::FxHashSet::default()),
+                );
+            let sg_5v1_node_23v1_antijoindata_pos = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
                     ),
                 );
+            let sg_5v1_node_23v1_persisttick = df
+                .add_state(std::cell::RefCell::new(0_usize));
             let sg_5v1_node_11v1_uniquedata = df
                 .add_state(
                     ::std::cell::RefCell::new(
@@ -1028,12 +1037,58 @@ fn main() {
                         }
                         op_22v1__unique__loc_unknown_start_15_21_end_15_35(op_22v1)
                     };
-                    let mut sg_5v1_node_23v1_negset = context
-                        .state_ref(sg_5v1_node_23v1_diffdata_handle)
+                    let op_22v1 = op_22v1.map(|k| (k, ()));
+                    let mut sg_5v1_node_23v1_antijoindata_neg_borrow = context
+                        .state_ref(sg_5v1_node_23v1_antijoindata_neg)
                         .borrow_mut();
-                    sg_5v1_node_23v1_negset.extend(hoff_9v3_recv);
-                    let op_23v1 = op_22v1
-                        .filter(move |x| !sg_5v1_node_23v1_negset.contains(x));
+                    let mut sg_5v1_node_23v1_antijoindata_pos_borrow = context
+                        .state_ref(sg_5v1_node_23v1_antijoindata_pos)
+                        .borrow_mut();
+                    let op_23v1 = {
+                        /// Limit error propagation by bounding locally, erasing output iterator type.
+                        #[inline(always)]
+                        fn check_inputs<'a, K, I1, V, I2>(
+                            input_neg: I1,
+                            input_pos: I2,
+                            neg_state: &'a mut hydroflow::rustc_hash::FxHashSet<K>,
+                            pos_state: &'a mut hydroflow::rustc_hash::FxHashSet<(K, V)>,
+                            is_new_tick: bool,
+                        ) -> impl 'a + Iterator<Item = (K, V)>
+                        where
+                            K: Eq + ::std::hash::Hash + Clone,
+                            V: Eq + ::std::hash::Hash + Clone,
+                            I1: 'a + Iterator<Item = K>,
+                            I2: 'a + Iterator<Item = (K, V)>,
+                        {
+                            neg_state.extend(input_neg);
+                            hydroflow::compiled::pull::AntiJoin::new_from_mut(
+                                input_pos,
+                                neg_state,
+                                pos_state,
+                                is_new_tick,
+                            )
+                        }
+                        let __is_new_tick = {
+                            let mut __borrow_ident = context
+                                .state_ref(sg_5v1_node_23v1_persisttick)
+                                .borrow_mut();
+                            if *__borrow_ident <= context.current_tick() {
+                                *__borrow_ident = context.current_tick();
+                                true
+                            } else {
+                                false
+                            }
+                        };
+                        check_inputs(
+                            hoff_9v3_recv,
+                            op_22v1,
+                            &mut *sg_5v1_node_23v1_antijoindata_neg_borrow,
+                            &mut *sg_5v1_node_23v1_antijoindata_pos_borrow
+                                .get_mut_clear(context.current_tick()),
+                            __is_new_tick,
+                        )
+                    };
+                    let op_23v1 = op_23v1.map(|(k, ())| k);
                     let op_23v1 = {
                         #[allow(non_snake_case)]
                         #[inline(always)]
@@ -1725,12 +1780,21 @@ fn main() {
                         >::default(),
                     ),
                 );
-            let sg_7v1_node_18v1_diffdata_handle = df
+            let sg_7v1_node_18v1_antijoindata_neg = df
                 .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::rustc_hash::FxHashSet::default(),
+                    std::cell::RefCell::new(hydroflow::rustc_hash::FxHashSet::default()),
+                );
+            let sg_7v1_node_18v1_antijoindata_pos = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
                     ),
                 );
+            let sg_7v1_node_18v1_persisttick = df
+                .add_state(std::cell::RefCell::new(0_usize));
             let sg_7v1_node_31v1_persistdata = df
                 .add_state(::std::cell::RefCell::new((0_usize, ::std::vec::Vec::new())));
             df.add_subgraph_stratified(
@@ -1873,12 +1937,58 @@ fn main() {
                         }
                         op_17v1__unique__loc_unknown_start_9_21_end_9_28(op_17v1)
                     };
-                    let mut sg_7v1_node_18v1_negset = context
-                        .state_ref(sg_7v1_node_18v1_diffdata_handle)
+                    let op_17v1 = op_17v1.map(|k| (k, ()));
+                    let mut sg_7v1_node_18v1_antijoindata_neg_borrow = context
+                        .state_ref(sg_7v1_node_18v1_antijoindata_neg)
                         .borrow_mut();
-                    sg_7v1_node_18v1_negset.extend(hoff_15v3_recv);
-                    let op_18v1 = op_17v1
-                        .filter(move |x| !sg_7v1_node_18v1_negset.contains(x));
+                    let mut sg_7v1_node_18v1_antijoindata_pos_borrow = context
+                        .state_ref(sg_7v1_node_18v1_antijoindata_pos)
+                        .borrow_mut();
+                    let op_18v1 = {
+                        /// Limit error propagation by bounding locally, erasing output iterator type.
+                        #[inline(always)]
+                        fn check_inputs<'a, K, I1, V, I2>(
+                            input_neg: I1,
+                            input_pos: I2,
+                            neg_state: &'a mut hydroflow::rustc_hash::FxHashSet<K>,
+                            pos_state: &'a mut hydroflow::rustc_hash::FxHashSet<(K, V)>,
+                            is_new_tick: bool,
+                        ) -> impl 'a + Iterator<Item = (K, V)>
+                        where
+                            K: Eq + ::std::hash::Hash + Clone,
+                            V: Eq + ::std::hash::Hash + Clone,
+                            I1: 'a + Iterator<Item = K>,
+                            I2: 'a + Iterator<Item = (K, V)>,
+                        {
+                            neg_state.extend(input_neg);
+                            hydroflow::compiled::pull::AntiJoin::new_from_mut(
+                                input_pos,
+                                neg_state,
+                                pos_state,
+                                is_new_tick,
+                            )
+                        }
+                        let __is_new_tick = {
+                            let mut __borrow_ident = context
+                                .state_ref(sg_7v1_node_18v1_persisttick)
+                                .borrow_mut();
+                            if *__borrow_ident <= context.current_tick() {
+                                *__borrow_ident = context.current_tick();
+                                true
+                            } else {
+                                false
+                            }
+                        };
+                        check_inputs(
+                            hoff_15v3_recv,
+                            op_17v1,
+                            &mut *sg_7v1_node_18v1_antijoindata_neg_borrow,
+                            &mut *sg_7v1_node_18v1_antijoindata_pos_borrow
+                                .get_mut_clear(context.current_tick()),
+                            __is_new_tick,
+                        )
+                    };
+                    let op_18v1 = op_18v1.map(|(k, ())| k);
                     let op_18v1 = {
                         #[allow(non_snake_case)]
                         #[inline(always)]

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__join_with_other@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__join_with_other@datalog_program.snap
@@ -376,10 +376,10 @@ fn main() {
                         }
                         {
                             let __is_new_tick = if *sg_1v1_node_13v1_persisttick_borrow
-                                < context.current_tick()
+                                <= context.current_tick()
                             {
                                 *sg_1v1_node_13v1_persisttick_borrow = context
-                                    .current_tick();
+                                    .current_tick() + 1;
                                 true
                             } else {
                                 false

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__join_with_self@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__join_with_self@datalog_program.snap
@@ -338,10 +338,10 @@ fn main() {
                         }
                         {
                             let __is_new_tick = if *sg_2v1_node_9v1_persisttick_borrow
-                                < context.current_tick()
+                                <= context.current_tick()
                             {
-                                *sg_2v1_node_9v1_persisttick_borrow = context
-                                    .current_tick();
+                                *sg_2v1_node_9v1_persisttick_borrow = context.current_tick()
+                                    + 1;
                                 true
                             } else {
                                 false

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist@datalog_program.snap
@@ -1306,7 +1306,7 @@ fn main() {
                                 .state_ref(sg_5v1_node_51v1_persisttick)
                                 .borrow_mut();
                             if *__borrow_ident <= context.current_tick() {
-                                *__borrow_ident = context.current_tick();
+                                *__borrow_ident = context.current_tick() + 1;
                                 true
                             } else {
                                 false
@@ -1707,7 +1707,7 @@ fn main() {
                                 .state_ref(sg_6v1_node_3v1_persisttick)
                                 .borrow_mut();
                             if *__borrow_ident <= context.current_tick() {
-                                *__borrow_ident = context.current_tick();
+                                *__borrow_ident = context.current_tick() + 1;
                                 true
                             } else {
                                 false
@@ -2341,7 +2341,7 @@ fn main() {
                                 .state_ref(sg_7v1_node_31v1_persisttick)
                                 .borrow_mut();
                             if *__borrow_ident <= context.current_tick() {
-                                *__borrow_ident = context.current_tick();
+                                *__borrow_ident = context.current_tick() + 1;
                                 true
                             } else {
                                 false
@@ -2788,7 +2788,7 @@ fn main() {
                                 .state_ref(sg_8v1_node_8v1_persisttick)
                                 .borrow_mut();
                             if *__borrow_ident <= context.current_tick() {
-                                *__borrow_ident = context.current_tick();
+                                *__borrow_ident = context.current_tick() + 1;
                                 true
                             } else {
                                 false

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist@datalog_program.snap
@@ -721,10 +721,10 @@ fn main() {
                         }
                         {
                             let __is_new_tick = if *sg_4v1_node_41v1_persisttick_borrow
-                                < context.current_tick()
+                                <= context.current_tick()
                             {
                                 *sg_4v1_node_41v1_persisttick_borrow = context
-                                    .current_tick();
+                                    .current_tick() + 1;
                                 true
                             } else {
                                 false
@@ -909,10 +909,10 @@ fn main() {
                         }
                         {
                             let __is_new_tick = if *sg_4v1_node_45v1_persisttick_borrow
-                                < context.current_tick()
+                                <= context.current_tick()
                             {
                                 *sg_4v1_node_45v1_persisttick_borrow = context
-                                    .current_tick();
+                                    .current_tick() + 1;
                                 true
                             } else {
                                 false
@@ -1294,7 +1294,7 @@ fn main() {
                             I2: 'a + Iterator<Item = (K, V)>,
                         {
                             neg_state.extend(input_neg);
-                            hydroflow::compiled::pull::AntiJoin::new_from_mut(
+                            hydroflow::compiled::pull::anti_join_into_iter(
                                 input_pos,
                                 neg_state,
                                 pos_state,
@@ -1695,7 +1695,7 @@ fn main() {
                             I2: 'a + Iterator<Item = (K, V)>,
                         {
                             neg_state.extend(input_neg);
-                            hydroflow::compiled::pull::AntiJoin::new_from_mut(
+                            hydroflow::compiled::pull::anti_join_into_iter(
                                 input_pos,
                                 neg_state,
                                 pos_state,
@@ -2329,7 +2329,7 @@ fn main() {
                             I2: 'a + Iterator<Item = (K, V)>,
                         {
                             neg_state.extend(input_neg);
-                            hydroflow::compiled::pull::AntiJoin::new_from_mut(
+                            hydroflow::compiled::pull::anti_join_into_iter(
                                 input_pos,
                                 neg_state,
                                 pos_state,
@@ -2776,7 +2776,7 @@ fn main() {
                             I2: 'a + Iterator<Item = (K, V)>,
                         {
                             neg_state.extend(input_neg);
-                            hydroflow::compiled::pull::AntiJoin::new_from_mut(
+                            hydroflow::compiled::pull::anti_join_into_iter(
                                 input_pos,
                                 neg_state,
                                 pos_state,

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist@datalog_program.snap
@@ -1151,15 +1151,26 @@ fn main() {
             );
             let sg_5v1_node_53v1_persistdata = df
                 .add_state(::std::cell::RefCell::new((0_usize, ::std::vec::Vec::new())));
-            let sg_5v1_node_51v1_diffdata_handle = df
+            let sg_5v1_node_51v1_antijoindata_neg = df
                 .add_state(
-                    ::std::cell::RefCell::new(
+                    std::cell::RefCell::new(
                         hydroflow::util::monotonic_map::MonotonicMap::<
                             _,
                             hydroflow::rustc_hash::FxHashSet<_>,
                         >::default(),
                     ),
                 );
+            let sg_5v1_node_51v1_antijoindata_pos = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_5v1_node_51v1_persisttick = df
+                .add_state(std::cell::RefCell::new(0_usize));
             let sg_5v1_node_18v1_uniquedata = df
                 .add_state(
                     ::std::cell::RefCell::new(
@@ -1260,34 +1271,55 @@ fn main() {
                         }
                         op_54v1__map__loc_unknown_start_16_26_end_16_34(op_54v1)
                     };
-                    let mut sg_5v1_node_51v1_borrow = context
-                        .state_ref(sg_5v1_node_51v1_diffdata_handle)
+                    let mut sg_5v1_node_51v1_antijoindata_neg_borrow = context
+                        .state_ref(sg_5v1_node_51v1_antijoindata_neg)
+                        .borrow_mut();
+                    let mut sg_5v1_node_51v1_antijoindata_pos_borrow = context
+                        .state_ref(sg_5v1_node_51v1_antijoindata_pos)
                         .borrow_mut();
                     let op_51v1 = {
                         /// Limit error propagation by bounding locally, erasing output iterator type.
                         #[inline(always)]
                         fn check_inputs<'a, K, I1, V, I2>(
-                            input_pos: I1,
-                            input_neg: I2,
-                            borrow_state: &'a mut hydroflow::rustc_hash::FxHashSet<K>,
+                            input_neg: I1,
+                            input_pos: I2,
+                            neg_state: &'a mut hydroflow::rustc_hash::FxHashSet<K>,
+                            pos_state: &'a mut hydroflow::rustc_hash::FxHashSet<(K, V)>,
+                            is_new_tick: bool,
                         ) -> impl 'a + Iterator<Item = (K, V)>
                         where
                             K: Eq + ::std::hash::Hash + Clone,
-                            V: Eq + Clone,
-                            I1: 'a + Iterator<Item = (K, V)>,
-                            I2: 'a + Iterator<Item = K>,
+                            V: Eq + ::std::hash::Hash + Clone,
+                            I1: 'a + Iterator<Item = K>,
+                            I2: 'a + Iterator<Item = (K, V)>,
                         {
-                            borrow_state.extend(input_neg);
-                            input_pos.filter(move |x| !borrow_state.contains(&x.0))
+                            neg_state.extend(input_neg);
+                            hydroflow::compiled::pull::AntiJoin::new_from_mut(
+                                input_pos,
+                                neg_state,
+                                pos_state,
+                                is_new_tick,
+                            )
                         }
+                        let __is_new_tick = {
+                            let mut __borrow_ident = context
+                                .state_ref(sg_5v1_node_51v1_persisttick)
+                                .borrow_mut();
+                            if *__borrow_ident <= context.current_tick() {
+                                *__borrow_ident = context.current_tick();
+                                true
+                            } else {
+                                false
+                            }
+                        };
                         check_inputs(
-                            op_54v1,
                             hoff_20v3_recv,
-                            sg_5v1_node_51v1_borrow
-                                .get_mut_clear((
-                                    context.current_tick(),
-                                    context.current_stratum(),
-                                )),
+                            op_54v1,
+                            &mut *sg_5v1_node_51v1_antijoindata_neg_borrow
+                                .get_mut_clear(context.current_tick()),
+                            &mut *sg_5v1_node_51v1_antijoindata_pos_borrow
+                                .get_mut_clear(context.current_tick()),
+                            __is_new_tick,
                         )
                     };
                     let op_51v1 = {
@@ -1518,12 +1550,21 @@ fn main() {
                         >::default(),
                     ),
                 );
-            let sg_6v1_node_3v1_diffdata_handle = df
+            let sg_6v1_node_3v1_antijoindata_neg = df
                 .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::rustc_hash::FxHashSet::default(),
+                    std::cell::RefCell::new(hydroflow::rustc_hash::FxHashSet::default()),
+                );
+            let sg_6v1_node_3v1_antijoindata_pos = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
                     ),
                 );
+            let sg_6v1_node_3v1_persisttick = df
+                .add_state(std::cell::RefCell::new(0_usize));
             let sg_6v1_node_21v1_uniquedata = df
                 .add_state(
                     ::std::cell::RefCell::new(
@@ -1630,12 +1671,58 @@ fn main() {
                         }
                         op_2v1__unique__loc_unknown_start_2_19_end_2_24(op_2v1)
                     };
-                    let mut sg_6v1_node_3v1_negset = context
-                        .state_ref(sg_6v1_node_3v1_diffdata_handle)
+                    let op_2v1 = op_2v1.map(|k| (k, ()));
+                    let mut sg_6v1_node_3v1_antijoindata_neg_borrow = context
+                        .state_ref(sg_6v1_node_3v1_antijoindata_neg)
                         .borrow_mut();
-                    sg_6v1_node_3v1_negset.extend(hoff_28v3_recv);
-                    let op_3v1 = op_2v1
-                        .filter(move |x| !sg_6v1_node_3v1_negset.contains(x));
+                    let mut sg_6v1_node_3v1_antijoindata_pos_borrow = context
+                        .state_ref(sg_6v1_node_3v1_antijoindata_pos)
+                        .borrow_mut();
+                    let op_3v1 = {
+                        /// Limit error propagation by bounding locally, erasing output iterator type.
+                        #[inline(always)]
+                        fn check_inputs<'a, K, I1, V, I2>(
+                            input_neg: I1,
+                            input_pos: I2,
+                            neg_state: &'a mut hydroflow::rustc_hash::FxHashSet<K>,
+                            pos_state: &'a mut hydroflow::rustc_hash::FxHashSet<(K, V)>,
+                            is_new_tick: bool,
+                        ) -> impl 'a + Iterator<Item = (K, V)>
+                        where
+                            K: Eq + ::std::hash::Hash + Clone,
+                            V: Eq + ::std::hash::Hash + Clone,
+                            I1: 'a + Iterator<Item = K>,
+                            I2: 'a + Iterator<Item = (K, V)>,
+                        {
+                            neg_state.extend(input_neg);
+                            hydroflow::compiled::pull::AntiJoin::new_from_mut(
+                                input_pos,
+                                neg_state,
+                                pos_state,
+                                is_new_tick,
+                            )
+                        }
+                        let __is_new_tick = {
+                            let mut __borrow_ident = context
+                                .state_ref(sg_6v1_node_3v1_persisttick)
+                                .borrow_mut();
+                            if *__borrow_ident <= context.current_tick() {
+                                *__borrow_ident = context.current_tick();
+                                true
+                            } else {
+                                false
+                            }
+                        };
+                        check_inputs(
+                            hoff_28v3_recv,
+                            op_2v1,
+                            &mut *sg_6v1_node_3v1_antijoindata_neg_borrow,
+                            &mut *sg_6v1_node_3v1_antijoindata_pos_borrow
+                                .get_mut_clear(context.current_tick()),
+                            __is_new_tick,
+                        )
+                    };
+                    let op_3v1 = op_3v1.map(|(k, ())| k);
                     let op_3v1 = {
                         #[allow(non_snake_case)]
                         #[inline(always)]
@@ -2093,12 +2180,21 @@ fn main() {
                         >::default(),
                     ),
                 );
-            let sg_7v1_node_31v1_diffdata_handle = df
+            let sg_7v1_node_31v1_antijoindata_neg = df
                 .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::rustc_hash::FxHashSet::default(),
+                    std::cell::RefCell::new(hydroflow::rustc_hash::FxHashSet::default()),
+                );
+            let sg_7v1_node_31v1_antijoindata_pos = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
                     ),
                 );
+            let sg_7v1_node_31v1_persisttick = df
+                .add_state(std::cell::RefCell::new(0_usize));
             let sg_7v1_node_24v1_uniquedata = df
                 .add_state(
                     ::std::cell::RefCell::new(
@@ -2209,12 +2305,58 @@ fn main() {
                         }
                         op_30v1__unique__loc_unknown_start_21_21_end_21_41(op_30v1)
                     };
-                    let mut sg_7v1_node_31v1_negset = context
-                        .state_ref(sg_7v1_node_31v1_diffdata_handle)
+                    let op_30v1 = op_30v1.map(|k| (k, ()));
+                    let mut sg_7v1_node_31v1_antijoindata_neg_borrow = context
+                        .state_ref(sg_7v1_node_31v1_antijoindata_neg)
                         .borrow_mut();
-                    sg_7v1_node_31v1_negset.extend(hoff_16v3_recv);
-                    let op_31v1 = op_30v1
-                        .filter(move |x| !sg_7v1_node_31v1_negset.contains(x));
+                    let mut sg_7v1_node_31v1_antijoindata_pos_borrow = context
+                        .state_ref(sg_7v1_node_31v1_antijoindata_pos)
+                        .borrow_mut();
+                    let op_31v1 = {
+                        /// Limit error propagation by bounding locally, erasing output iterator type.
+                        #[inline(always)]
+                        fn check_inputs<'a, K, I1, V, I2>(
+                            input_neg: I1,
+                            input_pos: I2,
+                            neg_state: &'a mut hydroflow::rustc_hash::FxHashSet<K>,
+                            pos_state: &'a mut hydroflow::rustc_hash::FxHashSet<(K, V)>,
+                            is_new_tick: bool,
+                        ) -> impl 'a + Iterator<Item = (K, V)>
+                        where
+                            K: Eq + ::std::hash::Hash + Clone,
+                            V: Eq + ::std::hash::Hash + Clone,
+                            I1: 'a + Iterator<Item = K>,
+                            I2: 'a + Iterator<Item = (K, V)>,
+                        {
+                            neg_state.extend(input_neg);
+                            hydroflow::compiled::pull::AntiJoin::new_from_mut(
+                                input_pos,
+                                neg_state,
+                                pos_state,
+                                is_new_tick,
+                            )
+                        }
+                        let __is_new_tick = {
+                            let mut __borrow_ident = context
+                                .state_ref(sg_7v1_node_31v1_persisttick)
+                                .borrow_mut();
+                            if *__borrow_ident <= context.current_tick() {
+                                *__borrow_ident = context.current_tick();
+                                true
+                            } else {
+                                false
+                            }
+                        };
+                        check_inputs(
+                            hoff_16v3_recv,
+                            op_30v1,
+                            &mut *sg_7v1_node_31v1_antijoindata_neg_borrow,
+                            &mut *sg_7v1_node_31v1_antijoindata_pos_borrow
+                                .get_mut_clear(context.current_tick()),
+                            __is_new_tick,
+                        )
+                    };
+                    let op_31v1 = op_31v1.map(|(k, ())| k);
                     let op_31v1 = {
                         #[allow(non_snake_case)]
                         #[inline(always)]
@@ -2516,12 +2658,21 @@ fn main() {
                         >::default(),
                     ),
                 );
-            let sg_8v1_node_8v1_diffdata_handle = df
+            let sg_8v1_node_8v1_antijoindata_neg = df
                 .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::rustc_hash::FxHashSet::default(),
+                    std::cell::RefCell::new(hydroflow::rustc_hash::FxHashSet::default()),
+                );
+            let sg_8v1_node_8v1_antijoindata_pos = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
                     ),
                 );
+            let sg_8v1_node_8v1_persisttick = df
+                .add_state(std::cell::RefCell::new(0_usize));
             let sg_8v1_node_55v1_persistdata = df
                 .add_state(::std::cell::RefCell::new((0_usize, ::std::vec::Vec::new())));
             df.add_subgraph_stratified(
@@ -2601,12 +2752,58 @@ fn main() {
                         }
                         op_7v1__unique__loc_unknown_start_5_19_end_5_24(op_7v1)
                     };
-                    let mut sg_8v1_node_8v1_negset = context
-                        .state_ref(sg_8v1_node_8v1_diffdata_handle)
+                    let op_7v1 = op_7v1.map(|k| (k, ()));
+                    let mut sg_8v1_node_8v1_antijoindata_neg_borrow = context
+                        .state_ref(sg_8v1_node_8v1_antijoindata_neg)
                         .borrow_mut();
-                    sg_8v1_node_8v1_negset.extend(hoff_22v3_recv);
-                    let op_8v1 = op_7v1
-                        .filter(move |x| !sg_8v1_node_8v1_negset.contains(x));
+                    let mut sg_8v1_node_8v1_antijoindata_pos_borrow = context
+                        .state_ref(sg_8v1_node_8v1_antijoindata_pos)
+                        .borrow_mut();
+                    let op_8v1 = {
+                        /// Limit error propagation by bounding locally, erasing output iterator type.
+                        #[inline(always)]
+                        fn check_inputs<'a, K, I1, V, I2>(
+                            input_neg: I1,
+                            input_pos: I2,
+                            neg_state: &'a mut hydroflow::rustc_hash::FxHashSet<K>,
+                            pos_state: &'a mut hydroflow::rustc_hash::FxHashSet<(K, V)>,
+                            is_new_tick: bool,
+                        ) -> impl 'a + Iterator<Item = (K, V)>
+                        where
+                            K: Eq + ::std::hash::Hash + Clone,
+                            V: Eq + ::std::hash::Hash + Clone,
+                            I1: 'a + Iterator<Item = K>,
+                            I2: 'a + Iterator<Item = (K, V)>,
+                        {
+                            neg_state.extend(input_neg);
+                            hydroflow::compiled::pull::AntiJoin::new_from_mut(
+                                input_pos,
+                                neg_state,
+                                pos_state,
+                                is_new_tick,
+                            )
+                        }
+                        let __is_new_tick = {
+                            let mut __borrow_ident = context
+                                .state_ref(sg_8v1_node_8v1_persisttick)
+                                .borrow_mut();
+                            if *__borrow_ident <= context.current_tick() {
+                                *__borrow_ident = context.current_tick();
+                                true
+                            } else {
+                                false
+                            }
+                        };
+                        check_inputs(
+                            hoff_22v3_recv,
+                            op_7v1,
+                            &mut *sg_8v1_node_8v1_antijoindata_neg_borrow,
+                            &mut *sg_8v1_node_8v1_antijoindata_pos_borrow
+                                .get_mut_clear(context.current_tick()),
+                            __is_new_tick,
+                        )
+                    };
+                    let op_8v1 = op_8v1.map(|(k, ())| k);
                     let op_8v1 = {
                         #[allow(non_snake_case)]
                         #[inline(always)]

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist_uniqueness@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist_uniqueness@datalog_program.snap
@@ -642,7 +642,7 @@ fn main() {
                             I2: 'a + Iterator<Item = (K, V)>,
                         {
                             neg_state.extend(input_neg);
-                            hydroflow::compiled::pull::AntiJoin::new_from_mut(
+                            hydroflow::compiled::pull::anti_join_into_iter(
                                 input_pos,
                                 neg_state,
                                 pos_state,

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist_uniqueness@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist_uniqueness@datalog_program.snap
@@ -654,7 +654,7 @@ fn main() {
                                 .state_ref(sg_3v1_node_3v1_persisttick)
                                 .borrow_mut();
                             if *__borrow_ident <= context.current_tick() {
-                                *__borrow_ident = context.current_tick();
+                                *__borrow_ident = context.current_tick() + 1;
                                 true
                             } else {
                                 false

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist_uniqueness@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist_uniqueness@datalog_program.snap
@@ -419,12 +419,21 @@ fn main() {
                         >::default(),
                     ),
                 );
-            let sg_3v1_node_3v1_diffdata_handle = df
+            let sg_3v1_node_3v1_antijoindata_neg = df
                 .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::rustc_hash::FxHashSet::default(),
+                    std::cell::RefCell::new(hydroflow::rustc_hash::FxHashSet::default()),
+                );
+            let sg_3v1_node_3v1_antijoindata_pos = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
                     ),
                 );
+            let sg_3v1_node_3v1_persisttick = df
+                .add_state(std::cell::RefCell::new(0_usize));
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(3v1)",
                 1,
@@ -609,12 +618,58 @@ fn main() {
                         }
                         op_2v1__unique__loc_unknown_start_2_21_end_2_26(op_2v1)
                     };
-                    let mut sg_3v1_node_3v1_negset = context
-                        .state_ref(sg_3v1_node_3v1_diffdata_handle)
+                    let op_2v1 = op_2v1.map(|k| (k, ()));
+                    let mut sg_3v1_node_3v1_antijoindata_neg_borrow = context
+                        .state_ref(sg_3v1_node_3v1_antijoindata_neg)
                         .borrow_mut();
-                    sg_3v1_node_3v1_negset.extend(hoff_11v3_recv);
-                    let op_3v1 = op_2v1
-                        .filter(move |x| !sg_3v1_node_3v1_negset.contains(x));
+                    let mut sg_3v1_node_3v1_antijoindata_pos_borrow = context
+                        .state_ref(sg_3v1_node_3v1_antijoindata_pos)
+                        .borrow_mut();
+                    let op_3v1 = {
+                        /// Limit error propagation by bounding locally, erasing output iterator type.
+                        #[inline(always)]
+                        fn check_inputs<'a, K, I1, V, I2>(
+                            input_neg: I1,
+                            input_pos: I2,
+                            neg_state: &'a mut hydroflow::rustc_hash::FxHashSet<K>,
+                            pos_state: &'a mut hydroflow::rustc_hash::FxHashSet<(K, V)>,
+                            is_new_tick: bool,
+                        ) -> impl 'a + Iterator<Item = (K, V)>
+                        where
+                            K: Eq + ::std::hash::Hash + Clone,
+                            V: Eq + ::std::hash::Hash + Clone,
+                            I1: 'a + Iterator<Item = K>,
+                            I2: 'a + Iterator<Item = (K, V)>,
+                        {
+                            neg_state.extend(input_neg);
+                            hydroflow::compiled::pull::AntiJoin::new_from_mut(
+                                input_pos,
+                                neg_state,
+                                pos_state,
+                                is_new_tick,
+                            )
+                        }
+                        let __is_new_tick = {
+                            let mut __borrow_ident = context
+                                .state_ref(sg_3v1_node_3v1_persisttick)
+                                .borrow_mut();
+                            if *__borrow_ident <= context.current_tick() {
+                                *__borrow_ident = context.current_tick();
+                                true
+                            } else {
+                                false
+                            }
+                        };
+                        check_inputs(
+                            hoff_11v3_recv,
+                            op_2v1,
+                            &mut *sg_3v1_node_3v1_antijoindata_neg_borrow,
+                            &mut *sg_3v1_node_3v1_antijoindata_pos_borrow
+                                .get_mut_clear(context.current_tick()),
+                            __is_new_tick,
+                        )
+                    };
+                    let op_3v1 = op_3v1.map(|(k, ())| k);
                     let op_3v1 = {
                         #[allow(non_snake_case)]
                         #[inline(always)]

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__single_column_program@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__single_column_program@datalog_program.snap
@@ -376,10 +376,10 @@ fn main() {
                         }
                         {
                             let __is_new_tick = if *sg_1v1_node_13v1_persisttick_borrow
-                                < context.current_tick()
+                                <= context.current_tick()
                             {
                                 *sg_1v1_node_13v1_persisttick_borrow = context
-                                    .current_tick();
+                                    .current_tick() + 1;
                                 true
                             } else {
                                 false

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__transitive_closure@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__transitive_closure@datalog_program.snap
@@ -452,10 +452,10 @@ fn main() {
                         }
                         {
                             let __is_new_tick = if *sg_1v1_node_15v1_persisttick_borrow
-                                < context.current_tick()
+                                <= context.current_tick()
                             {
                                 *sg_1v1_node_15v1_persisttick_borrow = context
-                                    .current_tick();
+                                    .current_tick() + 1;
                                 true
                             } else {
                                 false

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__triple_relation_join@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__triple_relation_join@datalog_program.snap
@@ -506,10 +506,10 @@ fn main() {
                         }
                         {
                             let __is_new_tick = if *sg_1v1_node_17v1_persisttick_borrow
-                                < context.current_tick()
+                                <= context.current_tick()
                             {
                                 *sg_1v1_node_17v1_persisttick_borrow = context
-                                    .current_tick();
+                                    .current_tick() + 1;
                                 true
                             } else {
                                 false
@@ -696,10 +696,10 @@ fn main() {
                         }
                         {
                             let __is_new_tick = if *sg_1v1_node_21v1_persisttick_borrow
-                                < context.current_tick()
+                                <= context.current_tick()
                             {
                                 *sg_1v1_node_21v1_persisttick_borrow = context
-                                    .current_tick();
+                                    .current_tick() + 1;
                                 true
                             } else {
                                 false

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__wildcard_fields@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__wildcard_fields@datalog_program.snap
@@ -338,10 +338,10 @@ fn main() {
                         }
                         {
                             let __is_new_tick = if *sg_2v1_node_9v1_persisttick_borrow
-                                < context.current_tick()
+                                <= context.current_tick()
                             {
-                                *sg_2v1_node_9v1_persisttick_borrow = context
-                                    .current_tick();
+                                *sg_2v1_node_9v1_persisttick_borrow = context.current_tick()
+                                    + 1;
                                 true
                             } else {
                                 false

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__wildcard_join_count@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__wildcard_join_count@datalog_program.snap
@@ -954,10 +954,10 @@ fn main() {
                         }
                         {
                             let __is_new_tick = if *sg_5v1_node_17v1_persisttick_borrow
-                                < context.current_tick()
+                                <= context.current_tick()
                             {
                                 *sg_5v1_node_17v1_persisttick_borrow = context
-                                    .current_tick();
+                                    .current_tick() + 1;
                                 true
                             } else {
                                 false
@@ -1224,10 +1224,10 @@ fn main() {
                         }
                         {
                             let __is_new_tick = if *sg_6v1_node_24v1_persisttick_borrow
-                                < context.current_tick()
+                                <= context.current_tick()
                             {
                                 *sg_6v1_node_24v1_persisttick_borrow = context
-                                    .current_tick();
+                                    .current_tick() + 1;
                                 true
                             } else {
                                 false

--- a/hydroflow_lang/src/graph/ops/anti_join.rs
+++ b/hydroflow_lang/src/graph/ops/anti_join.rs
@@ -144,7 +144,7 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
                     {
                         neg_state.extend(input_neg);
 
-                        #root::compiled::pull::AntiJoin::new_from_mut(input_pos, neg_state, pos_state, is_new_tick)
+                        #root::compiled::pull::anti_join_into_iter(input_pos, neg_state, pos_state, is_new_tick)
                     }
 
                     let __is_new_tick = {

--- a/hydroflow_lang/src/graph/ops/anti_join.rs
+++ b/hydroflow_lang/src/graph/ops/anti_join.rs
@@ -151,7 +151,7 @@ pub const ANTI_JOIN: OperatorConstraints = OperatorConstraints {
                         let mut __borrow_ident = #context.state_ref(#tick_ident).borrow_mut();
 
                         if *__borrow_ident <= #context.current_tick() {
-                            *__borrow_ident = #context.current_tick();
+                            *__borrow_ident = #context.current_tick() + 1;
                             // new tick
                             true
                         } else {

--- a/hydroflow_lang/src/graph/ops/anti_join_multiset.rs
+++ b/hydroflow_lang/src/graph/ops/anti_join_multiset.rs
@@ -18,9 +18,9 @@ use crate::graph::{OpInstGenerics, OperatorInstance, PortIndexValue};
 /// or as many times as they appear in the input (if not matched in `neg`)
 ///
 /// ```hydroflow
-/// source_iter(vec![("dog", 1), ("cat", 2), ("elephant", 3)]) -> [pos]diff;
+/// source_iter(vec![("cat", 2), ("cat", 2), ("elephant", 3), ("elephant", 3)]) -> [pos]diff;
 /// source_iter(vec!["dog", "cat", "gorilla"]) -> [neg]diff;
-/// diff = anti_join() -> assert_eq([("elephant", 3)]);
+/// diff = anti_join_multiset() -> assert_eq([("elephant", 3), ("elephant", 3)]);
 /// ```
 
 // This implementation is largely redundant to ANTI_JOIN and should be DRY'ed

--- a/hydroflow_lang/src/graph/ops/cross_join_multiset.rs
+++ b/hydroflow_lang/src/graph/ops/cross_join_multiset.rs
@@ -1,0 +1,68 @@
+use quote::quote_spanned;
+use syn::parse_quote;
+
+use super::{
+    FlowProperties, FlowPropertyVal, OperatorCategory, OperatorConstraints, WriteContextArgs,
+    RANGE_1,
+};
+
+/// > 2 input streams of type S and T, 1 output stream of type (S, T)
+///
+/// Forms the multiset cross-join (Cartesian product) of the (possibly duplicated) items in the input streams, returning all
+/// tupled pairs regardless of duplicates.
+///
+/// ```hydroflow
+/// source_iter(vec!["happy", "happy", "sad"]) -> [0]my_join;
+/// source_iter(vec!["dog", "cat", "cat"]) -> [1]my_join;
+/// my_join = cross_join_multiset() -> sort() -> assert_eq([
+///     ("happy", "cat"),
+///     ("happy", "cat"),
+///     ("happy", "cat"),
+///     ("happy", "cat"),
+///     ("happy", "dog"),
+///     ("happy", "dog"),
+///     ("sad", "cat"),
+///     ("sad", "cat"),
+///     ("sad", "dog"), ]);
+/// ```
+pub const CROSS_JOIN_MULTISET: OperatorConstraints = OperatorConstraints {
+    name: "cross_join_multiset",
+    categories: &[OperatorCategory::MultiIn],
+    hard_range_inn: &(2..=2),
+    soft_range_inn: &(2..=2),
+    hard_range_out: RANGE_1,
+    soft_range_out: RANGE_1,
+    num_args: 0,
+    persistence_args: &(0..=2),
+    type_args: &(0..=1),
+    is_external_input: false,
+    ports_inn: Some(|| super::PortListSpec::Fixed(parse_quote! { 0, 1 })),
+    ports_out: None,
+    properties: FlowProperties {
+        deterministic: FlowPropertyVal::Preserve,
+        monotonic: FlowPropertyVal::Preserve,
+        inconsistency_tainted: false,
+    },
+    input_delaytype_fn: |_| None,
+    write_fn: |wc @ &WriteContextArgs {
+                   op_span,
+                   ident,
+                   inputs,
+                   ..
+               },
+               diagnostics| {
+        let mut output = (super::join_multiset::JOIN_MULTISET.write_fn)(wc, diagnostics)?;
+
+        let lhs = &inputs[0];
+        let rhs = &inputs[1];
+        let write_iterator = output.write_iterator;
+        output.write_iterator = quote_spanned!(op_span=>
+            let #lhs = #lhs.map(|a| ((), a));
+            let #rhs = #rhs.map(|b| ((), b));
+            #write_iterator
+            let #ident = #ident.map(|((), (a, b))| (a, b));
+        );
+
+        Ok(output)
+    },
+};

--- a/hydroflow_lang/src/graph/ops/difference.rs
+++ b/hydroflow_lang/src/graph/ops/difference.rs
@@ -9,12 +9,15 @@ use crate::graph::{OperatorInstance, PortIndexValue};
 
 /// > 2 input streams of the same type T, 1 output stream of type T
 ///
-/// For a given tick, forms the set difference of the items in the input
+/// Forms the set difference of the items in the input
 /// streams, returning items in the `pos` input that are not found in the
 /// `neg` input.
 ///
 /// `difference` can be provided with one or two generic lifetime persistence arguments
 /// in the same way as [`join`](#join), see [`join`'s documentation](#join) for more info.
+///
+/// Note set semantics here: duplicate items in the `pos` input
+/// are output 0 or 1 times (if they do/do-not have a match in `neg` respectively.)
 ///
 /// ```hydroflow
 /// source_iter(vec!["dog", "cat", "elephant"]) -> [pos]diff;
@@ -46,26 +49,18 @@ pub const DIFFERENCE: OperatorConstraints = OperatorConstraints {
         _else => None,
     },
     write_fn: |wc @ &WriteContextArgs {
-                           op_span,
-                           ident,
-                           inputs,
-                           op_inst:
-                               OperatorInstance {
-                                   ..
-                               },
-                           ..
-                       },
-                       diagnostics| {
-        let wc = WriteContextArgs {
-            inputs: inputs,
-            ..wc.clone()
-        };
-
+                   op_span,
+                   ident,
+                   inputs,
+                   op_inst: OperatorInstance { .. },
+                   ..
+               },
+               diagnostics| {
         let OperatorWriteOutput {
             write_prologue,
             write_iterator,
             write_iterator_after,
-        } = (super::anti_join::ANTI_JOIN.write_fn)(&wc, diagnostics)?;
+        } = (super::anti_join::ANTI_JOIN.write_fn)(wc, diagnostics)?;
 
         let pos = &inputs[1];
         let write_iterator = quote_spanned! {op_span=>
@@ -80,104 +75,4 @@ pub const DIFFERENCE: OperatorConstraints = OperatorConstraints {
             write_iterator_after,
         })
     },
-    };
-
-
-
-
-//     write_fn: |wc @ &WriteContextArgs {
-//                    root,
-//                    context,
-//                    hydroflow,
-//                    op_span,
-//                    ident,
-//                    inputs,
-//                    op_inst:
-//                        OperatorInstance {
-//                            generics:
-//                                OpInstGenerics {
-//                                    persistence_args, ..
-//                                },
-//                            ..
-//                        },
-//                    ..
-//                },
-//                diagnostics| {
-//         let handle_ident = wc.make_ident("diffdata_handle");
-
-//         let persistence = match &persistence_args[..] {
-//             [] => Persistence::Tick,
-//             [Persistence::Tick, Persistence::Tick] => Persistence::Tick,
-//             [Persistence::Tick, Persistence::Static] => Persistence::Static,
-//             other => {
-//                 diagnostics.push(Diagnostic::spanned(
-//                     op_span,
-//                     Level::Error,
-//                     &*format!(
-//                         "Unexpected persistence arguments for difference, expected two arguments with the first as `'tick`, got {:?}", // or whatever
-//                         other
-//                     ),
-//                 ));
-
-//                 Persistence::Tick
-//             }
-//         };
-
-//         let (write_prologue, write_iterator) = {
-//             let borrow_ident = wc.make_ident("borrow");
-//             let negset_ident = wc.make_ident("negset");
-
-//             let input_neg = &inputs[0]; // N before P
-//             let input_pos = &inputs[1];
-
-//             let (write_prologue, get_set) = match persistence {
-//                 Persistence::Tick => (
-//                     quote_spanned! {op_span=>
-//                         let #handle_ident = #hydroflow.add_state(std::cell::RefCell::new(
-//                             #root::util::monotonic_map::MonotonicMap::<_, #root::rustc_hash::FxHashSet<_>>::default(),
-//                         ));
-//                     },
-//                     quote_spanned! {op_span=>
-//                         let mut #borrow_ident = #context.state_ref(#handle_ident).borrow_mut();
-//                         let #negset_ident = #borrow_ident
-//                             .get_mut_with((#context.current_tick(), #context.current_stratum()), || {
-//                                 #input_neg.collect()
-//                             });
-//                     },
-//                 ),
-
-//                 Persistence::Static => (
-//                     quote_spanned! {op_span=>
-//                         let #handle_ident = #hydroflow.add_state(::std::cell::RefCell::new(#root::rustc_hash::FxHashSet::default()));
-//                     },
-//                     quote_spanned! {op_span=>
-//                         let mut #negset_ident = #context.state_ref(#handle_ident).borrow_mut();
-//                         #negset_ident.extend(#input_neg);
-//                     },
-//                 ),
-
-//                 Persistence::Mutable => {
-//                     diagnostics.push(Diagnostic::spanned(
-//                         op_span,
-//                         Level::Error,
-//                         "An implementation of 'mutable does not exist",
-//                     ));
-//                     return Err(());
-//                 }
-//             };
-
-//             (
-//                 write_prologue,
-//                 quote_spanned! {op_span=>
-//                     #get_set
-//                     let #ident = #input_pos.filter(move |x| !#negset_ident.contains(x));
-//                 },
-//             )
-//         };
-//         Ok(OperatorWriteOutput {
-//             write_prologue,
-//             write_iterator,
-//             ..Default::default()
-//         })
-//     },
-// };
+};

--- a/hydroflow_lang/src/graph/ops/difference_multiset.rs
+++ b/hydroflow_lang/src/graph/ops/difference_multiset.rs
@@ -21,8 +21,8 @@ use crate::graph::{OperatorInstance, PortIndexValue};
 /// source_iter(vec!["dog", "cat", "gorilla"]) -> [neg]diff;
 /// diff = difference() -> assert_eq(["elephant"]);
 /// ```
-pub const DIFFERENCE: OperatorConstraints = OperatorConstraints {
-    name: "difference",
+pub const DIFFERENCE_MULTISET: OperatorConstraints = OperatorConstraints {
+    name: "difference_multiset",
     categories: &[OperatorCategory::MultiIn],
     hard_range_inn: &(2..=2),
     soft_range_inn: &(2..=2),
@@ -65,7 +65,7 @@ pub const DIFFERENCE: OperatorConstraints = OperatorConstraints {
             write_prologue,
             write_iterator,
             write_iterator_after,
-        } = (super::anti_join::ANTI_JOIN.write_fn)(&wc, diagnostics)?;
+        } = (super::anti_join_multiset::ANTI_JOIN_MULTISET.write_fn)(&wc, diagnostics)?;
 
         let pos = &inputs[1];
         let write_iterator = quote_spanned! {op_span=>

--- a/hydroflow_lang/src/graph/ops/difference_multiset.rs
+++ b/hydroflow_lang/src/graph/ops/difference_multiset.rs
@@ -9,12 +9,15 @@ use crate::graph::{OperatorInstance, PortIndexValue};
 
 /// > 2 input streams of the same type T, 1 output stream of type T
 ///
-/// For a given tick, forms the set difference of the items in the input
+/// Forms the set difference of the items in the input
 /// streams, returning items in the `pos` input that are not found in the
 /// `neg` input.
 ///
 /// `difference` can be provided with one or two generic lifetime persistence arguments
 /// in the same way as [`join`](#join), see [`join`'s documentation](#join) for more info.
+///
+/// Note multiset semantics here: each (possibly duplicated) item in the `pos` input
+/// that has no match in `neg` is sent to the output.
 ///
 /// ```hydroflow
 /// source_iter(vec!["dog", "cat", "elephant"]) -> [pos]diff;
@@ -46,26 +49,18 @@ pub const DIFFERENCE_MULTISET: OperatorConstraints = OperatorConstraints {
         _else => None,
     },
     write_fn: |wc @ &WriteContextArgs {
-                           op_span,
-                           ident,
-                           inputs,
-                           op_inst:
-                               OperatorInstance {
-                                   ..
-                               },
-                           ..
-                       },
-                       diagnostics| {
-        let wc = WriteContextArgs {
-            inputs: inputs,
-            ..wc.clone()
-        };
-
+                   op_span,
+                   ident,
+                   inputs,
+                   op_inst: OperatorInstance { .. },
+                   ..
+               },
+               diagnostics| {
         let OperatorWriteOutput {
             write_prologue,
             write_iterator,
             write_iterator_after,
-        } = (super::anti_join_multiset::ANTI_JOIN_MULTISET.write_fn)(&wc, diagnostics)?;
+        } = (super::anti_join_multiset::ANTI_JOIN_MULTISET.write_fn)(wc, diagnostics)?;
 
         let pos = &inputs[1];
         let write_iterator = quote_spanned! {op_span=>
@@ -80,104 +75,4 @@ pub const DIFFERENCE_MULTISET: OperatorConstraints = OperatorConstraints {
             write_iterator_after,
         })
     },
-    };
-
-
-
-
-//     write_fn: |wc @ &WriteContextArgs {
-//                    root,
-//                    context,
-//                    hydroflow,
-//                    op_span,
-//                    ident,
-//                    inputs,
-//                    op_inst:
-//                        OperatorInstance {
-//                            generics:
-//                                OpInstGenerics {
-//                                    persistence_args, ..
-//                                },
-//                            ..
-//                        },
-//                    ..
-//                },
-//                diagnostics| {
-//         let handle_ident = wc.make_ident("diffdata_handle");
-
-//         let persistence = match &persistence_args[..] {
-//             [] => Persistence::Tick,
-//             [Persistence::Tick, Persistence::Tick] => Persistence::Tick,
-//             [Persistence::Tick, Persistence::Static] => Persistence::Static,
-//             other => {
-//                 diagnostics.push(Diagnostic::spanned(
-//                     op_span,
-//                     Level::Error,
-//                     &*format!(
-//                         "Unexpected persistence arguments for difference, expected two arguments with the first as `'tick`, got {:?}", // or whatever
-//                         other
-//                     ),
-//                 ));
-
-//                 Persistence::Tick
-//             }
-//         };
-
-//         let (write_prologue, write_iterator) = {
-//             let borrow_ident = wc.make_ident("borrow");
-//             let negset_ident = wc.make_ident("negset");
-
-//             let input_neg = &inputs[0]; // N before P
-//             let input_pos = &inputs[1];
-
-//             let (write_prologue, get_set) = match persistence {
-//                 Persistence::Tick => (
-//                     quote_spanned! {op_span=>
-//                         let #handle_ident = #hydroflow.add_state(std::cell::RefCell::new(
-//                             #root::util::monotonic_map::MonotonicMap::<_, #root::rustc_hash::FxHashSet<_>>::default(),
-//                         ));
-//                     },
-//                     quote_spanned! {op_span=>
-//                         let mut #borrow_ident = #context.state_ref(#handle_ident).borrow_mut();
-//                         let #negset_ident = #borrow_ident
-//                             .get_mut_with((#context.current_tick(), #context.current_stratum()), || {
-//                                 #input_neg.collect()
-//                             });
-//                     },
-//                 ),
-
-//                 Persistence::Static => (
-//                     quote_spanned! {op_span=>
-//                         let #handle_ident = #hydroflow.add_state(::std::cell::RefCell::new(#root::rustc_hash::FxHashSet::default()));
-//                     },
-//                     quote_spanned! {op_span=>
-//                         let mut #negset_ident = #context.state_ref(#handle_ident).borrow_mut();
-//                         #negset_ident.extend(#input_neg);
-//                     },
-//                 ),
-
-//                 Persistence::Mutable => {
-//                     diagnostics.push(Diagnostic::spanned(
-//                         op_span,
-//                         Level::Error,
-//                         "An implementation of 'mutable does not exist",
-//                     ));
-//                     return Err(());
-//                 }
-//             };
-
-//             (
-//                 write_prologue,
-//                 quote_spanned! {op_span=>
-//                     #get_set
-//                     let #ident = #input_pos.filter(move |x| !#negset_ident.contains(x));
-//                 },
-//             )
-//         };
-//         Ok(OperatorWriteOutput {
-//             write_prologue,
-//             write_iterator,
-//             ..Default::default()
-//         })
-//     },
-// };
+};

--- a/hydroflow_lang/src/graph/ops/difference_multiset.rs
+++ b/hydroflow_lang/src/graph/ops/difference_multiset.rs
@@ -20,9 +20,9 @@ use crate::graph::{OperatorInstance, PortIndexValue};
 /// that has no match in `neg` is sent to the output.
 ///
 /// ```hydroflow
-/// source_iter(vec!["dog", "cat", "elephant"]) -> [pos]diff;
-/// source_iter(vec!["dog", "cat", "gorilla"]) -> [neg]diff;
-/// diff = difference() -> assert_eq(["elephant"]);
+/// source_iter(vec!["cat", "cat", "elephant", "elephant"]) -> [pos]diff;
+/// source_iter(vec!["cat", "gorilla"]) -> [neg]diff;
+/// diff = difference_multiset() -> assert_eq(["elephant", "elephant"]);
 /// ```
 pub const DIFFERENCE_MULTISET: OperatorConstraints = OperatorConstraints {
     name: "difference_multiset",

--- a/hydroflow_lang/src/graph/ops/join.rs
+++ b/hydroflow_lang/src/graph/ops/join.rs
@@ -130,9 +130,6 @@ pub const JOIN: OperatorConstraints = OperatorConstraints {
         // TODO: This is really bad.
         // This will break if the user aliases HalfSetJoinState to something else. Temporary hacky solution.
         // Note that cross_join() depends on the implementation here as well.
-        // Need to decide on what to do about multisetjoin.
-        // Should it be a separate operator (multisetjoin() and multisetcrossjoin())?
-        // Should the default be multiset join? And setjoin requires the use of lattice_join() with SetUnion lattice?
         let additional_trait_bounds = if join_type.to_string().contains("HalfSetJoinState") {
             quote_spanned!(op_span=>
                 + ::std::cmp::Eq

--- a/hydroflow_lang/src/graph/ops/join.rs
+++ b/hydroflow_lang/src/graph/ops/join.rs
@@ -226,8 +226,8 @@ pub const JOIN: OperatorConstraints = OperatorConstraints {
                 }
 
                 {
-                    let __is_new_tick = if *#tick_borrow_ident < #context.current_tick() {
-                        *#tick_borrow_ident = #context.current_tick();
+                    let __is_new_tick = if *#tick_borrow_ident <= #context.current_tick() {
+                        *#tick_borrow_ident = #context.current_tick() + 1;
                         true
                     } else {
                         false

--- a/hydroflow_lang/src/graph/ops/mod.rs
+++ b/hydroflow_lang/src/graph/ops/mod.rs
@@ -233,6 +233,7 @@ declare_ops![
     assert::ASSERT,
     assert_eq::ASSERT_EQ,
     cross_join::CROSS_JOIN,
+    cross_join_multiset::CROSS_JOIN_MULTISET,
     demux::DEMUX,
     dest_file::DEST_FILE,
     dest_sink::DEST_SINK,

--- a/hydroflow_lang/src/graph/ops/mod.rs
+++ b/hydroflow_lang/src/graph/ops/mod.rs
@@ -229,6 +229,7 @@ macro_rules! declare_ops {
 }
 declare_ops![
     anti_join::ANTI_JOIN,
+    anti_join_multiset::ANTI_JOIN_MULTISET,
     assert::ASSERT,
     assert_eq::ASSERT_EQ,
     cross_join::CROSS_JOIN,
@@ -237,6 +238,7 @@ declare_ops![
     dest_sink::DEST_SINK,
     dest_sink_serde::DEST_SINK_SERDE,
     difference::DIFFERENCE,
+    difference_multiset::DIFFERENCE_MULTISET,
     enumerate::ENUMERATE,
     filter::FILTER,
     filter_map::FILTER_MAP,


### PR DESCRIPTION
Fixes #827 with multiset variants of antijoin and difference.
- `anti_join` rewritten in the style of `join`
- `anti_join_multiset` is a simpler version of `anti_join` 
- `difference` now reuses the logic of `anti_join`
- `difference_multiset` reuses the logic of `anti_join_multiset`

Also adds `cross_join_multiset` as well, reusing logic of of `join_multiset`.

In future it would be nice to clean this up further with macros:
1. replace the `difference` operators with macros over `antijoin`, so the `pos` side of `difference` as well as the output of `antijoin` are rewritten as:
```
... -> map(|k| (k, ()) -> [pos]my_antijoin;
my_antijoin = antijoin() -> map(|(k, v)| k)
```
2. replace the `antijoin` operator with a macro using `unique` and `antijoin_multiset`, so the `pos` side of `antijoin` is rewritten as:
```
... -> unique() -> [pos]my_antijoin_multiset
my_antijoin_multiset = antijoin_multiset()
```
