### PR TITLE
ci: parallelize target selection to speed up `cargo test`ing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        target_selection:
+          - "--lib --bins"
+          - "--examples"
+          - "--tests"
+          - "--benches"
+          - "--doc"
         rust_release: [pinned-nightly, latest-nightly]
         exclude:
           # For non-pull requests, event_name != 'pull_request' will be true,
@@ -127,17 +133,11 @@ jobs:
           toolchain: nightly
           override: ${{ matrix.rust_release == 'latest-nightly' }}
 
-      - name: Run cargo test all targets (which does not include doctests)
+      - name: Run cargo test on target_selection
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --profile cidev --no-fail-fast --all-targets --features python
-
-      - name: Run cargo doc tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --profile cidev --no-fail-fast --doc --features python
+          args: --profile cidev --no-fail-fast --features python ${{ matrix.target_selection }}
 
   test-wasm:
     name: Test Suite (WebAssembly)


### PR DESCRIPTION
Speeds up CI testing from about 23m to 12m

20 is the max number of parallel jobs running, this change results in 12 jobs per PR

Build seems to take about 4m, so that is fastest lower bound without upgrading to beefier gh-actions machines

before:
![23m 12s](https://github.com/hydro-project/hydroflow/assets/6778341/3c325995-c454-47f7-a233-638bf98c0741)

after:
![11m 53s](https://github.com/hydro-project/hydroflow/assets/6778341/03e53806-54e1-4b63-a2a0-5bb505c45979)
