### PR TITLE
optimization: join probe returns first item directly

### DIFF
--- a/hydroflow/src/compiled/pull/half_join_state/mod.rs
+++ b/hydroflow/src/compiled/pull/half_join_state/mod.rs
@@ -16,6 +16,6 @@ pub type SetJoinState<Key, V1, V2> = (HalfSetJoinState<Key, V1, V2>, HalfSetJoin
 
 pub trait HalfJoinState<Key, ValBuild, ValProbe> {
     fn build(&mut self, k: Key, v: &ValBuild) -> bool;
-    fn probe(&mut self, k: &Key, v: &ValProbe);
+    fn probe(&mut self, k: &Key, v: &ValProbe) -> Option<(Key, ValProbe, ValBuild)>;
     fn pop_match(&mut self) -> Option<(Key, ValProbe, ValBuild)>;
 }

--- a/hydroflow/src/compiled/pull/half_join_state/mod.rs
+++ b/hydroflow/src/compiled/pull/half_join_state/mod.rs
@@ -15,7 +15,14 @@ pub use set::HalfSetJoinState;
 pub type SetJoinState<Key, V1, V2> = (HalfSetJoinState<Key, V1, V2>, HalfSetJoinState<Key, V2, V1>);
 
 pub trait HalfJoinState<Key, ValBuild, ValProbe> {
+    /// Insert a key value pair into the join state, currently this is always inserting into a hash table
+    /// If the key-value pair exists then it is implementation defined what hapepns, usually either two copies are stored or only one copy is stored.
     fn build(&mut self, k: Key, v: &ValBuild) -> bool;
+
+    /// This function does the actual joining part of the join. It looks up a key in the local join state and creates matches
+    /// The first match is return directly to the caller, and any additional matches are stored internally to be retrieved later with `pop_match`
     fn probe(&mut self, k: &Key, v: &ValProbe) -> Option<(Key, ValProbe, ValBuild)>;
+
+    /// If there are any stored matches from previous calls to probe then this function will remove them one at a time and return it.
     fn pop_match(&mut self) -> Option<(Key, ValProbe, ValBuild)>;
 }

--- a/hydroflow/src/compiled/pull/half_join_state/multiset.rs
+++ b/hydroflow/src/compiled/pull/half_join_state/multiset.rs
@@ -60,7 +60,7 @@ where
     fn probe(&mut self, k: &Key, v: &ValProbe) -> Option<(Key, ValProbe, ValBuild)> {
         // TODO: We currently don't free/shrink the self.current_matches vecdeque to save time.
         // This mean it will grow to eventually become the largest number of matches in a single probe call.
-        // Maybe we should clear this memory at the beginning of every tick/periodically?'
+        // Maybe we should clear this memory at the beginning of every tick/periodically?
         let mut iter = self
             .table
             .get(k)?

--- a/hydroflow/src/compiled/pull/half_join_state/multiset.rs
+++ b/hydroflow/src/compiled/pull/half_join_state/multiset.rs
@@ -57,17 +57,21 @@ where
         true
     }
 
-    fn probe(&mut self, k: &Key, v: &ValProbe) {
-        if let Some(entry) = self.table.get(k) {
-            // TODO: We currently don't free/shrink the self.current_matches vecdeque to save time.
-            // This mean it will grow to eventually become the largest number of matches in a single probe call.
-            // Maybe we should clear this memory at the beginning of every tick/periodically?
-            self.current_matches.extend(
-                entry
-                    .iter()
-                    .map(|valbuild| (k.clone(), v.clone(), valbuild.clone())),
-            );
-        }
+    fn probe(&mut self, k: &Key, v: &ValProbe) -> Option<(Key, ValProbe, ValBuild)> {
+        // TODO: We currently don't free/shrink the self.current_matches vecdeque to save time.
+        // This mean it will grow to eventually become the largest number of matches in a single probe call.
+        // Maybe we should clear this memory at the beginning of every tick/periodically?'
+        let mut iter = self
+            .table
+            .get(k)?
+            .iter()
+            .map(|valbuild| (k.clone(), v.clone(), valbuild.clone()));
+
+        let first = iter.next();
+
+        self.current_matches.extend(iter);
+
+        first
     }
 
     fn pop_match(&mut self) -> Option<(Key, ValProbe, ValBuild)> {

--- a/hydroflow/src/compiled/pull/half_join_state/set.rs
+++ b/hydroflow/src/compiled/pull/half_join_state/set.rs
@@ -65,7 +65,7 @@ where
     fn probe(&mut self, k: &Key, v: &ValProbe) -> Option<(Key, ValProbe, ValBuild)> {
         // TODO: We currently don't free/shrink the self.current_matches vecdeque to save time.
         // This mean it will grow to eventually become the largest number of matches in a single probe call.
-        // Maybe we should clear this memory at the beginning of every tick/periodically?'
+        // Maybe we should clear this memory at the beginning of every tick/periodically?
         let mut iter = self
             .table
             .get(k)?

--- a/hydroflow/src/compiled/pull/half_join_state/set.rs
+++ b/hydroflow/src/compiled/pull/half_join_state/set.rs
@@ -62,17 +62,21 @@ where
         false
     }
 
-    fn probe(&mut self, k: &Key, v: &ValProbe) {
-        if let Some(entry) = self.table.get(k) {
-            // TODO: We currently don't free/shrink the self.current_matches vecdeque to save time.
-            // This mean it will grow to eventually become the largest number of matches in a single probe call.
-            // Maybe we should clear this memory at the beginning of every tick/periodically?
-            self.current_matches.extend(
-                entry
-                    .iter()
-                    .map(|valbuild| (k.clone(), v.clone(), valbuild.clone())),
-            );
-        }
+    fn probe(&mut self, k: &Key, v: &ValProbe) -> Option<(Key, ValProbe, ValBuild)> {
+        // TODO: We currently don't free/shrink the self.current_matches vecdeque to save time.
+        // This mean it will grow to eventually become the largest number of matches in a single probe call.
+        // Maybe we should clear this memory at the beginning of every tick/periodically?'
+        let mut iter = self
+            .table
+            .get(k)?
+            .iter()
+            .map(|valbuild| (k.clone(), v.clone(), valbuild.clone()));
+
+        let first = iter.next();
+
+        self.current_matches.extend(iter);
+
+        first
     }
 
     fn pop_match(&mut self) -> Option<(Key, ValProbe, ValBuild)> {

--- a/hydroflow/src/compiled/pull/symmetric_hash_join.rs
+++ b/hydroflow/src/compiled/pull/symmetric_hash_join.rs
@@ -40,13 +40,17 @@ where
 
             if let Some((k, v1)) = self.lhs.next() {
                 if self.lhs_state.build(k.clone(), &v1) {
-                    self.rhs_state.probe(&k, &v1);
+                    if let Some((k, v1, v2)) = self.rhs_state.probe(&k, &v1) {
+                        return Some((k, (v1, v2)));
+                    }
                 }
                 continue;
             }
             if let Some((k, v2)) = self.rhs.next() {
                 if self.rhs_state.build(k.clone(), &v2) {
-                    self.lhs_state.probe(&k, &v2);
+                    if let Some((k, v2, v1)) = self.lhs_state.probe(&k, &v2) {
+                        return Some((k, (v1, v2)));
+                    }
                 }
                 continue;
             }


### PR DESCRIPTION
evidence for this change is pretty weak:

```
micro/ops/join          time:   [113.65 µs 114.38 µs 115.80 µs]
                        change: [-0.0148% +1.0042% +2.3994%] (p = 0.12 > 0.05)
                        No change in performance detected.

micro/ops/crossjoin     time:   [152.13 µs 153.46 µs 155.27 µs]
                        change: [+2.3725% +3.6797% +5.3980%] (p = 0.00 < 0.05)
                        Performance has regressed.

micro/ops/anti_join     time:   [12.927 µs 12.957 µs 12.994 µs]
                        change: [-0.4503% +0.1853% +0.7231%] (p = 0.57 > 0.05)
                        No change in performance detected.

symmetric_hash_join/no_match
                        time:   [126.19 µs 126.68 µs 127.37 µs]
                        change: [-4.5148% -0.9976% +2.6660%] (p = 0.59 > 0.05)
                        No change in performance detected.

symmetric_hash_join/match_keys_diff_values
                        time:   [174.17 µs 174.47 µs 174.78 µs]
                        change: [-6.0184% -3.7568% -1.7607%] (p = 0.00 < 0.05)
                        Performance has improved.

symmetric_hash_join/match_keys_same_values
                        time:   [173.95 µs 174.89 µs 176.70 µs]
                        change: [-6.2952% -3.9995% -1.7759%] (p = 0.00 < 0.05)
                        Performance has improved.

symmetric_hash_join/zipf_keys_low_contention_unique_values
                        time:   [164.71 µs 166.60 µs 168.60 µs]
                        change: [-4.2218% -1.9710% +0.2797%] (p = 0.10 > 0.05)
                        No change in performance detected.

symmetric_hash_join/zipf_keys_high_contention_unique_values
                        time:   [3.4813 ms 3.5060 ms 3.5381 ms]
                        change: [-2.8375% -1.1905% +0.3146%] (p = 0.14 > 0.05)
                        No change in performance detected.
```