### PR TITLE
feat: make StateHandle's Id public

### DIFF
--- a/hydroflow/src/scheduled/state.rs
+++ b/hydroflow/src/scheduled/state.rs
@@ -9,7 +9,9 @@ use super::StateId;
 #[must_use]
 #[derive(Debug)]
 pub struct StateHandle<T> {
-    pub(crate) state_id: StateId,
+    /// A staten handle's ID. Invalid if used in a different [`graph::Hydroflow`]
+    /// instance than the original that created it.
+    pub state_id: StateId,
     pub(crate) _phantom: PhantomData<*mut T>,
 }
 impl<T> Copy for StateHandle<T> {}

--- a/hydroflow/src/scheduled/state.rs
+++ b/hydroflow/src/scheduled/state.rs
@@ -9,7 +9,7 @@ use super::StateId;
 #[must_use]
 #[derive(Debug)]
 pub struct StateHandle<T> {
-    /// A staten handle's ID. Invalid if used in a different [`graph::Hydroflow`]
+    /// A staten handle's ID. Invalid if used in a different [`Hydroflow`](super::graph::Hydroflow)
     /// instance than the original that created it.
     pub state_id: StateId,
     pub(crate) _phantom: PhantomData<*mut T>,

--- a/hydroflow/src/scheduled/state.rs
+++ b/hydroflow/src/scheduled/state.rs
@@ -9,14 +9,19 @@ use super::StateId;
 #[must_use]
 #[derive(Debug)]
 pub struct StateHandle<T> {
-    /// A staten handle's ID. Invalid if used in a different [`Hydroflow`](super::graph::Hydroflow)
-    /// instance than the original that created it.
-    pub state_id: StateId,
+    pub(crate) state_id: StateId,
     pub(crate) _phantom: PhantomData<*mut T>,
 }
 impl<T> Copy for StateHandle<T> {}
 impl<T> Clone for StateHandle<T> {
     fn clone(&self) -> Self {
         *self
+    }
+}
+
+impl<T> StateHandle<T> {
+    /// Returns the [`StateId`] of this handle.
+    pub fn state_id(&self) -> StateId {
+        self.state_id
     }
 }


### PR DESCRIPTION
make StateHandle's Id public, so one can link state with subgraph by using something like `BTreeMap<SubgraphId, BTreeSet<StateId>>`