### PR TITLE
add 100ms sleep to chat example to avoid dropped packet

### DIFF
--- a/hydroflow/examples/chat/main.rs
+++ b/hydroflow/examples/chat/main.rs
@@ -95,6 +95,10 @@ fn test() {
         "Client live!",
     );
 
+    // wait 100ms so we don't drop a packet
+    let hundo_millis = std::time::Duration::from_millis(100);
+    std::thread::sleep(hundo_millis);
+
     client1_input.write_all(b"Hello\n").unwrap();
 
     wait_for_process_output(


### PR DESCRIPTION
chat example was failing tests, seems to be due to missed message. adding a 100ms sleep helps.