### PR TITLE
refactor(hydroflow_lang): emit prologue code before all subgraph code

### DIFF
--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__aggregations_and_comments@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__aggregations_and_comments@datalog_program.snap
@@ -66,6 +66,42 @@ fn main() {
                         >::default(),
                     ),
                 );
+            let sg_1v1_node_14v1_groupbydata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::rustc_hash::FxHashMap::<(_,), (Option<_>,)>::default(),
+                    ),
+                );
+            let sg_1v1_node_5v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_2v1_node_21v1_groupbydata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::rustc_hash::FxHashMap::<(_,), (Option<_>,)>::default(),
+                    ),
+                );
+            let sg_2v1_node_8v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_3v1_node_17v1_groupbydata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::rustc_hash::FxHashMap::<(_,), (Option<_>,)>::default(),
+                    ),
+                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(5v1)",
                 0,
@@ -323,21 +359,6 @@ fn main() {
                     check_pivot_run(op_2v1, op_3v1);
                 },
             );
-            let sg_1v1_node_14v1_groupbydata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::rustc_hash::FxHashMap::<(_,), (Option<_>,)>::default(),
-                    ),
-                );
-            let sg_1v1_node_5v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(1v1)",
                 1,
@@ -643,21 +664,6 @@ fn main() {
                     check_pivot_run(op_5v1, op_11v1);
                 },
             );
-            let sg_2v1_node_21v1_groupbydata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::rustc_hash::FxHashMap::<(_,), (Option<_>,)>::default(),
-                    ),
-                );
-            let sg_2v1_node_8v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(2v1)",
                 1,
@@ -865,12 +871,6 @@ fn main() {
                     check_pivot_run(op_8v1, op_12v1);
                 },
             );
-            let sg_3v1_node_17v1_groupbydata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::rustc_hash::FxHashMap::<(_,), (Option<_>,)>::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(3v1)",
                 1,

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__aggregations_fold_keyed_expr@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__aggregations_fold_keyed_expr@datalog_program.snap
@@ -41,6 +41,21 @@ fn main() {
                         >::default(),
                     ),
                 );
+            let sg_1v1_node_10v1_groupbydata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::rustc_hash::FxHashMap::<(_,), (Option<_>,)>::default(),
+                    ),
+                );
+            let sg_1v1_node_5v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(2v1)",
                 0,
@@ -184,21 +199,6 @@ fn main() {
                     check_pivot_run(op_9v1, hoff_6v3_send);
                 },
             );
-            let sg_1v1_node_10v1_groupbydata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::rustc_hash::FxHashMap::<(_,), (Option<_>,)>::default(),
-                    ),
-                );
-            let sg_1v1_node_5v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(1v1)",
                 1,

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__anti_join@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__anti_join@datalog_program.snap
@@ -51,6 +51,97 @@ fn main() {
                         >::default(),
                     ),
                 );
+            let mut sg_3v1_node_13v1_stream = {
+                #[inline(always)]
+                fn check_stream<
+                    Stream: hydroflow::futures::stream::Stream<Item = Item>
+                        + ::std::marker::Unpin,
+                    Item,
+                >(
+                    stream: Stream,
+                ) -> impl hydroflow::futures::stream::Stream<
+                    Item = Item,
+                > + ::std::marker::Unpin {
+                    stream
+                }
+                check_stream(ints_1)
+            };
+            let mut sg_4v1_node_14v1_stream = {
+                #[inline(always)]
+                fn check_stream<
+                    Stream: hydroflow::futures::stream::Stream<Item = Item>
+                        + ::std::marker::Unpin,
+                    Item,
+                >(
+                    stream: Stream,
+                ) -> impl hydroflow::futures::stream::Stream<
+                    Item = Item,
+                > + ::std::marker::Unpin {
+                    stream
+                }
+                check_stream(ints_2)
+            };
+            let sg_1v1_node_2v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_1v1_node_5v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_1v1_node_17v1_joindata_lhs = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
+                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
+                        ),
+                    ),
+                );
+            let sg_1v1_node_17v1_joindata_rhs = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
+                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
+                        ),
+                    ),
+                );
+            let sg_1v1_node_21v1_antijoindata_neg = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_1v1_node_21v1_antijoindata_pos = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_1v1_node_11v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(2v1)",
                 0,
@@ -194,21 +285,6 @@ fn main() {
                     check_pivot_run(op_24v1, hoff_12v3_send);
                 },
             );
-            let mut sg_3v1_node_13v1_stream = {
-                #[inline(always)]
-                fn check_stream<
-                    Stream: hydroflow::futures::stream::Stream<Item = Item>
-                        + ::std::marker::Unpin,
-                    Item,
-                >(
-                    stream: Stream,
-                ) -> impl hydroflow::futures::stream::Stream<
-                    Item = Item,
-                > + ::std::marker::Unpin {
-                    stream
-                }
-                check_stream(ints_1)
-            };
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(3v1)",
                 0,
@@ -272,21 +348,6 @@ fn main() {
                     check_pivot_run(op_13v1, hoff_9v3_send);
                 },
             );
-            let mut sg_4v1_node_14v1_stream = {
-                #[inline(always)]
-                fn check_stream<
-                    Stream: hydroflow::futures::stream::Stream<Item = Item>
-                        + ::std::marker::Unpin,
-                    Item,
-                >(
-                    stream: Stream,
-                ) -> impl hydroflow::futures::stream::Stream<
-                    Item = Item,
-                > + ::std::marker::Unpin {
-                    stream
-                }
-                check_stream(ints_2)
-            };
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(4v1)",
                 0,
@@ -350,67 +411,6 @@ fn main() {
                     check_pivot_run(op_14v1, hoff_6v3_send);
                 },
             );
-            let sg_1v1_node_2v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_1v1_node_5v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_1v1_node_17v1_joindata_lhs = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
-                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
-                        ),
-                    ),
-                );
-            let sg_1v1_node_17v1_joindata_rhs = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
-                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
-                        ),
-                    ),
-                );
-            let sg_1v1_node_21v1_antijoindata_neg = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_1v1_node_21v1_antijoindata_pos = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_1v1_node_11v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(1v1)",
                 1,

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__expr_lhs@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__expr_lhs@datalog_program.snap
@@ -66,6 +66,15 @@ fn main() {
                         >::default(),
                     ),
                 );
+            let sg_2v1_node_5v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(1v1)",
                 0,
@@ -257,15 +266,6 @@ fn main() {
                     check_pivot_run(op_2v1, op_3v1);
                 },
             );
-            let sg_2v1_node_5v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(2v1)",
                 0,

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__expr_predicate@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__expr_predicate@datalog_program.snap
@@ -56,6 +56,15 @@ fn main() {
                         >::default(),
                     ),
                 );
+            let sg_1v1_node_5v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(2v1)",
                 0,
@@ -356,15 +365,6 @@ fn main() {
                     check_pivot_run(op_2v1, op_3v1);
                 },
             );
-            let sg_1v1_node_5v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(1v1)",
                 0,

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__index@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__index@datalog_program.snap
@@ -91,6 +91,109 @@ fn main() {
                         hydroflow::util::monotonic_map::MonotonicMap::new_init(0..),
                     ),
                 );
+            let sg_4v1_node_37v1_groupbydata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::rustc_hash::FxHashMap::<(_,), (Option<_>,)>::default(),
+                    ),
+                );
+            let sg_4v1_node_38v1_counterdata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::new_init(0..),
+                    ),
+                );
+            let sg_4v1_node_8v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_5v1_node_22v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_5v1_node_23v1_antijoindata_neg = df
+                .add_state(
+                    std::cell::RefCell::new(hydroflow::rustc_hash::FxHashSet::default()),
+                );
+            let sg_5v1_node_23v1_antijoindata_pos = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_5v1_node_11v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_5v1_node_45v1_persistdata = df
+                .add_state(::std::cell::RefCell::new(::std::vec::Vec::new()));
+            let sg_5v1_node_43v1_counterdata = df
+                .add_state(::std::cell::RefCell::new(0..));
+            let sg_6v1_node_47v1_groupbydata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::rustc_hash::FxHashMap::<(_,), (Option<_>,)>::default(),
+                    ),
+                );
+            let sg_6v1_node_48v1_counterdata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::new_init(0..),
+                    ),
+                );
+            let sg_6v1_node_14v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_7v1_node_51v1_counterdata = df
+                .add_state(::std::cell::RefCell::new(0..));
+            let sg_7v1_node_17v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_7v1_node_18v1_antijoindata_neg = df
+                .add_state(
+                    std::cell::RefCell::new(hydroflow::rustc_hash::FxHashSet::default()),
+                );
+            let sg_7v1_node_18v1_antijoindata_pos = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_7v1_node_31v1_persistdata = df
+                .add_state(::std::cell::RefCell::new(::std::vec::Vec::new()));
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(3v1)",
                 0,
@@ -623,27 +726,6 @@ fn main() {
                     check_pivot_run(op_25v1, hoff_9v3_send);
                 },
             );
-            let sg_4v1_node_37v1_groupbydata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::rustc_hash::FxHashMap::<(_,), (Option<_>,)>::default(),
-                    ),
-                );
-            let sg_4v1_node_38v1_counterdata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::new_init(0..),
-                    ),
-                );
-            let sg_4v1_node_8v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(4v1)",
                 1,
@@ -911,41 +993,6 @@ fn main() {
                     check_pivot_run(op_8v1, op_28v1);
                 },
             );
-            let sg_5v1_node_22v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_5v1_node_23v1_antijoindata_neg = df
-                .add_state(
-                    std::cell::RefCell::new(hydroflow::rustc_hash::FxHashSet::default()),
-                );
-            let sg_5v1_node_23v1_antijoindata_pos = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_5v1_node_11v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_5v1_node_45v1_persistdata = df
-                .add_state(::std::cell::RefCell::new(::std::vec::Vec::new()));
-            let sg_5v1_node_43v1_counterdata = df
-                .add_state(::std::cell::RefCell::new(0..));
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(5v1)",
                 1,
@@ -1489,27 +1536,6 @@ fn main() {
                     context.schedule_subgraph(context.current_subgraph(), false);
                 },
             );
-            let sg_6v1_node_47v1_groupbydata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::rustc_hash::FxHashMap::<(_,), (Option<_>,)>::default(),
-                    ),
-                );
-            let sg_6v1_node_48v1_counterdata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::new_init(0..),
-                    ),
-                );
-            let sg_6v1_node_14v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(6v1)",
                 2,
@@ -1787,32 +1813,6 @@ fn main() {
                     context.schedule_subgraph(context.current_subgraph(), false);
                 },
             );
-            let sg_7v1_node_51v1_counterdata = df
-                .add_state(::std::cell::RefCell::new(0..));
-            let sg_7v1_node_17v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_7v1_node_18v1_antijoindata_neg = df
-                .add_state(
-                    std::cell::RefCell::new(hydroflow::rustc_hash::FxHashSet::default()),
-                );
-            let sg_7v1_node_18v1_antijoindata_pos = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_7v1_node_31v1_persistdata = df
-                .add_state(::std::cell::RefCell::new(::std::vec::Vec::new()));
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(7v1)",
                 1,

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__join_with_self@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__join_with_self@datalog_program.snap
@@ -46,6 +46,31 @@ fn main() {
                         >::default(),
                     ),
                 );
+            let sg_2v1_node_9v1_joindata_lhs = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
+                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
+                        ),
+                    ),
+                );
+            let sg_2v1_node_9v1_joindata_rhs = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
+                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
+                        ),
+                    ),
+                );
+            let sg_2v1_node_5v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(1v1)",
                 0,
@@ -195,31 +220,6 @@ fn main() {
                     check_pivot_run(op_2v1, op_3v1);
                 },
             );
-            let sg_2v1_node_9v1_joindata_lhs = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
-                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
-                        ),
-                    ),
-                );
-            let sg_2v1_node_9v1_joindata_rhs = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
-                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
-                        ),
-                    ),
-                );
-            let sg_2v1_node_5v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(2v1)",
                 0,

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__max@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__max@datalog_program.snap
@@ -41,6 +41,21 @@ fn main() {
                         >::default(),
                     ),
                 );
+            let sg_1v1_node_10v1_groupbydata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::rustc_hash::FxHashMap::<(_,), (Option<_>,)>::default(),
+                    ),
+                );
+            let sg_1v1_node_5v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(2v1)",
                 0,
@@ -184,21 +199,6 @@ fn main() {
                     check_pivot_run(op_9v1, hoff_6v3_send);
                 },
             );
-            let sg_1v1_node_10v1_groupbydata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::rustc_hash::FxHashMap::<(_,), (Option<_>,)>::default(),
-                    ),
-                );
-            let sg_1v1_node_5v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(1v1)",
                 1,

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__max_all@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__max_all@datalog_program.snap
@@ -41,6 +41,24 @@ fn main() {
                         >::default(),
                     ),
                 );
+            let sg_1v1_node_10v1_groupbydata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::rustc_hash::FxHashMap::<
+                            (),
+                            (Option<_>, Option<_>),
+                        >::default(),
+                    ),
+                );
+            let sg_1v1_node_5v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(2v1)",
                 0,
@@ -184,24 +202,6 @@ fn main() {
                     check_pivot_run(op_9v1, hoff_6v3_send);
                 },
             );
-            let sg_1v1_node_10v1_groupbydata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::rustc_hash::FxHashMap::<
-                            (),
-                            (Option<_>, Option<_>),
-                        >::default(),
-                    ),
-                );
-            let sg_1v1_node_5v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(1v1)",
                 1,

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist@datalog_program.snap
@@ -97,6 +97,208 @@ fn main() {
                 }
                 check_stream(ints1)
             };
+            let mut sg_10v1_node_35v1_stream = {
+                #[inline(always)]
+                fn check_stream<
+                    Stream: hydroflow::futures::stream::Stream<Item = Item>
+                        + ::std::marker::Unpin,
+                    Item,
+                >(
+                    stream: Stream,
+                ) -> impl hydroflow::futures::stream::Stream<
+                    Item = Item,
+                > + ::std::marker::Unpin {
+                    stream
+                }
+                check_stream(ints2)
+            };
+            let mut sg_11v1_node_36v1_stream = {
+                #[inline(always)]
+                fn check_stream<
+                    Stream: hydroflow::futures::stream::Stream<Item = Item>
+                        + ::std::marker::Unpin,
+                    Item,
+                >(
+                    stream: Stream,
+                ) -> impl hydroflow::futures::stream::Stream<
+                    Item = Item,
+                > + ::std::marker::Unpin {
+                    stream
+                }
+                check_stream(ints3)
+            };
+            let sg_4v1_node_12v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_4v1_node_41v1_joindata_lhs = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::compiled::pull::HalfMultisetJoinState::default(),
+                    ),
+                );
+            let sg_4v1_node_41v1_joindata_rhs = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::compiled::pull::HalfMultisetJoinState::default(),
+                    ),
+                );
+            let sg_4v1_node_45v1_joindata_lhs = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::compiled::pull::HalfMultisetJoinState::default(),
+                    ),
+                );
+            let sg_4v1_node_45v1_joindata_rhs = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
+                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
+                        ),
+                    ),
+                );
+            let sg_4v1_node_15v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_5v1_node_53v1_persistdata = df
+                .add_state(::std::cell::RefCell::new(::std::vec::Vec::new()));
+            let sg_5v1_node_51v1_antijoindata_neg = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_5v1_node_51v1_antijoindata_pos = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_5v1_node_18v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_6v1_node_2v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_6v1_node_3v1_antijoindata_neg = df
+                .add_state(
+                    std::cell::RefCell::new(hydroflow::rustc_hash::FxHashSet::default()),
+                );
+            let sg_6v1_node_3v1_antijoindata_pos = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_6v1_node_21v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_6v1_node_27v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_6v1_node_61v1_persistdata = df
+                .add_state(::std::cell::RefCell::new(::std::vec::Vec::new()));
+            let sg_7v1_node_30v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_7v1_node_31v1_antijoindata_neg = df
+                .add_state(
+                    std::cell::RefCell::new(hydroflow::rustc_hash::FxHashSet::default()),
+                );
+            let sg_7v1_node_31v1_antijoindata_pos = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_7v1_node_24v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_7v1_node_68v1_persistdata = df
+                .add_state(::std::cell::RefCell::new(::std::vec::Vec::new()));
+            let sg_8v1_node_7v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_8v1_node_8v1_antijoindata_neg = df
+                .add_state(
+                    std::cell::RefCell::new(hydroflow::rustc_hash::FxHashSet::default()),
+                );
+            let sg_8v1_node_8v1_antijoindata_pos = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_8v1_node_55v1_persistdata = df
+                .add_state(::std::cell::RefCell::new(::std::vec::Vec::new()));
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(9v1)",
                 0,
@@ -160,21 +362,6 @@ fn main() {
                     check_pivot_run(op_34v1, hoff_14v3_send);
                 },
             );
-            let mut sg_10v1_node_35v1_stream = {
-                #[inline(always)]
-                fn check_stream<
-                    Stream: hydroflow::futures::stream::Stream<Item = Item>
-                        + ::std::marker::Unpin,
-                    Item,
-                >(
-                    stream: Stream,
-                ) -> impl hydroflow::futures::stream::Stream<
-                    Item = Item,
-                > + ::std::marker::Unpin {
-                    stream
-                }
-                check_stream(ints2)
-            };
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(10v1)",
                 0,
@@ -238,21 +425,6 @@ fn main() {
                     check_pivot_run(op_35v1, hoff_11v3_send);
                 },
             );
-            let mut sg_11v1_node_36v1_stream = {
-                #[inline(always)]
-                fn check_stream<
-                    Stream: hydroflow::futures::stream::Stream<Item = Item>
-                        + ::std::marker::Unpin,
-                    Item,
-                >(
-                    stream: Stream,
-                ) -> impl hydroflow::futures::stream::Stream<
-                    Item = Item,
-                > + ::std::marker::Unpin {
-                    stream
-                }
-                check_stream(ints3)
-            };
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(11v1)",
                 0,
@@ -508,50 +680,6 @@ fn main() {
                     check_pivot_run(op_33v1, hoff_16v3_send);
                 },
             );
-            let sg_4v1_node_12v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_4v1_node_41v1_joindata_lhs = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::compiled::pull::HalfMultisetJoinState::default(),
-                    ),
-                );
-            let sg_4v1_node_41v1_joindata_rhs = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::compiled::pull::HalfMultisetJoinState::default(),
-                    ),
-                );
-            let sg_4v1_node_45v1_joindata_lhs = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::compiled::pull::HalfMultisetJoinState::default(),
-                    ),
-                );
-            let sg_4v1_node_45v1_joindata_rhs = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
-                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
-                        ),
-                    ),
-                );
-            let sg_4v1_node_15v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(4v1)",
                 1,
@@ -1124,35 +1252,6 @@ fn main() {
                     context.schedule_subgraph(context.current_subgraph(), false);
                 },
             );
-            let sg_5v1_node_53v1_persistdata = df
-                .add_state(::std::cell::RefCell::new(::std::vec::Vec::new()));
-            let sg_5v1_node_51v1_antijoindata_neg = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_5v1_node_51v1_antijoindata_pos = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_5v1_node_18v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(5v1)",
                 2,
@@ -1499,48 +1598,6 @@ fn main() {
                     context.schedule_subgraph(context.current_subgraph(), false);
                 },
             );
-            let sg_6v1_node_2v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_6v1_node_3v1_antijoindata_neg = df
-                .add_state(
-                    std::cell::RefCell::new(hydroflow::rustc_hash::FxHashSet::default()),
-                );
-            let sg_6v1_node_3v1_antijoindata_pos = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_6v1_node_21v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_6v1_node_27v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_6v1_node_61v1_persistdata = df
-                .add_state(::std::cell::RefCell::new(::std::vec::Vec::new()));
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(6v1)",
                 1,
@@ -2110,39 +2167,6 @@ fn main() {
                     context.schedule_subgraph(context.current_subgraph(), false);
                 },
             );
-            let sg_7v1_node_30v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_7v1_node_31v1_antijoindata_neg = df
-                .add_state(
-                    std::cell::RefCell::new(hydroflow::rustc_hash::FxHashSet::default()),
-                );
-            let sg_7v1_node_31v1_antijoindata_pos = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_7v1_node_24v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_7v1_node_68v1_persistdata = df
-                .add_state(::std::cell::RefCell::new(::std::vec::Vec::new()));
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(7v1)",
                 1,
@@ -2569,30 +2593,6 @@ fn main() {
                     context.schedule_subgraph(context.current_subgraph(), false);
                 },
             );
-            let sg_8v1_node_7v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_8v1_node_8v1_antijoindata_neg = df
-                .add_state(
-                    std::cell::RefCell::new(hydroflow::rustc_hash::FxHashSet::default()),
-                );
-            let sg_8v1_node_8v1_antijoindata_pos = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_8v1_node_55v1_persistdata = df
-                .add_state(::std::cell::RefCell::new(::std::vec::Vec::new()));
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(8v1)",
                 1,

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist_uniqueness@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist_uniqueness@datalog_program.snap
@@ -47,6 +47,52 @@ fn main() {
                 }
                 check_stream(ints2)
             };
+            let sg_2v1_node_17v1_groupbydata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::rustc_hash::FxHashMap::<(), (Option<_>,)>::default(),
+                    ),
+                );
+            let sg_2v1_node_10v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_3v1_node_7v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_3v1_node_2v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_3v1_node_3v1_antijoindata_neg = df
+                .add_state(
+                    std::cell::RefCell::new(hydroflow::rustc_hash::FxHashSet::default()),
+                );
+            let sg_3v1_node_3v1_antijoindata_pos = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(4v1)",
                 0,
@@ -174,21 +220,6 @@ fn main() {
                     check_pivot_run(op_5v1, hoff_11v3_send);
                 },
             );
-            let sg_2v1_node_17v1_groupbydata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::rustc_hash::FxHashMap::<(), (Option<_>,)>::default(),
-                    ),
-                );
-            let sg_2v1_node_10v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(2v1)",
                 2,
@@ -420,37 +451,6 @@ fn main() {
                     context.schedule_subgraph(context.current_subgraph(), false);
                 },
             );
-            let sg_3v1_node_7v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_3v1_node_2v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_3v1_node_3v1_antijoindata_neg = df
-                .add_state(
-                    std::cell::RefCell::new(hydroflow::rustc_hash::FxHashSet::default()),
-                );
-            let sg_3v1_node_3v1_antijoindata_pos = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(3v1)",
                 1,

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__send_to_node@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__send_to_node@datalog_program.snap
@@ -36,6 +36,39 @@ fn main() {
                         >::default(),
                     ),
                 );
+            let mut sg_2v1_node_7v1_stream = {
+                #[inline(always)]
+                fn check_stream<
+                    Stream: hydroflow::futures::stream::Stream<Item = Item>
+                        + ::std::marker::Unpin,
+                    Item,
+                >(
+                    stream: Stream,
+                ) -> impl hydroflow::futures::stream::Stream<
+                    Item = Item,
+                > + ::std::marker::Unpin {
+                    stream
+                }
+                check_stream(ints)
+            };
+            let sg_2v1_node_2v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_2v1_node_10v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(1v1)",
                 0,
@@ -174,39 +207,6 @@ fn main() {
                     check_pivot_run(op_5v1, op_8v1);
                 },
             );
-            let mut sg_2v1_node_7v1_stream = {
-                #[inline(always)]
-                fn check_stream<
-                    Stream: hydroflow::futures::stream::Stream<Item = Item>
-                        + ::std::marker::Unpin,
-                    Item,
-                >(
-                    stream: Stream,
-                ) -> impl hydroflow::futures::stream::Stream<
-                    Item = Item,
-                > + ::std::marker::Unpin {
-                    stream
-                }
-                check_stream(ints)
-            };
-            let sg_2v1_node_2v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
-            let sg_2v1_node_10v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(2v1)",
                 0,

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__wildcard_fields@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__wildcard_fields@datalog_program.snap
@@ -46,6 +46,31 @@ fn main() {
                         >::default(),
                     ),
                 );
+            let sg_2v1_node_9v1_joindata_lhs = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
+                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
+                        ),
+                    ),
+                );
+            let sg_2v1_node_9v1_joindata_rhs = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
+                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
+                        ),
+                    ),
+                );
+            let sg_2v1_node_5v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(1v1)",
                 0,
@@ -195,31 +220,6 @@ fn main() {
                     check_pivot_run(op_2v1, op_3v1);
                 },
             );
-            let sg_2v1_node_9v1_joindata_lhs = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
-                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
-                        ),
-                    ),
-                );
-            let sg_2v1_node_9v1_joindata_rhs = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
-                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
-                        ),
-                    ),
-                );
-            let sg_2v1_node_5v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(2v1)",
                 0,

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__wildcard_join_count@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__wildcard_join_count@datalog_program.snap
@@ -66,6 +66,92 @@ fn main() {
                         >::default(),
                     ),
                 );
+            let mut sg_2v1_node_14v1_stream = {
+                #[inline(always)]
+                fn check_stream<
+                    Stream: hydroflow::futures::stream::Stream<Item = Item>
+                        + ::std::marker::Unpin,
+                    Item,
+                >(
+                    stream: Stream,
+                ) -> impl hydroflow::futures::stream::Stream<
+                    Item = Item,
+                > + ::std::marker::Unpin {
+                    stream
+                }
+                check_stream(ints2)
+            };
+            let sg_2v1_node_5v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_3v1_node_22v1_groupbydata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::rustc_hash::FxHashMap::<(), (Option<_>,)>::default(),
+                    ),
+                );
+            let sg_3v1_node_8v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_4v1_node_29v1_groupbydata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::rustc_hash::FxHashMap::<(), (Option<_>,)>::default(),
+                    ),
+                );
+            let sg_4v1_node_11v1_uniquedata = df
+                .add_state(
+                    ::std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::<
+                            _,
+                            hydroflow::rustc_hash::FxHashSet<_>,
+                        >::default(),
+                    ),
+                );
+            let sg_5v1_node_17v1_joindata_lhs = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
+                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
+                        ),
+                    ),
+                );
+            let sg_5v1_node_17v1_joindata_rhs = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
+                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
+                        ),
+                    ),
+                );
+            let sg_6v1_node_24v1_joindata_lhs = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
+                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
+                        ),
+                    ),
+                );
+            let sg_6v1_node_24v1_joindata_rhs = df
+                .add_state(
+                    std::cell::RefCell::new(
+                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
+                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
+                        ),
+                    ),
+                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(1v1)",
                 0,
@@ -215,30 +301,6 @@ fn main() {
                     check_pivot_run(op_2v1, op_3v1);
                 },
             );
-            let mut sg_2v1_node_14v1_stream = {
-                #[inline(always)]
-                fn check_stream<
-                    Stream: hydroflow::futures::stream::Stream<Item = Item>
-                        + ::std::marker::Unpin,
-                    Item,
-                >(
-                    stream: Stream,
-                ) -> impl hydroflow::futures::stream::Stream<
-                    Item = Item,
-                > + ::std::marker::Unpin {
-                    stream
-                }
-                check_stream(ints2)
-            };
-            let sg_2v1_node_5v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(2v1)",
                 0,
@@ -388,21 +450,6 @@ fn main() {
                     check_pivot_run(op_5v1, op_6v1);
                 },
             );
-            let sg_3v1_node_22v1_groupbydata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::rustc_hash::FxHashMap::<(), (Option<_>,)>::default(),
-                    ),
-                );
-            let sg_3v1_node_8v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(3v1)",
                 1,
@@ -610,21 +657,6 @@ fn main() {
                     check_pivot_run(op_8v1, op_15v1);
                 },
             );
-            let sg_4v1_node_29v1_groupbydata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::rustc_hash::FxHashMap::<(), (Option<_>,)>::default(),
-                    ),
-                );
-            let sg_4v1_node_11v1_uniquedata = df
-                .add_state(
-                    ::std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::<
-                            _,
-                            hydroflow::rustc_hash::FxHashSet<_>,
-                        >::default(),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(4v1)",
                 1,
@@ -846,22 +878,6 @@ fn main() {
                     check_pivot_run(op_11v1, op_16v1);
                 },
             );
-            let sg_5v1_node_17v1_joindata_lhs = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
-                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
-                        ),
-                    ),
-                );
-            let sg_5v1_node_17v1_joindata_rhs = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
-                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
-                        ),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(5v1)",
                 0,
@@ -1101,22 +1117,6 @@ fn main() {
                     check_pivot_run(op_21v1, hoff_10v3_send);
                 },
             );
-            let sg_6v1_node_24v1_joindata_lhs = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
-                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
-                        ),
-                    ),
-                );
-            let sg_6v1_node_24v1_joindata_rhs = df
-                .add_state(
-                    std::cell::RefCell::new(
-                        hydroflow::util::monotonic_map::MonotonicMap::new_init(
-                            hydroflow::compiled::pull::HalfMultisetJoinState::default(),
-                        ),
-                    ),
-                );
             df.add_subgraph_stratified(
                 "Subgraph GraphSubgraphId(6v1)",
                 0,


### PR DESCRIPTION
Before, prologue code would be emitted before its subgraph, resulting in interleaving between subgraphs.