### PR TITLE
feat(hydroflow): add initial test using Hydro CLI from Hydroflow+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,11 +216,6 @@ jobs:
           pip install maturin
           maturin develop
 
-      - name: Configure core dumps
-        run: |
-          mkdir cli-core-dumps
-          echo "$PWD/cli-core-dumps/corefile-%e-%p-%t" | sudo tee /proc/sys/kernel/core_pattern
-
       - name: Run Python tests
         run: |
           ulimit -c unlimited
@@ -229,24 +224,16 @@ jobs:
           cd python_tests
           pip install -r requirements.txt
           RUST_BACKTRACE=1 pytest *.py
+          cd ../..
 
-      - name: Print backtraces
-        if: ${{ failure() }}
+      - name: Run Hydroflow+ Python tests
         run: |
-          cd cli-core-dumps
-          sudo apt-get install gdb
-          for file in $(ls); do
-            echo "Backtrace for $file"
-            rust-gdb -ex "thread apply all bt" -batch $PWD/../.venv/bin/python $file
-          done
-          cd ..
-
-      - name: Upload core dumps
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@master
-        with:
-          name: cli-core-dumps
-          path: ./cli-core-dumps/*
+          ulimit -c unlimited
+          cd hydro_cli
+          source .venv/bin/activate
+          cd ../hydroflow_plus_test/python_tests
+          pip install -r requirements.txt
+          RUST_BACKTRACE=1 pytest *.py
 
   lints:
     name: Lints

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,6 +1494,7 @@ dependencies = [
 name = "hydroflow_plus_test"
 version = "0.0.0"
 dependencies = [
+ "hydroflow",
  "hydroflow_plus",
  "hydroflow_plus_test_macro",
  "insta",
@@ -1501,17 +1502,20 @@ dependencies = [
  "serde",
  "stageleft",
  "stageleft_tool",
+ "tokio",
 ]
 
 [[package]]
 name = "hydroflow_plus_test_macro"
 version = "0.0.0"
 dependencies = [
+ "hydroflow",
  "hydroflow_plus",
  "regex",
  "serde",
  "stageleft",
  "stageleft_tool",
+ "tokio",
 ]
 
 [[package]]

--- a/docs/docs/deploy/your-first-deploy.md
+++ b/docs/docs/deploy/your-first-deploy.md
@@ -29,7 +29,7 @@ Let's open up `src/main.rs` in the generated project and write a new `main` func
 ```rust
 #[hydroflow::main]
 async fn main() {
-    let mut ports = hydroflow::util::cli::init().await;
+    let ports = hydroflow::util::cli::init().await;
 }
 ```
 
@@ -72,7 +72,7 @@ use hydroflow::hydroflow_syntax;
 
 #[hydroflow::main]
 async fn main() {
-    let mut ports = hydroflow::util::cli::init().await;
+    let ports = hydroflow::util::cli::init().await;
 
     let input_recv = ports
         .port("input")

--- a/hydro_cli_examples/examples/dedalus_2pc_coordinator/main.rs
+++ b/hydro_cli_examples/examples/dedalus_2pc_coordinator/main.rs
@@ -4,7 +4,7 @@ use hydroflow_datalog::datalog;
 
 #[hydroflow::main]
 async fn main() {
-    let mut ports = hydroflow::util::cli::init().await;
+    let ports = hydroflow::util::cli::init().await;
     let vote_to_participant_port = ports
         .port("vote_to_participant")
         .connect::<ConnectedDemux<ConnectedDirect>>()

--- a/hydro_cli_examples/examples/dedalus_2pc_participant/main.rs
+++ b/hydro_cli_examples/examples/dedalus_2pc_participant/main.rs
@@ -4,7 +4,7 @@ use hydroflow_datalog::datalog;
 
 #[hydroflow::main]
 async fn main() {
-    let mut ports = hydroflow::util::cli::init().await;
+    let ports = hydroflow::util::cli::init().await;
     let vote_to_participant_source = ports
         .port("vote_to_participant")
         .connect::<ConnectedDirect>()

--- a/hydro_cli_examples/examples/dedalus_receiver/main.rs
+++ b/hydro_cli_examples/examples/dedalus_receiver/main.rs
@@ -4,7 +4,7 @@ use hydroflow_datalog::datalog;
 
 #[hydroflow::main]
 async fn main() {
-    let mut ports = hydroflow::util::cli::init().await;
+    let ports = hydroflow::util::cli::init().await;
     let broadcast_recv = ports
         .port("broadcast")
         .connect::<ConnectedDirect>()

--- a/hydro_cli_examples/examples/dedalus_sender/main.rs
+++ b/hydro_cli_examples/examples/dedalus_sender/main.rs
@@ -5,7 +5,7 @@ use hydroflow_datalog::datalog;
 
 #[hydroflow::main]
 async fn main() {
-    let mut ports = hydroflow::util::cli::init().await;
+    let ports = hydroflow::util::cli::init().await;
     let broadcast_port = ports
         .port("broadcast")
         .connect::<ConnectedDemux<ConnectedDirect>>()

--- a/hydro_cli_examples/examples/dedalus_vote_leader/main.rs
+++ b/hydro_cli_examples/examples/dedalus_vote_leader/main.rs
@@ -4,7 +4,7 @@ use hydroflow_datalog::datalog;
 
 #[hydroflow::main]
 async fn main() {
-    let mut ports = hydroflow::util::cli::init().await;
+    let ports = hydroflow::util::cli::init().await;
     let to_replica_port = ports
         .port("to_replica")
         .connect::<ConnectedDemux<ConnectedDirect>>()

--- a/hydro_cli_examples/examples/dedalus_vote_participant/main.rs
+++ b/hydro_cli_examples/examples/dedalus_vote_participant/main.rs
@@ -4,7 +4,7 @@ use hydroflow_datalog::datalog;
 
 #[hydroflow::main]
 async fn main() {
-    let mut ports = hydroflow::util::cli::init().await;
+    let ports = hydroflow::util::cli::init().await;
     let to_replica_source = ports
         .port("to_replica")
         .connect::<ConnectedDirect>()

--- a/hydro_cli_examples/examples/stdout_receiver/main.rs
+++ b/hydro_cli_examples/examples/stdout_receiver/main.rs
@@ -3,7 +3,7 @@ use hydroflow::util::cli::{ConnectedDirect, ConnectedSource};
 
 #[hydroflow::main]
 async fn main() {
-    let mut ports = hydroflow::util::cli::init().await;
+    let ports = hydroflow::util::cli::init().await;
     let echo_recv = ports
         .port("echo")
         .connect::<ConnectedDirect>()

--- a/hydro_cli_examples/examples/tagged_stdout_receiver/main.rs
+++ b/hydro_cli_examples/examples/tagged_stdout_receiver/main.rs
@@ -3,7 +3,7 @@ use hydroflow::util::cli::{ConnectedDirect, ConnectedSource, ConnectedTagged};
 
 #[hydroflow::main]
 async fn main() {
-    let mut ports = hydroflow::util::cli::init().await;
+    let ports = hydroflow::util::cli::init().await;
     let echo_recv = ports
         .port("echo")
         .connect::<ConnectedTagged<ConnectedDirect>>()

--- a/hydro_cli_examples/examples/ws_chat_server/main.rs
+++ b/hydro_cli_examples/examples/ws_chat_server/main.rs
@@ -29,7 +29,7 @@ struct ChatMessage {
 
 #[hydroflow::main]
 async fn main() {
-    let mut ports = hydroflow::util::cli::init().await;
+    let ports = hydroflow::util::cli::init().await;
 
     let from_peer = ports
         .port("from_peer")

--- a/hydroflow/src/scheduled/context.rs
+++ b/hydroflow/src/scheduled/context.rs
@@ -3,6 +3,7 @@
 use std::any::Any;
 use std::future::Future;
 use std::marker::PhantomData;
+use std::pin::Pin;
 
 use instant::Instant;
 use tokio::sync::mpsc::UnboundedSender;
@@ -36,6 +37,8 @@ pub struct Context {
     /// not being forwarded to a running operator, this field is (mostly)
     /// meaningless.
     pub(crate) subgraph_id: SubgraphId,
+
+    pub(crate) tasks_to_spawn: Vec<Pin<Box<dyn Future<Output = ()> + 'static>>>,
 
     /// Join handles for spawned tasks.
     pub(crate) task_join_handles: Vec<JoinHandle<()>>,
@@ -155,23 +158,29 @@ impl Context {
             .expect("StateHandle wrong type T for casting.")
     }
 
-    /// Spawns an async task on the internal Tokio executor.
-    pub fn spawn_task<Fut>(&mut self, future: Fut)
+    /// Prepares an async task to be launched by [`Self::spawn_tasks`].
+    pub fn request_task<Fut>(&mut self, future: Fut)
     where
         Fut: Future<Output = ()> + 'static,
     {
-        self.task_join_handles
-            .push(tokio::task::spawn_local(future));
+        self.tasks_to_spawn.push(Box::pin(future));
     }
 
-    /// Aborts all tasks spawned with [`Self::spawn_task`].
+    /// Launches all tasks requested with [`Self::request_task`] on the internal Tokio executor.
+    pub fn spawn_tasks(&mut self) {
+        for task in self.tasks_to_spawn.drain(..) {
+            self.task_join_handles.push(tokio::task::spawn_local(task));
+        }
+    }
+
+    /// Aborts all tasks spawned with [`Self::spawn_tasks`].
     pub fn abort_tasks(&mut self) {
         for task in self.task_join_handles.drain(..) {
             task.abort();
         }
     }
 
-    /// Waits for all tasks spawned with [`Self::spawn_task`] to complete.
+    /// Waits for all tasks spawned with [`Self::spawn_tasks`] to complete.
     ///
     /// Will probably just hang.
     pub async fn join_tasks(&mut self) {

--- a/hydroflow/src/scheduled/graph.rs
+++ b/hydroflow/src/scheduled/graph.rs
@@ -61,6 +61,7 @@ impl<'a> Default for Hydroflow<'a> {
 
             subgraph_id: SubgraphId(0),
 
+            tasks_to_spawn: Vec::new(),
             task_join_handles: Vec::new(),
         };
         Self {
@@ -351,6 +352,7 @@ impl<'a> Hydroflow<'a> {
     /// TODO(mingwei): Currently blockes forever, no notion of "completion."
     #[tracing::instrument(level = "trace", skip(self), ret)]
     pub async fn run_async(&mut self) -> Option<Never> {
+        self.context.spawn_tasks();
         loop {
             // Run any work which is immediately available.
             self.run_available_async().await;
@@ -681,12 +683,12 @@ impl<'a> Hydroflow<'a> {
 }
 
 impl<'a> Hydroflow<'a> {
-    /// Alias for [`Context::spawn_task`].
-    pub fn spawn_task<Fut>(&mut self, future: Fut)
+    /// Alias for [`Context::request_task`].
+    pub fn request_task<Fut>(&mut self, future: Fut)
     where
         Fut: Future<Output = ()> + 'static,
     {
-        self.context.spawn_task(future);
+        self.context.request_task(future);
     }
 
     /// Alias for [`Context::abort_tasks`].

--- a/hydroflow_cli_integration/src/lib.rs
+++ b/hydroflow_cli_integration/src/lib.rs
@@ -175,6 +175,12 @@ impl ServerOrBound {
         T::from_defn(self).await
     }
 
+    pub fn connect_local_blocking<T: Connected>(self) -> T {
+        let handle = tokio::runtime::Handle::current();
+        let _guard = handle.enter();
+        futures::executor::block_on(T::from_defn(self))
+    }
+
     pub async fn accept_tcp(&mut self) -> TcpStream {
         if let ServerOrBound::Bound(BoundConnection::TcpPort(handle, _)) = self {
             handle.recv().await.unwrap().unwrap()

--- a/hydroflow_lang/src/graph/ops/dest_sink.rs
+++ b/hydroflow_lang/src/graph/ops/dest_sink.rs
@@ -11,7 +11,7 @@ use super::{
 /// A `Sink` is a thing into which values can be sent, asynchronously. For example, sending items
 /// into a bounded channel.
 ///
-/// Note this operator must be used within a Tokio runtime.
+/// Note this operator must be used within a Tokio runtime, and the Hydroflow program must be launched with `run_async`.
 ///
 /// ```rustbook
 /// # #[hydroflow::main]
@@ -139,7 +139,7 @@ pub const DEST_SINK: OperatorConstraints = OperatorConstraints {
                     }
                 }
                 #hydroflow
-                    .spawn_task(sink_feed_flush(#recv_ident, #sink_arg));
+                    .request_task(sink_feed_flush(#recv_ident, #sink_arg));
             }
         };
 

--- a/hydroflow_plus_test/Cargo.toml
+++ b/hydroflow_plus_test/Cargo.toml
@@ -5,7 +5,9 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+hydroflow = { path = "../hydroflow", version = "^0.5.0", features = [ "cli_integration" ] }
 hydroflow_plus = { path = "../hydroflow_plus", version = "^0.5.0" }
+tokio = { version = "1.16", features = [ "full" ] }
 stageleft = { path = "../stageleft", version = "^0.1.0" }
 regex = "1"
 serde = "1"

--- a/hydroflow_plus_test/examples/networked_basic.rs
+++ b/hydroflow_plus_test/examples/networked_basic.rs
@@ -1,0 +1,12 @@
+use hydroflow_plus_test::*;
+
+// cannot use hydroflow::main because connect_local_blocking causes a deadlock
+#[tokio::main]
+async fn main() {
+    let node_id: usize = std::env::args().nth(1).unwrap().parse().unwrap();
+    let ports = hydroflow::util::cli::init().await;
+
+    let joined = hydroflow_plus_test::networked::networked_basic!(&ports, node_id);
+
+    hydroflow::util::cli::launch_flow(joined).await;
+}

--- a/hydroflow_plus_test/python_tests/basic.py
+++ b/hydroflow_plus_test/python_tests/basic.py
@@ -1,0 +1,48 @@
+from codecs import decode
+import json
+from pathlib import Path
+import pytest
+import hydro
+
+@pytest.mark.asyncio
+async def test_networked_basic():
+    deployment = hydro.Deployment()
+    localhost_machine = deployment.Localhost()
+
+    sender = deployment.CustomService(
+        external_ports=[],
+        on=localhost_machine.client_only(),
+    )
+
+    program_zero = deployment.HydroflowCrate(
+        src=str((Path(__file__).parent.parent).absolute()),
+        args=["0"],
+        example="networked_basic",
+        profile="dev",
+        on=localhost_machine
+    )
+
+    program_one = deployment.HydroflowCrate(
+        src=str((Path(__file__).parent.parent).absolute()),
+        args=["1"],
+        example="networked_basic",
+        profile="dev",
+        on=localhost_machine
+    )
+
+    sender_port = sender.client_port()
+    sender_port.send_to(program_zero.ports.node_zero_input)
+
+    program_zero.ports.node_zero_output.send_to(program_one.ports.node_one_input)
+
+    await deployment.deploy()
+
+    receiver_out = await program_one.stdout()
+    connection = await (await sender_port.server_port()).into_sink()
+
+    await deployment.start()
+    await connection.send(bytes("hi!", "utf-8"))
+
+    async for log in receiver_out:
+        assert log == "node one received: \"hi!\""
+        break

--- a/hydroflow_plus_test/python_tests/requirements.txt
+++ b/hydroflow_plus_test/python_tests/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-asyncio

--- a/hydroflow_plus_test/src/lib.rs
+++ b/hydroflow_plus_test/src/lib.rs
@@ -7,6 +7,8 @@ use hydroflow_plus::tokio_stream::wrappers::UnboundedReceiverStream;
 use hydroflow_plus::HfBuilder;
 use stageleft::{q, Quoted, RuntimeData};
 
+pub mod networked;
+
 #[stageleft::entry(UnboundedReceiverStream<u32>)]
 pub fn teed_join<'a, S: Stream<Item = u32> + Unpin + 'a>(
     graph: &'a HfBuilder<'a>,

--- a/hydroflow_plus_test/src/networked.rs
+++ b/hydroflow_plus_test/src/networked.rs
@@ -1,0 +1,47 @@
+use hydroflow::bytes::BytesMut;
+use hydroflow::util::cli::{ConnectedDirect, ConnectedSink, ConnectedSource, HydroCLI};
+use hydroflow_plus::scheduled::graph::Hydroflow;
+use hydroflow_plus::HfBuilder;
+use stageleft::{q, Quoted, RuntimeData};
+
+#[stageleft::entry]
+pub fn networked_basic<'a>(
+    graph: &'a HfBuilder<'a>,
+    cli: RuntimeData<&'a HydroCLI>,
+    node_id: RuntimeData<usize>,
+) -> impl Quoted<'a, Hydroflow<'a>> {
+    let source_zero = graph.source_stream(
+        0,
+        q!({
+            cli.port("node_zero_input")
+                .connect_local_blocking::<ConnectedDirect>()
+                .into_source()
+        }),
+    );
+
+    source_zero
+        .map(q!(|v: Result<BytesMut, _>| v.unwrap().freeze()))
+        .dest_sink(q!({
+            cli.port("node_zero_output")
+                .connect_local_blocking::<ConnectedDirect>()
+                .into_sink()
+        }));
+
+    let source_one = graph.source_stream(
+        1,
+        q!({
+            cli.port("node_one_input")
+                .connect_local_blocking::<ConnectedDirect>()
+                .into_source()
+        }),
+    );
+
+    source_one.for_each(q!(|v: Result<BytesMut, _>| {
+        println!(
+            "node one received: {:?}",
+            std::str::from_utf8(&v.unwrap()).unwrap()
+        );
+    }));
+
+    graph.build(node_id)
+}

--- a/hydroflow_plus_test_macro/Cargo.toml
+++ b/hydroflow_plus_test_macro/Cargo.toml
@@ -13,7 +13,9 @@ default = ["macro"]
 macro = []
 
 [dependencies]
+hydroflow = { path = "../hydroflow", version = "^0.5.0", features = [ "cli_integration" ] }
 hydroflow_plus = { path = "../hydroflow_plus", version = "^0.5.0" }
+tokio = { version = "1.16", features = [ "full" ] }
 stageleft = { path = "../stageleft", version = "^0.1.0" }
 regex = "1"
 serde = "1"

--- a/stageleft_macro/src/lib.rs
+++ b/stageleft_macro/src/lib.rs
@@ -296,7 +296,6 @@ pub fn entry(
     };
 
     let input_contents = input
-        .block
         .to_token_stream()
         .to_string()
         .chars()

--- a/stageleft_tool/src/lib.rs
+++ b/stageleft_tool/src/lib.rs
@@ -32,8 +32,9 @@ impl<'a> Visit<'a> for GenMacroVistor {
 
         if is_entry {
             let cur_path = &self.current_mod;
-            let contents = i
-                .block
+            let mut i_cloned = i.clone();
+            i_cloned.attrs = vec![];
+            let contents = i_cloned
                 .to_token_stream()
                 .to_string()
                 .chars()

--- a/topolotree/src/latency_measure.rs
+++ b/topolotree/src/latency_measure.rs
@@ -16,7 +16,7 @@ use protocol::*;
 
 #[tokio::main]
 async fn main() {
-    let mut ports = hydroflow::util::cli::init().await;
+    let ports = hydroflow::util::cli::init().await;
     let mut start_node = ports
         .port("increment_start_node")
         .connect::<ConnectedDirect>()

--- a/topolotree/src/main.rs
+++ b/topolotree/src/main.rs
@@ -216,7 +216,7 @@ async fn main() {
     let _self_id: u32 = args.next().unwrap().parse().unwrap();
     let neighbors: Vec<u32> = args.map(|x| x.parse().unwrap()).collect();
 
-    let mut ports = hydroflow::util::cli::init().await;
+    let ports = hydroflow::util::cli::init().await;
 
     let input_recv = ports
         .port("from_peer")

--- a/topolotree/src/pn.rs
+++ b/topolotree/src/pn.rs
@@ -23,7 +23,7 @@ enum GossipOrIncrement {
 
 #[hydroflow::main]
 async fn main() {
-    let mut ports = hydroflow::util::cli::init().await;
+    let ports = hydroflow::util::cli::init().await;
 
     let my_id: Vec<usize> = serde_json::from_str(&std::env::args().nth(1).unwrap()).unwrap();
     let my_id = my_id[0];

--- a/topolotree/src/pn_delta.rs
+++ b/topolotree/src/pn_delta.rs
@@ -23,7 +23,7 @@ type NextStateType = (u64, bool, Rc<RefCell<(Vec<u64>, Vec<u64>)>>);
 
 #[hydroflow::main]
 async fn main() {
-    let mut ports = hydroflow::util::cli::init().await;
+    let ports = hydroflow::util::cli::init().await;
 
     let my_id: Vec<usize> = serde_json::from_str(&std::env::args().nth(1).unwrap()).unwrap();
     let my_id = my_id[0];


### PR DESCRIPTION
feat(hydroflow): add initial test using Hydro CLI from Hydroflow+





This also required a change to Hydroflow core to make it possible to run the dataflow itself on a single thread (using a LocalSet), even if the surrounding runtime is not single-threaded (required to work around deadlocks because we can't use async APIs inside Hydroflow+). This requires us to spawn any Hydroflow tasks (only for `dest_sink` at the moment) right next to when we run the dataflow rather than when the Hydroflow graph is initialized. From a conceptual perspective, this seems _more right_, since now creating a Hydroflow program will not result in any actual tasks running.

In the third PR of this series, I aim to add a new Hydroflow+ operator that will automate the setup of a `dest_sink`/`source_stream` pair that span nodes.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydroflow/pull/978).
* #982
* #981
* __->__ #978