### PR TITLE
feat(hydroflow): allow Hydroflow+ programs to emit multiple graphs

### DIFF
--- a/hydroflow_plus/src/builder.rs
+++ b/hydroflow_plus/src/builder.rs
@@ -1,11 +1,12 @@
 use std::cell::RefCell;
+use std::collections::BTreeMap;
 use std::marker::PhantomData;
 
 use hydroflow::futures::stream::Stream;
 use hydroflow_lang::graph::{
     eliminate_extra_unions_tees, partition_graph, propegate_flow_props, FlatGraphBuilder,
 };
-use proc_macro2::Span;
+use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use stageleft::{IntoQuotedOnce, Quoted, QuotedContext};
 use syn::parse_quote;
@@ -14,7 +15,7 @@ use crate::{HfBuilt, HfStream, RuntimeContext};
 
 pub struct HfBuilder<'a> {
     pub(crate) next_id: RefCell<usize>,
-    pub(crate) builder: RefCell<Option<FlatGraphBuilder>>,
+    pub(crate) builders: RefCell<Option<BTreeMap<usize, FlatGraphBuilder>>>,
     _phantom: PhantomData<&'a mut &'a ()>,
 }
 
@@ -29,39 +30,66 @@ impl<'a> HfBuilder<'a> {
     pub fn new() -> HfBuilder<'a> {
         HfBuilder {
             next_id: RefCell::new(0),
-            builder: RefCell::new(Some(FlatGraphBuilder::new())),
+            builders: RefCell::new(Some(Default::default())),
             _phantom: PhantomData,
         }
     }
 
-    pub fn build(&self) -> HfBuilt<'a> {
-        let builder = self.builder.borrow_mut().take().unwrap();
+    pub fn build(&self, id: impl Quoted<'a, usize>) -> HfBuilt<'a> {
+        let builders = self.builders.borrow_mut().take().unwrap();
 
-        let (mut flat_graph, _, _) = builder.build();
-        eliminate_extra_unions_tees(&mut flat_graph);
-        let mut partitioned_graph =
-            partition_graph(flat_graph).expect("Failed to partition (cycle detected).");
+        let mut conditioned_tokens = None;
+        for (node_id, builder) in builders {
+            let (mut flat_graph, _, _) = builder.build();
+            eliminate_extra_unions_tees(&mut flat_graph);
+            let mut partitioned_graph =
+                partition_graph(flat_graph).expect("Failed to partition (cycle detected).");
 
-        let hydroflow_crate = proc_macro_crate::crate_name("hydroflow_plus")
-            .expect("hydroflow_plus should be present in `Cargo.toml`");
-        let root = match hydroflow_crate {
-            proc_macro_crate::FoundCrate::Itself => quote! { hydroflow_plus },
-            proc_macro_crate::FoundCrate::Name(name) => {
-                let ident = syn::Ident::new(&name, Span::call_site());
-                quote! { #ident }
+            let hydroflow_crate = proc_macro_crate::crate_name("hydroflow_plus")
+                .expect("hydroflow_plus should be present in `Cargo.toml`");
+            let root = match hydroflow_crate {
+                proc_macro_crate::FoundCrate::Itself => quote! { hydroflow_plus },
+                proc_macro_crate::FoundCrate::Name(name) => {
+                    let ident = syn::Ident::new(&name, Span::call_site());
+                    quote! { #ident }
+                }
+            };
+
+            let mut diagnostics = Vec::new();
+            // Propgeate flow properties throughout the graph.
+            // TODO(mingwei): Should this be done at a flat graph stage instead?
+            let _ = propegate_flow_props::propegate_flow_props(
+                &mut partitioned_graph,
+                &mut diagnostics,
+            );
+
+            let tokens = partitioned_graph.as_code(&root, true, quote::quote!(), &mut diagnostics);
+
+            if let Some(conditioned_tokens) = conditioned_tokens.as_mut() {
+                *conditioned_tokens = parse_quote! {
+                    #conditioned_tokens else if __given_id == #node_id {
+                        #tokens
+                    }
+                };
+            } else {
+                conditioned_tokens = Some(parse_quote! {
+                    if __given_id == #node_id {
+                        #tokens
+                    }
+                });
             }
-        };
+        }
 
-        let mut diagnostics = Vec::new();
-        // Propgeate flow properties throughout the graph.
-        // TODO(mingwei): Should this be done at a flat graph stage instead?
-        let _ =
-            propegate_flow_props::propegate_flow_props(&mut partitioned_graph, &mut diagnostics);
-
-        let tokens = partitioned_graph.as_code(&root, true, quote::quote!(), &mut diagnostics);
+        let id_spliced = id.splice();
+        let conditioned_tokens: TokenStream = conditioned_tokens.unwrap();
 
         HfBuilt {
-            tokens,
+            tokens: parse_quote! {
+                let __given_id = #id_spliced;
+                #conditioned_tokens else {
+                    panic!("Invalid node id: {}", __given_id);
+                }
+            },
             _phantom: PhantomData,
         }
     }
@@ -74,6 +102,7 @@ impl<'a> HfBuilder<'a> {
 
     pub fn source_stream<T, E: Stream<Item = T> + Unpin>(
         &'a self,
+        node_id: usize,
         e: impl Quoted<'a, E>,
     ) -> HfStream<'a, T> {
         let next_id = {
@@ -86,16 +115,19 @@ impl<'a> HfBuilder<'a> {
         let ident = syn::Ident::new(&format!("stream_{}", next_id), Span::call_site());
         let e = e.splice();
 
-        self.builder
+        self.builders
             .borrow_mut()
             .as_mut()
             .unwrap()
+            .entry(node_id)
+            .or_default()
             .add_statement(parse_quote! {
                 #ident = source_stream(#e) -> tee();
             });
 
         HfStream {
             ident,
+            node_id,
             graph: self,
             _phantom: PhantomData,
         }
@@ -103,6 +135,7 @@ impl<'a> HfBuilder<'a> {
 
     pub fn source_iter<T, E: IntoIterator<Item = T>>(
         &'a self,
+        node_id: usize,
         e: impl IntoQuotedOnce<'a, E>,
     ) -> HfStream<'a, T> {
         let next_id = {
@@ -115,22 +148,25 @@ impl<'a> HfBuilder<'a> {
         let ident = syn::Ident::new(&format!("stream_{}", next_id), Span::call_site());
         let e = e.splice();
 
-        self.builder
+        self.builders
             .borrow_mut()
             .as_mut()
             .unwrap()
+            .entry(node_id)
+            .or_default()
             .add_statement(parse_quote! {
                 #ident = source_iter(#e) -> tee();
             });
 
         HfStream {
             ident,
+            node_id,
             graph: self,
             _phantom: PhantomData,
         }
     }
 
-    pub fn cycle<T>(&'a self) -> (HfCycle<'a, T>, HfStream<'a, T>) {
+    pub fn cycle<T>(&'a self, node_id: usize) -> (HfCycle<'a, T>, HfStream<'a, T>) {
         let next_id = {
             let mut next_id = self.next_id.borrow_mut();
             let id = *next_id;
@@ -140,10 +176,12 @@ impl<'a> HfBuilder<'a> {
 
         let ident = syn::Ident::new(&format!("stream_{}", next_id), Span::call_site());
 
-        self.builder
+        self.builders
             .borrow_mut()
             .as_mut()
             .unwrap()
+            .entry(node_id)
+            .or_default()
             .add_statement(parse_quote! {
                 #ident = tee();
             });
@@ -151,11 +189,13 @@ impl<'a> HfBuilder<'a> {
         (
             HfCycle {
                 ident: ident.clone(),
+                node_id,
                 graph: self,
                 _phantom: PhantomData,
             },
             HfStream {
                 ident,
+                node_id,
                 graph: self,
                 _phantom: PhantomData,
             },
@@ -165,6 +205,7 @@ impl<'a> HfBuilder<'a> {
 
 pub struct HfCycle<'a, T> {
     ident: syn::Ident,
+    node_id: usize,
     graph: &'a HfBuilder<'a>,
     _phantom: PhantomData<T>,
 }
@@ -175,10 +216,12 @@ impl<'a, T> HfCycle<'a, T> {
         let stream_ident = stream.ident.clone();
 
         self.graph
-            .builder
+            .builders
             .borrow_mut()
             .as_mut()
             .unwrap()
+            .entry(self.node_id)
+            .or_default()
             .add_statement(parse_quote! {
                 #stream_ident -> #ident;
             });

--- a/hydroflow_plus_test/src/snapshots/hydroflow_plus_test__tests__teed_join_multi_node@graphvis_dot.snap
+++ b/hydroflow_plus_test/src/snapshots/hydroflow_plus_test__tests__teed_join_multi_node@graphvis_dot.snap
@@ -1,0 +1,27 @@
+---
+source: hydroflow_plus_test/src/lib.rs
+expression: "joined.meta_graph().unwrap().to_dot(&Default::default())"
+---
+digraph {
+    node [fontname="Monaco,Menlo,Consolas,&quot;Droid Sans Mono&quot;,Inconsolata,&quot;Courier New&quot;,monospace", style=filled];
+    edge [fontname="Monaco,Menlo,Consolas,&quot;Droid Sans Mono&quot;,Inconsolata,&quot;Courier New&quot;,monospace"];
+    n1v1 [label="(n1v1) source_iter({\l    use crate::__staged::*;\l    0..5\l})\l", shape=invhouse, fillcolor="#88aaff"]
+    n3v1 [label="(n3v1) for_each({\l    use crate::__staged::*;\l    let output = output;\l    |v| {\l        output.send(v).unwrap();\l    }\l})\l", shape=house, fillcolor="#ffff88"]
+    n1v1 -> n3v1
+    subgraph "cluster n1v1" {
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_1v1\nstratum 0"
+        n1v1
+        n3v1
+        subgraph "cluster_sg_1v1_var_stream_7" {
+            label="var stream_7"
+            n1v1
+        }
+        subgraph "cluster_sg_1v1_var_stream_8" {
+            label="var stream_8"
+            n3v1
+        }
+    }
+}
+

--- a/hydroflow_plus_test/src/snapshots/hydroflow_plus_test__tests__teed_join_multi_node@graphvis_mermaid.snap
+++ b/hydroflow_plus_test/src/snapshots/hydroflow_plus_test__tests__teed_join_multi_node@graphvis_mermaid.snap
@@ -1,0 +1,24 @@
+---
+source: hydroflow_plus_test/src/lib.rs
+expression: "joined.meta_graph().unwrap().to_mermaid(&Default::default())"
+---
+%%{init:{'theme':'base','themeVariables':{'clusterBkg':'#ddd','clusterBorder':'#888'}}}%%
+flowchart TD
+classDef pullClass fill:#8af,stroke:#000,text-align:left,white-space:pre
+classDef pushClass fill:#ff8,stroke:#000,text-align:left,white-space:pre
+classDef otherClass fill:#fdc,stroke:#000,text-align:left,white-space:pre
+linkStyle default stroke:#aaa
+1v1[\"<div style=text-align:center>(1v1)</div> <code>source_iter({<br>    use crate::__staged::*;<br>    0..5<br>})</code>"/]:::pullClass
+3v1[/"<div style=text-align:center>(3v1)</div> <code>for_each({<br>    use crate::__staged::*;<br>    let output = output;<br>    |v| {<br>        output.send(v).unwrap();<br>    }<br>})</code>"\]:::pushClass
+1v1-->3v1
+subgraph sg_1v1 ["sg_1v1 stratum 0"]
+    1v1
+    3v1
+    subgraph sg_1v1_var_stream_7 ["var <tt>stream_7</tt>"]
+        1v1
+    end
+    subgraph sg_1v1_var_stream_8 ["var <tt>stream_8</tt>"]
+        3v1
+    end
+end
+


### PR DESCRIPTION
feat(hydroflow): allow Hydroflow+ programs to emit multiple graphs



This PR adds support for tagging elements of Hydroflow+ graphs with a node ID, an integer which specifies which Hydroflow graph the computation should be emitted to. The generated code includes the Hydroflow graph for each node ID, so that the appropriate graph can be selected at runtime.

At a larger scale, this is a precursor to adding network operators to Hydroflow+, which will allow distributed logic to be described in a single Hydroflow+ program by specifying points at which data is transferred between different graphs.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydroflow/pull/976).
* #982
* #981
* #978
* __->__ #976