### PR TITLE
fix: bump pinned Rust to fix ICE in surface syntax type inference, fix #951

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2023-10-11"
+channel = "nightly-2023-10-14"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Refs: #951