### PR TITLE
feat(hydroflow): add preliminary `send_to` operator for multi-node graphs

### DIFF
--- a/hydroflow_plus_test/python_tests/basic.py
+++ b/hydroflow_plus_test/python_tests/basic.py
@@ -33,7 +33,7 @@ async def test_networked_basic():
     sender_port = sender.client_port()
     sender_port.send_to(program_zero.ports.node_zero_input)
 
-    program_zero.ports.node_zero_output.send_to(program_one.ports.node_one_input)
+    program_zero.ports.zero_to_one.send_to(program_one.ports.zero_to_one)
 
     await deployment.deploy()
 

--- a/hydroflow_plus_test/src/networked.rs
+++ b/hydroflow_plus_test/src/networked.rs
@@ -1,5 +1,5 @@
 use hydroflow::bytes::BytesMut;
-use hydroflow::util::cli::{ConnectedDirect, ConnectedSink, ConnectedSource, HydroCLI};
+use hydroflow::util::cli::{ConnectedDirect, ConnectedSource, HydroCLI};
 use hydroflow_plus::scheduled::graph::Hydroflow;
 use hydroflow_plus::HfBuilder;
 use stageleft::{q, Quoted, RuntimeData};
@@ -20,28 +20,14 @@ pub fn networked_basic<'a>(
     );
 
     source_zero
-        .map(q!(|v: Result<BytesMut, _>| v.unwrap().freeze()))
-        .dest_sink(q!({
-            cli.port("node_zero_output")
-                .connect_local_blocking::<ConnectedDirect>()
-                .into_sink()
+        .map(q!(|v| v.unwrap().freeze()))
+        .send_to(1, "zero_to_one", cli)
+        .for_each(q!(|v: Result<BytesMut, _>| {
+            println!(
+                "node one received: {:?}",
+                std::str::from_utf8(&v.unwrap()).unwrap()
+            );
         }));
-
-    let source_one = graph.source_stream(
-        1,
-        q!({
-            cli.port("node_one_input")
-                .connect_local_blocking::<ConnectedDirect>()
-                .into_source()
-        }),
-    );
-
-    source_one.for_each(q!(|v: Result<BytesMut, _>| {
-        println!(
-            "node one received: {:?}",
-            std::str::from_utf8(&v.unwrap()).unwrap()
-        );
-    }));
 
     graph.build(node_id)
 }


### PR DESCRIPTION
feat(hydroflow): add preliminary `send_to` operator for multi-node graphs

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydroflow/pull/981).
* #982
* __->__ #981