### PR TITLE
feat(lattices): formalize `Default::default()` as returning bottom for lattice types

### DIFF
--- a/lattices/README.md
+++ b/lattices/README.md
@@ -83,11 +83,14 @@ type, e.g. between [`set_union::SetUnionBTreeSet`] and [`set_union::SetUnionHash
 lattice (lattices with nested lattice types), the `LatticeFrom` implementation should be recursive
 for those nested lattices.
 
-### `IsBot` and `IsTop`
+### `IsBot`, `IsTop`, and `Default`
 
 A bottom (⊥) is strictly less than all other values. A top (⊤) is strictly greater than all other
-values. `IsBot::is_bot` and `IsTop::is_top` determine if a lattice instance is top or
-bottom respectively.
+values. `IsBot::is_bot` and `IsTop::is_top` determine if a lattice instance is top or bottom
+respectively.
+
+For lattice types, `Default::default()` must create a bottom value. `IsBot::is_bot(&Default::default())`
+should always return true for all lattice types.
 
 ### `Atomize`
 

--- a/lattices/src/conflict.rs
+++ b/lattices/src/conflict.rs
@@ -12,7 +12,7 @@ use crate::{IsBot, IsTop, LatticeFrom, LatticeOrd, Merge};
 ///
 /// This can be used to wrap non-lattice (scalar) data into a lattice type.
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, Default, Eq)]
+#[derive(Copy, Clone, Debug, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Conflict<T>(Option<T>);
 impl<T> Conflict<T> {
@@ -106,7 +106,10 @@ impl<T> IsTop for Conflict<T> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test::check_all;
+    use crate::test::{
+        check_all, check_lattice_is_bot, check_lattice_is_top, check_lattice_ord,
+        check_lattice_properties, check_partial_ord_properties,
+    };
     use crate::WithBot;
 
     #[test]
@@ -116,7 +119,11 @@ mod test {
             Conflict::new_from("bar"),
             Conflict::new(None),
         ];
-        check_all(items);
+        check_lattice_ord(items);
+        check_partial_ord_properties(items);
+        check_lattice_properties(items);
+        check_lattice_is_bot(items);
+        check_lattice_is_top(items);
     }
 
     #[test]

--- a/lattices/src/dom_pair.rs
+++ b/lattices/src/dom_pair.rs
@@ -156,7 +156,7 @@ mod test {
     use crate::ord::Max;
     use crate::set_union::SetUnionHashSet;
     use crate::test::{
-        check_lattice_bot, check_lattice_ord, check_lattice_properties, check_lattice_top,
+        check_lattice_is_bot, check_lattice_is_top, check_lattice_ord, check_lattice_properties,
         check_partial_ord_properties,
     };
     use crate::WithTop;
@@ -176,7 +176,7 @@ mod test {
 
         check_lattice_ord(&test_vec);
         check_partial_ord_properties(&test_vec);
-        check_lattice_bot(&test_vec);
+        check_lattice_is_bot(&test_vec);
         // DomPair is not actually a lattice.
         assert!(std::panic::catch_unwind(|| check_lattice_properties(&test_vec)).is_err());
     }
@@ -208,8 +208,8 @@ mod test {
 
         check_lattice_ord(&test_vec);
         check_partial_ord_properties(&test_vec);
-        check_lattice_bot(&test_vec);
-        check_lattice_top(&test_vec);
+        check_lattice_is_bot(&test_vec);
+        check_lattice_is_top(&test_vec);
         // DomPair is not actually a lattice.
         assert!(std::panic::catch_unwind(|| check_lattice_properties(&test_vec)).is_err());
     }

--- a/lattices/src/test.rs
+++ b/lattices/src/test.rs
@@ -4,14 +4,15 @@ use std::fmt::Debug;
 
 use crate::{Atomize, IsBot, IsTop, Lattice, LatticeOrd, Merge, NaiveLatticeOrd};
 
-/// Helper which calls [`check_lattice_ord`], [`check_partial_ord_properties`],
-/// [`check_lattice_properties`], and [`check_lattice_bot`].
-pub fn check_all<T: Lattice + Clone + Eq + Debug>(items: &[T]) {
+/// Helper which calls many other `check_*` functions in this module. See source code for which
+/// functions are called.
+pub fn check_all<T: Lattice + Clone + Eq + Debug + Default>(items: &[T]) {
     check_lattice_ord(items);
     check_partial_ord_properties(items);
     check_lattice_properties(items);
-    check_lattice_bot(items);
-    check_lattice_top(items);
+    check_lattice_is_bot(items);
+    check_lattice_is_top(items);
+    check_lattice_default_is_bot::<T>();
 }
 
 /// Check that the lattice's `PartialOrd` implementation agrees with the `NaiveLatticeOrd` partial
@@ -139,7 +140,7 @@ pub fn check_lattice_properties<T: Merge<T> + Clone + Eq + Debug>(items: &[T]) {
 }
 
 /// Checks that the item which is bot is less than (or equal to) all other items.
-pub fn check_lattice_bot<T: IsBot + LatticeOrd + Debug>(items: &[T]) {
+pub fn check_lattice_is_bot<T: IsBot + LatticeOrd + Debug>(items: &[T]) {
     let Some(bot) = items.iter().find(|&x| IsBot::is_bot(x)) else {
         return;
     };
@@ -150,7 +151,7 @@ pub fn check_lattice_bot<T: IsBot + LatticeOrd + Debug>(items: &[T]) {
 }
 
 /// Checks that the item which is top is greater than (or equal to) all other items.
-pub fn check_lattice_top<T: IsTop + LatticeOrd + Debug>(items: &[T]) {
+pub fn check_lattice_is_top<T: IsTop + LatticeOrd + Debug>(items: &[T]) {
     let Some(top) = items.iter().find(|&x| IsTop::is_top(x)) else {
         return;
     };
@@ -158,6 +159,11 @@ pub fn check_lattice_top<T: IsTop + LatticeOrd + Debug>(items: &[T]) {
         assert!(x <= top);
         assert_eq!(top == x, x.is_top(), "{:?}", x);
     }
+}
+
+/// Asserts that [`IsBot`] is true for [`Default::default()`].
+pub fn check_lattice_default_is_bot<T: IsBot + Default>() {
+    assert!(T::is_bot(&T::default()));
 }
 
 /// Check that the atomized lattice points re-merge to form the same original lattice point, for each item in `items`.

--- a/lattices/src/with_top.rs
+++ b/lattices/src/with_top.rs
@@ -145,7 +145,7 @@ where
 mod test {
     use super::*;
     use crate::set_union::{SetUnionHashSet, SetUnionSingletonSet};
-    use crate::test::{check_all, check_atomize_each, check_lattice_top};
+    use crate::test::{check_all, check_atomize_each, check_lattice_is_top};
 
     #[test]
     fn test_singly_nested_singleton_example() {
@@ -200,7 +200,7 @@ mod test {
             WithTop::new_from(SetUnionHashSet::new_from([0, 1])),
         ];
         check_all(items);
-        check_lattice_top(items);
+        check_lattice_is_top(items);
     }
 
     #[test]


### PR DESCRIPTION
Not a breaking change since changed names were introduced only in this version