### PR TITLE
docs: Few improvements to the quickstart guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ cargo generate gh:hydro-project/hydroflow-template
 and you will get a well-formed Hydroflow/Rust project to use as a starting point. It provides a simple Echo Server and Client, and advice
 for adapting it to other uses.
 
+### Enable Ligature Support In IDE
+Since flow edges `->` appear frequently in flows described using the Hydroflow surface syntax, enabling ligature support
+in your IDE may improve your code reading experience. This has no impact on code functionality or performance.
+
+Instructions to enable this for the `Fira Code` font:
+- [VSCode](https://github.com/tonsky/FiraCode/wiki/VS-Code-Instructions)
+- [IntelliJ](https://github.com/tonsky/FiraCode/wiki/IntelliJ-products-instructions)
+
+More font options are available [here](https://github.com/tonsky/FiraCode?tab=readme-ov-file#alternatives).
+
 ## Dev Setup
 
 See the [setup section of the book](https://hydro.run/docs/hydroflow/quickstart/setup).

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ cargo generate gh:hydro-project/hydroflow-template
 and you will get a well-formed Hydroflow/Rust project to use as a starting point. It provides a simple Echo Server and Client, and advice
 for adapting it to other uses.
 
-### Enable Ligature Support In IDE
+### Enable IDE Support for Ligatures
 Since flow edges `->` appear frequently in flows described using the Hydroflow surface syntax, enabling ligature support
 in your IDE may improve your code reading experience. This has no impact on code functionality or performance.
 

--- a/docs/docs/hydroflow/quickstart/example_1_simplest.mdx
+++ b/docs/docs/hydroflow/quickstart/example_1_simplest.mdx
@@ -47,7 +47,7 @@ Although this is a trivial program, it's useful to go through it line by line.
 <CodeBlock language="rust">{getLines(exampleCode, 1)}</CodeBlock>
 
 This import gives you everything you need from Hydroflow to write code with Hydroflow's
-[_surface syntax_](../syntax/index).
+[_surface syntax_](../syntax).
 
 Next, inside the main method we specify a flow by calling the
 `hydroflow_syntax!` macro. We assign the resulting `Hydroflow` instance to

--- a/docs/docs/hydroflow/quickstart/example_1_simplest.mdx
+++ b/docs/docs/hydroflow/quickstart/example_1_simplest.mdx
@@ -43,7 +43,9 @@ And then run the program:
 
 ## Understanding the Code
 Although this is a trivial program, it's useful to go through it line by line.
+
 <CodeBlock language="rust">{getLines(exampleCode, 1)}</CodeBlock>
+
 This import gives you everything you need from Hydroflow to write code with Hydroflow's
 [_surface syntax_](../syntax/index).
 

--- a/docs/docs/hydroflow/quickstart/example_2_simple.mdx
+++ b/docs/docs/hydroflow/quickstart/example_2_simple.mdx
@@ -64,7 +64,7 @@ Replace the contents of `src/main.rs` with the following:
 Here the `filter_map` operator takes a map closure that returns a Rust [`Option`](https://doc.rust-lang.org/std/option/enum.Option.html).
 If the value is `Some(...)`, it is passed to the output; if it is `None` it is filtered.
 
-The `flat_map` operator takes a map closure that generates a iterable type (in this case a `RangeInclusive`)
+The `flat_map` operator takes a map closure that generates an iterable type (in this case a `RangeInclusive`)
 which is flattened.
 
 Results:

--- a/docs/docs/hydroflow/quickstart/example_2_simple.mdx
+++ b/docs/docs/hydroflow/quickstart/example_2_simple.mdx
@@ -64,7 +64,7 @@ Replace the contents of `src/main.rs` with the following:
 Here the `filter_map` operator takes a map closure that returns a Rust [`Option`](https://doc.rust-lang.org/std/option/enum.Option.html).
 If the value is `Some(...)`, it is passed to the output; if it is `None` it is filtered.
 
-The `flat_map` operator takes a map closure that generates a collection type (in this case a `Vec`)
+The `flat_map` operator takes a map closure that generates a iterable type (in this case a `RangeInclusive`)
 which is flattened.
 
 Results:

--- a/docs/docs/hydroflow/quickstart/example_5_reachability.mdx
+++ b/docs/docs/hydroflow/quickstart/example_5_reachability.mdx
@@ -64,7 +64,7 @@ addition of the `reached_vertices` variable, which uses the [union()](../syntax/
 op to union the output of two operators into one.
 We route the `origin` vertex into it as one input right away:
 
-<CodeBlock language="rust">{getLines(exampleCode, 8, 12)}</CodeBlock>
+<CodeBlock language="rust">{getLines(exampleCode, 19, 19)}</CodeBlock>
 
 Note the square-bracket syntax for assigning index names to the multiple inputs to `union()`; this is similar
 to the indexes for `join()`, except that (a) union can have an arbitrary number of inputs, (b) the index names can be arbitrary strings, and (c) the indexes are optional can be omitted entirely. (By contrast, recall that

--- a/docs/docs/hydroflow/quickstart/example_5_reachability.mdx
+++ b/docs/docs/hydroflow/quickstart/example_5_reachability.mdx
@@ -81,7 +81,7 @@ Finally, we process the output of the `join` as passed through the `tee`.
 One branch pushes reached vertices back up into the `reached_vertices` variable (which begins with a `union`), while the other
 prints out all the reached vertices as in the simple program.
 
-<CodeBlock language="rust">{getLines(exampleCode, 14, 17)}</CodeBlock>
+<CodeBlock language="rust">{getLines(exampleCode, 12, 15)}</CodeBlock>
 
 Below is the diagram rendered by [mermaid](https://mermaid-js.github.io/) showing
 the structure of the full flow:


### PR DESCRIPTION
1. Simplest example: one of the links wasn't rendering. The line containing the link needs to be in a separate paragraph from <CodeBlock> for the link to work.
2. Simple example: `flat_map` generates a `RangeInclusive`. Existing code probably generated a `Vec`. Updated.
3. Graph Reachability: Code block now shows the line where `origin` vertex is input into `reached_vertices`.
4. Added `README.md` instructions to enable ligatures.