### PR TITLE
fix(hydroflow_lang): Clean up degenerate subgraph error message for consistency

### DIFF
--- a/hydroflow/tests/compile-fail/surface_degenerate_null.stderr
+++ b/hydroflow/tests/compile-fail/surface_degenerate_null.stderr
@@ -7,6 +7,4 @@ error: proc macro panicked
 7 | |     };
   | |_____^
   |
-  = help: message: assertion failed: `(left == right)`
-            left: `1`,
-           right: `0`: If entire subgraph is pull, should have only one handoff output. Do you have a loose `null()` or other degenerate pipeline somewhere?
+  = help: message: Degenerate subgraph detected, is there a disconnected `null()` or other degenerate pipeline somewhere?

--- a/hydroflow/tests/compile-fail/surface_null.stderr
+++ b/hydroflow/tests/compile-fail/surface_null.stderr
@@ -7,6 +7,4 @@ error: proc macro panicked
 6 | |     };
   | |_____^
   |
-  = help: message: assertion failed: `(left == right)`
-            left: `1`,
-           right: `0`: If entire subgraph is pull, should have only one handoff output. Do you have a loose `null()` or other degenerate pipeline somewhere?
+  = help: message: Degenerate subgraph detected, is there a disconnected `null()` or other degenerate pipeline somewhere?

--- a/hydroflow_lang/src/graph/hydroflow_graph.rs
+++ b/hydroflow_lang/src/graph/hydroflow_graph.rs
@@ -823,10 +823,9 @@ impl HydroflowGraph {
                             self.node_as_ident(node_id, false)
                         } else {
                             // Entire subgraph is pull (except for a single send/push handoff output).
-                            assert_eq!(
-                                1,
-                                send_ports.len(),
-                                "If entire subgraph is pull, should have only one handoff output. Do you have a loose `null()` or other degenerate pipeline somewhere?"
+                            assert!(
+                                1 == send_ports.len(),
+                                "Degenerate subgraph detected, is there a disconnected `null()` or other degenerate pipeline somewhere?"
                             );
                             send_ports[0].clone()
                         };


### PR DESCRIPTION
Makes the pinned and latest nightly version have the same stderr output for consistent testing.