### PR TITLE
feat(hydroflow_plus): tweak naming of windowing operators

### DIFF
--- a/hydroflow_plus/src/stream.rs
+++ b/hydroflow_plus/src/stream.rs
@@ -109,10 +109,6 @@ impl<'a, T, W, N: HfNode<'a>> Stream<'a, T, W, N> {
         self.pipeline_op(parse_quote!(filter_map(#f)))
     }
 
-    pub fn persist(&self) -> Stream<'a, T, Windowed, N> {
-        self.pipeline_op(parse_quote!(persist()))
-    }
-
     // TODO(shadaj): should allow for differing windows, using strongest one
     pub fn cross_product<O>(&self, other: &Stream<'a, O, W, N>) -> Stream<'a, (T, O), W, N> {
         let next_id = {
@@ -236,7 +232,11 @@ impl<'a, T, W, N: HfNode<'a>> Stream<'a, T, W, N> {
 }
 
 impl<'a, T, N: HfNode<'a>> Stream<'a, T, Async, N> {
-    pub fn batched(&self) -> Stream<'a, T, Windowed, N> {
+    pub fn all_ticks(&self) -> Stream<'a, T, Windowed, N> {
+        self.pipeline_op(parse_quote!(persist()))
+    }
+
+    pub fn tick_batch(&self) -> Stream<'a, T, Windowed, N> {
         Stream {
             ident: self.ident.clone(),
             node: self.node.clone(),

--- a/hydroflow_plus_test/src/cluster.rs
+++ b/hydroflow_plus_test/src/cluster.rs
@@ -56,11 +56,11 @@ pub fn map_reduce<'a, D: Deploy<'a>>(
 
     words_partitioned
         .demux_bincode(&cluster)
-        .batched()
+        .tick_batch()
         .fold(q!(|| 0), q!(|count, string: String| *count += string.len()))
         .inspect(q!(|count| println!("partition count: {}", count)))
         .send_bincode_tagged(&node)
-        .persist()
+        .all_ticks()
         .map(q!(|(_mid, count)| count))
         .fold(q!(|| 0), q!(|total, count| *total += count))
         .for_each(q!(|data| println!("total: {}", data)));


### PR DESCRIPTION
feat(hydroflow_plus): tweak naming of windowing operators

persist -> all_ticks
batched -> tick_batch

seems to help with legibility

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydroflow/pull/1006).
* #1007
* #1002
* __->__ #1006