### PR TITLE
feat: tee port for scheduled API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__/
 perf.data
 perf.data.old
 flamegraph.svg
+
+/rustc-ice-*.txt

--- a/benches/build.rs
+++ b/benches/build.rs
@@ -4,7 +4,13 @@ use std::path::PathBuf;
 
 const NUM_OPS: usize = 20;
 
-pub fn main() -> std::io::Result<()> {
+pub fn main() {
+    if let Err(err) = fork_join() {
+        eprintln!("benches/build.rs error: {:?}", err);
+    }
+}
+
+pub fn fork_join() -> std::io::Result<()> {
     let path = PathBuf::from_iter([
         env!("CARGO_MANIFEST_DIR"),
         "benches",

--- a/hydroflow/src/scheduled/graph.rs
+++ b/hydroflow/src/scheduled/graph.rs
@@ -3,7 +3,7 @@
 use std::any::Any;
 use std::borrow::Cow;
 use std::cell::Cell;
-use std::collections::VecDeque;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::future::Future;
 use std::marker::PhantomData;
 
@@ -29,6 +29,11 @@ pub struct Hydroflow<'a> {
     pub(super) subgraphs: Vec<SubgraphData<'a>>,
     pub(super) context: Context,
     handoffs: Vec<HandoffData>,
+    /// The root handoff of a handoff that's tee'd.
+    /// child -> root
+    handoff_root: BTreeMap<HandoffId, HandoffId>,
+    /// The set of child handoffs of a root tee handoff
+    handoff_tee_childs: BTreeMap<HandoffId, BTreeSet<HandoffId>>,
 
     /// TODO(mingwei): separate scheduler into its own struct/trait?
     /// Index is stratum, value is FIFO queue for that stratum.
@@ -69,6 +74,8 @@ impl<'a> Default for Hydroflow<'a> {
             subgraphs: Vec::new(),
             context,
             handoffs: Vec::new(),
+            handoff_root: BTreeMap::new(),
+            handoff_tee_childs: BTreeMap::new(),
 
             stratum_queues,
             event_queue_recv,
@@ -78,6 +85,41 @@ impl<'a> Default for Hydroflow<'a> {
             meta_graph: None,
             diagnostics: None,
         }
+    }
+}
+impl<'a> Hydroflow<'a> {
+    /// Adds a handoff that's teed from a old handoff `root` to the graph.
+    pub(crate) fn add_tee_handoff<Name: Into<Cow<'static, str>>>(
+        &mut self,
+        name: Name,
+        mut root: HandoffId,
+        handoff: impl HandoffMeta + 'static,
+    ) -> HandoffId {
+        let handoff_id = HandoffId(self.handoffs.len());
+        let old_root = root;
+        while let Some(prev) = self.handoff_root.get(&root) {
+            if prev == &root {
+                break;
+            }
+            root = *prev;
+        }
+        // compress the path. so cases like 0 -tee-> 1, 1 -tee->2, will allow
+        // 2  to correctly know root being 0
+        self.handoff_root.insert(old_root, root);
+        // insert handoff's root id.
+        self.handoff_root.insert(handoff_id, root);
+        self.handoff_tee_childs
+            .entry(root)
+            .or_default()
+            .insert(handoff_id);
+
+        // insert handoff.
+        self.handoffs.push(HandoffData::new(name.into(), handoff));
+        handoff_id
+    }
+    /// Get the handoff data by ID.
+    pub(crate) fn get_handoff_by_id(&self, id: HandoffId) -> &HandoffData {
+        &self.handoffs[id.0]
     }
 }
 impl<'a> Hydroflow<'a> {
@@ -216,11 +258,18 @@ impl<'a> Hydroflow<'a> {
             }
 
             let sg_data = &self.subgraphs[sg_id.0];
-
             for &handoff_id in sg_data.succs.iter() {
                 let handoff = &self.handoffs[handoff_id.0];
                 if !handoff.handoff.is_bottom() {
-                    for &succ_id in handoff.succs.iter() {
+                    // find out all child handoff spawn from teeing(if any)
+                    let mut all_succs = vec![handoff.succs.iter()];
+                    if let Some(childs) = self.handoff_tee_childs.get(&handoff_id) {
+                        for ch in childs.iter() {
+                            all_succs.push(self.handoffs[ch.0].succs.iter());
+                        }
+                    }
+
+                    for &succ_id in all_succs.iter().flat_map(|it| it.clone()) {
                         let succ_sg_data = &self.subgraphs[succ_id.0];
                         // If we have sent data to the next tick, then we can start the next tick.
                         if succ_sg_data.stratum < self.context.current_stratum && !sg_data.is_lazy {
@@ -482,6 +531,18 @@ impl<'a> Hydroflow<'a> {
         // Enqueue any other immediate events.
         let extra_count = self.try_recv_events();
         Some(count + extra_count)
+    }
+
+    /// Schedules a subgraph to be run. See also: [`Context::schedule_subgraph`].
+    pub fn schedule_subgraph(&mut self, sg_id: SubgraphId) -> bool {
+        let sg_data = &self.subgraphs[sg_id.0];
+        let already_scheduled = sg_data.is_scheduled.replace(true);
+        if !already_scheduled {
+            self.stratum_queues[sg_data.stratum].push_back(sg_id);
+            true
+        } else {
+            false
+        }
     }
 
     /// Adds a new compiled subgraph with the specified inputs and outputs in stratum 0.

--- a/hydroflow/src/scheduled/handoff/tee.rs
+++ b/hydroflow/src/scheduled/handoff/tee.rs
@@ -51,8 +51,9 @@ impl<T> TeeingHandoff<T>
 where
     T: Clone,
 {
+    /// Tee the internal shared datastructure to create a new tee output.
     #[must_use]
-    pub fn tee(&self) -> Self {
+    pub(crate) fn tee(&self) -> Self {
         let id = (*self.internal).borrow().readers.len();
         (*self.internal)
             .borrow_mut()
@@ -64,8 +65,8 @@ where
         }
     }
 
-    /// mark this teeing handoff as dead, so no more data will be written to it.
-    pub(crate) fn mark_as_dead(&self) {
+    /// Mark this particular teeing handoff output as dead, so no more data will be written to it.
+    pub(crate) fn drop(&self) {
         self.internal.borrow_mut().readers[self.read_from].0 = false;
     }
 }

--- a/hydroflow/src/scheduled/handoff/tee.rs
+++ b/hydroflow/src/scheduled/handoff/tee.rs
@@ -76,13 +76,13 @@ impl<T> HandoffMeta for TeeingHandoff<T> {
         self
     }
 
-    /// if all reader's content is empty, return true
+    /// If this output's buffer is empty, return true.
     fn is_bottom(&self) -> bool {
-        self.internal
-            .borrow()
-            .readers
+        self.internal.borrow().readers[self.read_from]
+            .1
+            .contents
             .iter()
-            .all(|r| r.1.contents.is_empty())
+            .all(Vec::is_empty)
     }
 }
 

--- a/hydroflow/src/scheduled/mod.rs
+++ b/hydroflow/src/scheduled/mod.rs
@@ -32,7 +32,7 @@ impl Display for SubgraphId {
 
 /// A handoff's ID. Invalid if used in a different [`graph::Hydroflow`]
 /// instance than the original that created it.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[repr(transparent)]
 pub struct HandoffId(pub(crate) usize);
 impl Display for HandoffId {

--- a/hydroflow/src/scheduled/port.rs
+++ b/hydroflow/src/scheduled/port.rs
@@ -64,6 +64,17 @@ impl<T: Clone> RecvPort<TeeingHandoff<T>> {
         };
         output_port
     }
+
+    /// Mark this teeing recv port as dead, so no more data will be written to it.
+    pub fn drop(self, df: &mut Hydroflow) {
+        let data = df.get_handoff_by_id(self.handoff_id);
+        let typed_handoff = data
+            .handoff
+            .any_ref()
+            .downcast_ref::<TeeingHandoff<T>>()
+            .unwrap();
+        typed_handoff.mark_as_dead();
+    }
 }
 
 /// Wrapper around a handoff to differentiate between output and input.

--- a/hydroflow/src/scheduled/port.rs
+++ b/hydroflow/src/scheduled/port.rs
@@ -51,11 +51,13 @@ impl<T: Clone> RecvPort<TeeingHandoff<T>> {
     pub fn tee(&self, df: &mut Hydroflow) -> RecvPort<TeeingHandoff<T>> {
         let data = df.get_handoff_by_id(self.handoff_id);
         let name = data.name.clone();
+
         let typed_handoff = data
             .handoff
             .any_ref()
             .downcast_ref::<TeeingHandoff<T>>()
             .unwrap();
+
         let new_handoff = typed_handoff.tee();
         let new_handoff_id = df.add_tee_handoff(name, self.handoff_id, new_handoff);
         let output_port = RecvPort {

--- a/hydroflow/src/scheduled/port.rs
+++ b/hydroflow/src/scheduled/port.rs
@@ -6,7 +6,8 @@ use ref_cast::RefCast;
 use sealed::sealed;
 
 use super::HandoffId;
-use crate::scheduled::handoff::{CanReceive, Handoff, TryCanReceive};
+use crate::scheduled::graph::Hydroflow;
+use crate::scheduled::handoff::{CanReceive, Handoff, TeeingHandoff, TryCanReceive};
 
 /// An empty trait used to denote [`Polarity`]: either **send** or **receive**.
 ///
@@ -30,7 +31,7 @@ impl Polarity for SEND {}
 impl Polarity for RECV {}
 
 /// Lightweight ID struct representing an input or output port for a [`Handoff`] added to a
-/// [`Hydroflow`](super::graph::Hydroflow) instance..
+/// [`Hydroflow`] instance..
 #[must_use]
 pub struct Port<S: Polarity, H>
 where
@@ -44,6 +45,26 @@ where
 pub type SendPort<H> = Port<SEND, H>;
 /// Recv-specific variant of [`Port`]. An input port.
 pub type RecvPort<H> = Port<RECV, H>;
+
+impl<T: Clone> RecvPort<TeeingHandoff<T>> {
+    /// Clone a tee recv port, See [`TeeingHandoff::tee`] for more information.
+    pub fn tee(&self, df: &mut Hydroflow) -> RecvPort<TeeingHandoff<T>> {
+        let data = df.get_handoff_by_id(self.handoff_id);
+        let name = data.name.clone();
+        let typed_handoff = data
+            .handoff
+            .any_ref()
+            .downcast_ref::<TeeingHandoff<T>>()
+            .unwrap();
+        let new_handoff = typed_handoff.tee();
+        let new_handoff_id = df.add_tee_handoff(name, self.handoff_id, new_handoff);
+        let output_port = RecvPort {
+            handoff_id: new_handoff_id,
+            _marker: PhantomData,
+        };
+        output_port
+    }
+}
 
 /// Wrapper around a handoff to differentiate between output and input.
 #[derive(RefCast)]

--- a/hydroflow/tests/scheduled_teeing_handoff.rs
+++ b/hydroflow/tests/scheduled_teeing_handoff.rs
@@ -1,0 +1,105 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use hydroflow::scheduled::graph::Hydroflow;
+use hydroflow::scheduled::graph_ext::GraphExt;
+use hydroflow::scheduled::handoff::TeeingHandoff;
+use multiplatform_test::multiplatform_test;
+
+#[multiplatform_test]
+fn test_basic() {
+    let mut df = Hydroflow::new();
+    let mut data = vec![1, 2, 3, 4];
+    let (source, sink1) = df.make_edge::<_, TeeingHandoff<i32>>("ok");
+    let sink2 = sink1.tee(&mut df);
+    let sink3 = sink2.tee(&mut df);
+
+    df.add_subgraph_source("source", source, move |_context, send| {
+        send.give(std::mem::take(&mut data));
+    });
+    let out1 = Rc::new(RefCell::new(Vec::new()));
+    let out1_inner = out1.clone();
+
+    df.add_subgraph_sink("sink1", sink1, move |_context, recv| {
+        for v in recv.take_inner() {
+            out1_inner.borrow_mut().extend(v);
+        }
+    });
+
+    let out2 = Rc::new(RefCell::new(Vec::new()));
+    let out2_inner = out2.clone();
+    df.add_subgraph_sink("sink2", sink2, move |_context, recv| {
+        for v in recv.take_inner() {
+            out2_inner.borrow_mut().extend(v);
+        }
+    });
+
+    let out3 = Rc::new(RefCell::new(Vec::new()));
+    let out3_inner = out3.clone();
+    df.add_subgraph_sink("sink2", sink3, move |_context, recv| {
+        for v in recv.take_inner() {
+            out3_inner.borrow_mut().extend(v);
+        }
+    });
+    df.run_available();
+    assert_eq!((*out1).borrow().clone(), vec![1, 2, 3, 4]);
+    assert_eq!((*out2).borrow().clone(), vec![1, 2, 3, 4]);
+    assert_eq!((*out3).borrow().clone(), vec![1, 2, 3, 4]);
+}
+
+#[multiplatform_test]
+fn test_scheduling() {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    let mut df = Hydroflow::new();
+    let input = Rc::new(RefCell::new(vec![1, 2, 3, 4]));
+    let input_recv = Rc::clone(&input);
+
+    let (source, sink1) = df.make_edge::<_, TeeingHandoff<i32>>("teeing-handoff");
+    let sink2 = sink1.tee(&mut df);
+    let sink3 = sink2.tee(&mut df);
+
+    let src_sg_id = df.add_subgraph_source("source", source, move |_context, send| {
+        let vec = std::mem::take(&mut *input_recv.borrow_mut());
+        println!("! {:?}", vec);
+        send.give(vec);
+    });
+    let out1 = Rc::new(RefCell::new(Vec::new()));
+    let out1_inner = out1.clone();
+
+    df.add_subgraph_sink("sink1", sink1, move |_context, recv| {
+        for v in recv.take_inner() {
+            out1_inner.borrow_mut().extend(v);
+        }
+    });
+
+    let out2 = Rc::new(RefCell::new(Vec::new()));
+    let out2_inner = out2.clone();
+    df.add_subgraph_sink("sink2", sink2, move |_context, recv| {
+        for v in recv.take_inner() {
+            out2_inner.borrow_mut().extend(v);
+        }
+    });
+
+    let out3 = Rc::new(RefCell::new(Vec::new()));
+    let out3_inner = out3.clone();
+    df.add_subgraph_sink("sink2", sink3, move |_context, recv| {
+        for v in recv.take_inner() {
+            out3_inner.borrow_mut().extend(v);
+        }
+    });
+
+    df.run_available();
+    assert_eq!(&*out1.borrow(), &[1, 2, 3, 4], "out1");
+    assert_eq!(&*out2.borrow(), &[1, 2, 3, 4], "out2");
+    assert_eq!(&*out3.borrow(), &[1, 2, 3, 4], "out3");
+
+    input.borrow_mut().extend(5..=8);
+    df.schedule_subgraph(src_sg_id);
+
+    df.run_available();
+    assert_eq!(&*out1.borrow(), &[1, 2, 3, 4, 5, 6, 7, 8], "out1");
+    assert_eq!(&*out2.borrow(), &[1, 2, 3, 4, 5, 6, 7, 8], "out2");
+    assert_eq!(&*out3.borrow(), &[1, 2, 3, 4, 5, 6, 7, 8], "out3");
+}

--- a/hydroflow/tests/scheduled_teeing_handoff.rs
+++ b/hydroflow/tests/scheduled_teeing_handoff.rs
@@ -13,10 +13,15 @@ fn test_basic() {
     let (source, sink1) = df.make_edge::<_, TeeingHandoff<i32>>("ok");
     let sink2 = sink1.tee(&mut df);
     let sink3 = sink2.tee(&mut df);
+    let sink4 = sink3.tee(&mut df);
+    let sink5 = sink4.tee(&mut df);
+    sink4.drop(&mut df);
 
     df.add_subgraph_source("source", source, move |_context, send| {
         send.give(std::mem::take(&mut data));
     });
+    sink5.drop(&mut df);
+
     let out1 = Rc::new(RefCell::new(Vec::new()));
     let out1_inner = out1.clone();
 
@@ -36,7 +41,7 @@ fn test_basic() {
 
     let out3 = Rc::new(RefCell::new(Vec::new()));
     let out3_inner = out3.clone();
-    df.add_subgraph_sink("sink2", sink3, move |_context, recv| {
+    df.add_subgraph_sink("sink3", sink3, move |_context, recv| {
         for v in recv.take_inner() {
             out3_inner.borrow_mut().extend(v);
         }

--- a/hydroflow/tests/scheduled_test.rs
+++ b/hydroflow/tests/scheduled_test.rs
@@ -12,9 +12,6 @@ use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]
 fn map_filter() {
-    use std::cell::RefCell;
-    use std::rc::Rc;
-
     use hydroflow::scheduled::handoff::VecHandoff;
 
     // A simple dataflow with one source feeding into one sink with some processing in the middle.
@@ -241,46 +238,6 @@ fn test_cycle() {
 
     assert_eq!(&*reachable_verts.borrow(), &[1, 2, 3, 4, 5]);
 }
-
-// #[test]
-// fn test_auto_tee() {
-//     use std::cell::RefCell;
-//     use std::rc::Rc;
-
-//     use crate::scheduled::handoff::TeeingHandoff;
-
-//     let mut df = Hydroflow::new();
-
-//     let mut data = vec![1, 2, 3, 4];
-//     let source = df.add_source(move |send: &SendCtx<TeeingHandoff<_>>| {
-//         send.give(std::mem::take(&mut data));
-//     });
-
-//     let out1 = Rc::new(RefCell::new(Vec::new()));
-//     let out1_inner = out1.clone();
-
-//     let sink1 = df.add_sink(move |recv: &RecvCtx<_>| {
-//         for v in recv.take_inner() {
-//             out1_inner.borrow_mut().extend(v);
-//         }
-//     });
-
-//     let out2 = Rc::new(RefCell::new(Vec::new()));
-//     let out2_inner = out2.clone();
-//     let sink2 = df.add_sink(move |recv: &RecvCtx<_>| {
-//         for v in recv.take_inner() {
-//             out2_inner.borrow_mut().extend(v);
-//         }
-//     });
-
-//     df.add_edge(source.clone(), sink1);
-//     df.add_edge(source, sink2);
-
-//     df.run_available();
-
-//     assert_eq!((*out1).borrow().clone(), vec![1, 2, 3, 4]);
-//     assert_eq!((*out2).borrow().clone(), vec![1, 2, 3, 4]);
-// }
 
 #[multiplatform_test]
 fn test_input_handle() {


### PR DESCRIPTION
- Add `tee()` method for `RecvPort<TeeingHandoff<T>>` so it can be cloned accordingly, I'm not sure if I made prec and succ fields right though.

- Added `add_handoff` and `get_handoff_by_id` for Hydroflow for a more detailed control of handoffs

- also added test `test_auto_tee` back. So `tee` method is tested.