### PR TITLE
docs: Fix undeclared quickstart variable

### DIFF
--- a/docs/docs/hydroflow_plus/quickstart/clusters.mdx
+++ b/docs/docs/hydroflow_plus/quickstart/clusters.mdx
@@ -89,6 +89,7 @@ use hydroflow_plus_cli_integration::{DeployProcessSpec, DeployClusterSpec};
 async fn main() {
     let deployment = RefCell::new(Deployment::new());
     let localhost = deployment.borrow_mut().Localhost();
+    let profile = "dev";
 
     let builder = hydroflow_plus::FlowBuilder::new();
     flow::broadcast::broadcast(

--- a/docs/docs/hydroflow_plus/quickstart/structure.mdx
+++ b/docs/docs/hydroflow_plus/quickstart/structure.mdx
@@ -36,7 +36,7 @@ pub fn first_ten<'a, D: LocalDeploy<'a>>(
 ) {}
 ```
 
-To build a Hydroflow+ application, we need to define dataflow that spans multiple processes. The `FlowBuilder` parameter captures the global dataflow, while the `process_spec` variable defines how to construct the processes where the dataflow will be executed. For now, we will only use the `ProcessSpec` once, to add a single process to our global dataflow.
+To build a Hydroflow+ application, we need to define a dataflow that spans multiple processes. The `FlowBuilder` parameter captures the global dataflow, while the `process_spec` variable defines how to construct the processes where the dataflow will be executed. For now, we will only use the `ProcessSpec` once, to add a single process to our global dataflow.
 
 ```rust
 pub fn first_ten<'a, D: LocalDeploy<'a>>(


### PR DESCRIPTION
* Fixes undeclared variable in one of the quickstart code snippets. With this change all snippets work for me.
* Minor copyedit in the structure section.