### PR TITLE
fix: separate internal compiler operators in docs name/category/sort order

### DIFF
--- a/hydroflow/examples/kvs_bench/server.rs
+++ b/hydroflow/examples/kvs_bench/server.rs
@@ -226,7 +226,7 @@ pub fn run_server<RX>(
                     -> map(|(key, reg)| MapUnionSingletonMap::new_from((key, reg)))
                     -> [input]batcher;
 
-                batcher = lattice_batch::<MapUnionHashMap<_, _>>()
+                batcher = _lattice_fold_batch::<MapUnionHashMap<_, _>>()
                     -> map(|lattice| {
                         use bincode::Options;
                         let serialization_options = options();
@@ -244,7 +244,7 @@ pub fn run_server<RX>(
                     -> for_each(|(node_id, serialized_req)| transducer_to_peers_tx.try_send((serialized_req, node_id)).unwrap());
 
                 // join for lookups
-                lookup = lattice_join::<'static, 'tick, MyLastWriteWins<BUFFER_SIZE>, MySetUnion>();
+                lookup = _lattice_join_fused_join::<'static, 'tick, MyLastWriteWins<BUFFER_SIZE>, MySetUnion>();
 
                 client_input[store]
                     // -> inspect(|x| println!("{server_id}:{:5}: stores-into-lookup: {x:?}", context.current_tick()))

--- a/hydroflow/tests/surface_lattice_batch.rs
+++ b/hydroflow/tests/surface_lattice_batch.rs
@@ -10,17 +10,17 @@ pub fn test_lattice_batch() {
         // Can release in the same tick
         source_iter([SetUnionSingletonSet::new_from(0), SetUnionSingletonSet::new_from(1)]) -> [input]b1;
         source_iter([()]) -> defer_tick() -> [signal]b1;
-        b1 = lattice_batch::<SetUnionHashSet>() -> assert_eq([SetUnionHashSet::new_from([1, 0])]);
+        b1 = _lattice_fold_batch::<SetUnionHashSet>() -> assert_eq([SetUnionHashSet::new_from([1, 0])]);
 
         // Can hold the data across a tick
         source_iter([SetUnionSingletonSet::new_from(0), SetUnionSingletonSet::new_from(1)]) -> [input]b2;
         source_iter([()]) -> defer_tick() -> [signal]b2;
-        b2 = lattice_batch::<SetUnionHashSet>() -> assert_eq([SetUnionHashSet::new_from([1, 0])]);
+        b2 = _lattice_fold_batch::<SetUnionHashSet>() -> assert_eq([SetUnionHashSet::new_from([1, 0])]);
 
         // Doesn't release without a signal
         source_iter([SetUnionSingletonSet::new_from(0), SetUnionSingletonSet::new_from(1)]) -> [input]b3;
         source_iter([(); 0]) -> [signal]b3;
-        b3 = lattice_batch::<SetUnionHashSet>() -> assert(|_| false);
+        b3 = _lattice_fold_batch::<SetUnionHashSet>() -> assert(|_| false);
     };
 
     df.run_available();

--- a/hydroflow/tests/surface_lattice_join.rs
+++ b/hydroflow/tests/surface_lattice_join.rs
@@ -3,7 +3,7 @@ use hydroflow_macro::hydroflow_syntax;
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]
-pub fn test_lattice_join_reducing_behavior() {
+pub fn test_lattice_join_fused_join_reducing_behavior() {
     // lattice_fold has the following particular initialization behavior. It uses LatticeFrom to convert the first element into another lattice type to create the accumulator and then it folds the remaining elements into that accumulator.
     // This initialization style supports things like SetUnionSingletonSet -> SetUnionHashSet. It also helps with things like Min, where there is not obvious default value so you want reduce-like behavior.
     let mut df = hydroflow_syntax! {
@@ -13,7 +13,7 @@ pub fn test_lattice_join_reducing_behavior() {
         source_iter([(7, Min::new(5)), (7, Min::new(6))]) -> [0]my_join;
         source_iter([(7, Max::new(5)), (7, Max::new(6))]) -> [1]my_join;
 
-        my_join = lattice_join::<Min<usize>, Max<usize>>()
+        my_join = _lattice_join_fused_join::<Min<usize>, Max<usize>>()
             -> assert_eq([(7, (Min::new(5), Max::new(6)))]);
     };
 
@@ -21,7 +21,7 @@ pub fn test_lattice_join_reducing_behavior() {
 }
 
 #[multiplatform_test]
-pub fn test_lattice_join_set_union() {
+pub fn test_lattice_join_fused_join_set_union() {
     let mut df = hydroflow_syntax! {
         use lattices::set_union::SetUnionSingletonSet;
         use lattices::set_union::SetUnionHashSet;
@@ -29,7 +29,7 @@ pub fn test_lattice_join_set_union() {
         source_iter([(7, SetUnionHashSet::new_from([5])), (7, SetUnionHashSet::new_from([6]))]) -> [0]my_join;
         source_iter([(7, SetUnionSingletonSet::new_from(5)), (7, SetUnionSingletonSet::new_from(6))]) -> [1]my_join;
 
-        my_join = lattice_join::<SetUnionHashSet<usize>, SetUnionHashSet<usize>>()
+        my_join = _lattice_join_fused_join::<SetUnionHashSet<usize>, SetUnionHashSet<usize>>()
             -> assert_eq([(7, (SetUnionHashSet::new_from([5, 6]), SetUnionHashSet::new_from([5, 6])))]);
     };
 
@@ -37,7 +37,7 @@ pub fn test_lattice_join_set_union() {
 }
 
 #[multiplatform_test]
-pub fn test_lattice_join_map_union() {
+pub fn test_lattice_join_fused_join_map_union() {
     let mut df = hydroflow_syntax! {
         use lattices::map_union::MapUnionSingletonMap;
         use lattices::map_union::MapUnionHashMap;
@@ -46,7 +46,7 @@ pub fn test_lattice_join_map_union() {
         source_iter([(7, MapUnionHashMap::new_from([(3, Min::new(4))])), (7, MapUnionHashMap::new_from([(3, Min::new(5))]))]) -> [0]my_join;
         source_iter([(7, MapUnionSingletonMap::new_from((3, Min::new(5)))), (7, MapUnionSingletonMap::new_from((3, Min::new(4))))]) -> [1]my_join;
 
-        my_join = lattice_join::<MapUnionHashMap<usize, Min<usize>>, MapUnionHashMap<usize, Min<usize>>>()
+        my_join = _lattice_join_fused_join::<MapUnionHashMap<usize, Min<usize>>, MapUnionHashMap<usize, Min<usize>>>()
             -> assert_eq([(7, (MapUnionHashMap::new_from([(3, Min::new(4))]), MapUnionHashMap::new_from([(3, Min::new(4))])))]);
     };
 
@@ -54,7 +54,7 @@ pub fn test_lattice_join_map_union() {
 }
 
 #[multiplatform_test]
-pub fn test_lattice_join() {
+pub fn test_lattice_join_fused_join() {
     use hydroflow::lattices::Max;
 
     // 'static, 'tick.
@@ -65,7 +65,7 @@ pub fn test_lattice_join() {
         let (rhs_tx, rhs_rx) = hydroflow::util::unbounded_channel::<(usize, Max<usize>)>();
 
         let mut df = hydroflow_syntax! {
-            my_join = lattice_join::<'static, 'tick, Max<usize>, Max<usize>>();
+            my_join = _lattice_join_fused_join::<'static, 'tick, Max<usize>, Max<usize>>();
 
             source_stream(lhs_rx) -> [0]my_join;
             source_stream(rhs_rx) -> [1]my_join;
@@ -102,7 +102,7 @@ pub fn test_lattice_join() {
         let (rhs_tx, rhs_rx) = hydroflow::util::unbounded_channel::<(usize, Max<usize>)>();
 
         let mut df = hydroflow_syntax! {
-            my_join = lattice_join::<'static, 'static, Max<usize>, Max<usize>>();
+            my_join = _lattice_join_fused_join::<'static, 'static, Max<usize>, Max<usize>>();
 
             source_stream(lhs_rx) -> [0]my_join;
             source_stream(rhs_rx) -> [1]my_join;

--- a/hydroflow_lang/src/graph/ops/_lattice_fold_batch.rs
+++ b/hydroflow_lang/src/graph/ops/_lattice_fold_batch.rs
@@ -11,10 +11,10 @@ use crate::graph::{OpInstGenerics, OperatorInstance};
 ///
 /// Batches streaming input and releases it downstream when a signal is delivered. This allows for buffering data and delivering it later while also folding it into a single lattice data structure.
 /// This operator is similar to `defer_signal` in that it batches input and releases it when a signal is given. It is also similar to `lattice_fold` in that it folds the input into a single lattice.
-/// So, `lattice_batch` is a combination of both `defer_signal` and `lattice_fold`. This operator is useful when trying to combine a sequence of `defer_signal` and `lattice_fold` operators without unnecessary memory consumption.
+/// So, `_lattice_fold_batch` is a combination of both `defer_signal` and `lattice_fold`. This operator is useful when trying to combine a sequence of `defer_signal` and `lattice_fold` operators without unnecessary memory consumption.
 ///
-/// There are two inputs to `lattice_batch`, they are `input` and `signal`.
-/// `input` is the input data flow. Data that is delivered on this input is collected in order inside of the `lattice_batch` operator.
+/// There are two inputs to `_lattice_fold_batch`, they are `input` and `signal`.
+/// `input` is the input data flow. Data that is delivered on this input is collected in order inside of the `_lattice_fold_batch` operator.
 /// When anything is sent to `signal` the collected data is released downstream. The entire `signal` input is consumed each tick, so sending 5 things on `signal` will not release inputs on the next 5 consecutive ticks.
 ///
 /// ```hydroflow
@@ -28,12 +28,12 @@ use crate::graph::{OpInstGenerics, OperatorInstance};
 /// source_iter([()])
 ///     -> [signal]batcher;
 ///
-/// batcher = lattice_batch::<SetUnionHashSet<usize>>()
+/// batcher = _lattice_fold_batch::<SetUnionHashSet<usize>>()
 ///     -> assert_eq([SetUnionHashSet::new_from([1, 2, 3])]);
 /// ```
-pub const LATTICE_BATCH: OperatorConstraints = OperatorConstraints {
-    name: "lattice_batch",
-    categories: &[OperatorCategory::LatticeFold],
+pub const _LATTICE_FOLD_BATCH: OperatorConstraints = OperatorConstraints {
+    name: "_lattice_fold_batch",
+    categories: &[OperatorCategory::CompilerFusionOperator],
     persistence_args: RANGE_0,
     type_args: &(0..=1),
     hard_range_inn: &(2..=2),

--- a/hydroflow_lang/src/graph/ops/_lattice_join_fused_join.rs
+++ b/hydroflow_lang/src/graph/ops/_lattice_join_fused_join.rs
@@ -12,10 +12,10 @@ use crate::graph::{OpInstGenerics, OperatorInstance};
 /// equijoin of the resulting key/value pairs in the input streams by their first (key) attribute. Like [`join`](#join), the result nests the 2nd input field (values) into a tuple in the 2nd output field.
 ///
 /// You must specify the the accumulating lattice types, they cannot be inferred. The first type argument corresponds to the `[0]` input of the join, and the second to the `[1]` input.
-/// Type arguments are specified in hydroflow using the rust turbofish syntax `::<>`, for example `lattice_join::<Min<_>, Max<_>>()`
+/// Type arguments are specified in hydroflow using the rust turbofish syntax `::<>`, for example `_lattice_join_fused_join::<Min<_>, Max<_>>()`
 /// The accumulating lattice type is not necessarily the same type as the input, see the below example involving SetUnion for such a case.
 ///
-/// Like [`join`](#join), `lattice_join` can also be provided with one or two generic lifetime persistence arguments, either
+/// Like [`join`](#join), `_lattice_join_fused_join` can also be provided with one or two generic lifetime persistence arguments, either
 /// `'tick` or `'static`, to specify how join data persists. With `'tick`, pairs will only be
 /// joined with corresponding pairs within the same tick. With `'static`, pairs will be remembered
 /// across ticks and will be joined with pairs arriving in later ticks. When not explicitly
@@ -29,14 +29,14 @@ use crate::graph::{OpInstGenerics, OperatorInstance};
 ///
 /// The syntax is as follows:
 /// ```hydroflow,ignore
-/// lattice_join::<MaxRepr<usize>, MaxRepr<usize>>(); // Or
-/// lattice_join::<'static, MaxRepr<usize>, MaxRepr<usize>>();
+/// _lattice_join_fused_join::<MaxRepr<usize>, MaxRepr<usize>>(); // Or
+/// _lattice_join_fused_join::<'static, MaxRepr<usize>, MaxRepr<usize>>();
 ///
-/// lattice_join::<'tick, MaxRepr<usize>, MaxRepr<usize>>();
+/// _lattice_join_fused_join::<'tick, MaxRepr<usize>, MaxRepr<usize>>();
 ///
-/// lattice_join::<'static, 'tick, MaxRepr<usize>, MaxRepr<usize>>();
+/// _lattice_join_fused_join::<'static, 'tick, MaxRepr<usize>, MaxRepr<usize>>();
 ///
-/// lattice_join::<'tick, 'static, MaxRepr<usize>, MaxRepr<usize>>();
+/// _lattice_join_fused_join::<'tick, 'static, MaxRepr<usize>, MaxRepr<usize>>();
 /// // etc.
 /// ```
 ///
@@ -49,7 +49,7 @@ use crate::graph::{OpInstGenerics, OperatorInstance};
 /// source_iter([("key", Min::new(1)), ("key", Min::new(2))]) -> [0]my_join;
 /// source_iter([("key", Max::new(1)), ("key", Max::new(2))]) -> [1]my_join;
 ///
-/// my_join = lattice_join::<'tick, Min<usize>, Max<usize>>()
+/// my_join = _lattice_join_fused_join::<'tick, Min<usize>, Max<usize>>()
 ///     -> assert_eq([("key", (Min::new(1), Max::new(2)))]);
 /// ```
 ///
@@ -60,12 +60,12 @@ use crate::graph::{OpInstGenerics, OperatorInstance};
 /// source_iter([("key", SetUnionSingletonSet::new_from(0)), ("key", SetUnionSingletonSet::new_from(1))]) -> [0]my_join;
 /// source_iter([("key", SetUnionHashSet::new_from([0])), ("key", SetUnionHashSet::new_from([1]))]) -> [1]my_join;
 ///
-/// my_join = lattice_join::<'tick, SetUnionHashSet<usize>, SetUnionHashSet<usize>>()
+/// my_join = _lattice_join_fused_join::<'tick, SetUnionHashSet<usize>, SetUnionHashSet<usize>>()
 ///     -> assert_eq([("key", (SetUnionHashSet::new_from([0, 1]), SetUnionHashSet::new_from([0, 1])))]);
 /// ```
-pub const LATTICE_JOIN: OperatorConstraints = OperatorConstraints {
-    name: "lattice_join",
-    categories: &[OperatorCategory::MultiIn],
+pub const _LATTICE_JOIN_FUSED_JOIN: OperatorConstraints = OperatorConstraints {
+    name: "_lattice_join_fused_join",
+    categories: &[OperatorCategory::CompilerFusionOperator],
     hard_range_inn: &(2..=2),
     soft_range_inn: &(2..=2),
     hard_range_out: RANGE_1,

--- a/hydroflow_lang/src/graph/ops/mod.rs
+++ b/hydroflow_lang/src/graph/ops/mod.rs
@@ -287,9 +287,9 @@ declare_ops![
     join_multiset::JOIN_MULTISET,
     fold_keyed::FOLD_KEYED,
     reduce_keyed::REDUCE_KEYED,
-    lattice_batch::LATTICE_BATCH,
+    _lattice_fold_batch::_LATTICE_FOLD_BATCH,
     lattice_fold::LATTICE_FOLD,
-    lattice_join::LATTICE_JOIN,
+    _lattice_join_fused_join::_LATTICE_JOIN_FUSED_JOIN,
     lattice_reduce::LATTICE_REDUCE,
     map::MAP,
     union::UNION,
@@ -491,6 +491,7 @@ pub enum OperatorCategory {
     Source,
     Sink,
     Control,
+    CompilerFusionOperator,
 }
 impl OperatorCategory {
     /// Human-readible heading name, for docs.
@@ -508,6 +509,7 @@ impl OperatorCategory {
             OperatorCategory::Source => "Sources",
             OperatorCategory::Sink => "Sinks",
             OperatorCategory::Control => "Control Flow Operators",
+            OperatorCategory::CompilerFusionOperator => "Compiler Fusion Operators",
         }
     }
     /// Human description, for docs.
@@ -529,6 +531,9 @@ impl OperatorCategory {
                 "Operators which consume input elements (and produce no outputs)."
             }
             OperatorCategory::Control => "Operators which affect control flow/scheduling.",
+            OperatorCategory::CompilerFusionOperator => {
+                "Operators which are necessary to implement certain optimizations and rewrite rules"
+            }
         }
     }
 }

--- a/hydroflow_macro/build.rs
+++ b/hydroflow_macro/build.rs
@@ -39,7 +39,14 @@ fn write_operator_docgen(op_name: &str, mut write: &mut impl Write) -> Result<()
 
 fn update_book() -> Result<()> {
     let mut ops: Vec<_> = OPERATORS.iter().collect();
-    ops.sort_by_key(|op| op.name);
+    // operators that have their name start with "_" are internal compiler operators, we should sort those after all the user-facing ops.
+    // but underscore by default sorts before all [A-z]
+    ops.sort_by(|a, b| {
+        a.name
+            .starts_with('_')
+            .cmp(&b.name.starts_with('_'))
+            .then_with(|| a.name.cmp(b.name))
+    });
 
     let mut write = book_file_writer(FILENAME)?;
     writeln!(write, "{}", PREFIX)?;


### PR DESCRIPTION
fixes https://github.com/hydro-project/hydroflow/issues/832