### PR TITLE
feat(hydroflow_plus): simplify lifetime bounds for processes and clusters

### DIFF
--- a/docs/docs/hydroflow_plus/clusters.mdx
+++ b/docs/docs/hydroflow_plus/clusters.mdx
@@ -11,7 +11,7 @@ Clusters solve this by providing an nearly-identical API to processes, but repre
 Instantiating clusters is done using the `cluster` method on `FlowBuilder`, taking a `ClusterSpec`:
 ```rust
 pub fn my_flow<'a, D: Deploy<'a>>(
-    flow: &'a FlowBuilder<'a, D>,
+    flow: &FlowBuilder<'a, D>,
     cluster_spec: &impl ClusterSpec<'a, D>
 ) {
     let cluster = flow.cluster(cluster_spec);

--- a/docs/docs/hydroflow_plus/process_streams.mdx
+++ b/docs/docs/hydroflow_plus/process_streams.mdx
@@ -16,7 +16,7 @@ To create a process, we must take a `ProcessSpec` as an argument to our function
 
 ```rust
 pub fn my_flow<'a, D: Deploy<'a>>(
-    flow: &'a FlowBuilder<'a, D>,
+    flow: &FlowBuilder<'a, D>,
     process_spec: &impl ProcessSpec<'a, D>
 ) {
     ...

--- a/docs/docs/hydroflow_plus/quickstart/clusters.mdx
+++ b/docs/docs/hydroflow_plus/quickstart/clusters.mdx
@@ -26,7 +26,7 @@ use hydroflow_plus::*;
 use stageleft::*;
 
 pub fn broadcast<'a, D: Deploy<'a>>(
-    flow: &'a FlowBuilder<'a, D>,
+    flow: &FlowBuilder<'a, D>,
     process_spec: &impl ProcessSpec<'a, D>,
     cluster_spec: &impl ClusterSpec<'a, D>
 ) {
@@ -56,10 +56,10 @@ use hydroflow_plus_cli_integration::{CLIRuntime, HydroflowPlusMeta};
 
 #[stageleft::entry]
 pub fn broadcast_runtime<'a>(
-    flow: &'a FlowBuilder<'a, CLIRuntime>,
+    flow: FlowBuilder<'a, CLIRuntime>,
     cli: RuntimeData<&'a HydroCLI<HydroflowPlusMeta>>,
 ) -> impl Quoted<'a, Hydroflow<'a>> {
-    broadcast(flow, &cli, &cli);
+    broadcast(&flow, &cli, &cli);
     flow.extract()
         .optimize_default()
         .with_dynamic_id(q!(cli.meta.subgraph_id))

--- a/docs/docs/hydroflow_plus/quickstart/distributed.mdx
+++ b/docs/docs/hydroflow_plus/quickstart/distributed.mdx
@@ -10,7 +10,7 @@ use hydroflow_plus::*;
 use stageleft::*;
 
 pub fn first_ten<'a, D: LocalDeploy<'a>>(
-    flow: &'a FlowBuilder<'a, D>,
+    flow: &FlowBuilder<'a, D>,
     process_spec: &impl ProcessSpec<'a, D>
 ) {
     let process = flow.process(process_spec);
@@ -26,7 +26,7 @@ use hydroflow_plus::*;
 use stageleft::*;
 
 pub fn first_ten_distributed<'a, D: Deploy<'a>>(
-    flow: &'a FlowBuilder<'a, D>,
+    flow: &FlowBuilder<'a, D>,
     process_spec: &impl ProcessSpec<'a, D>
 ) {
     let process = flow.process(process_spec);
@@ -52,10 +52,10 @@ use hydroflow_plus_cli_integration::{CLIRuntime, HydroflowPlusMeta};
 
 #[stageleft::entry]
 pub fn first_ten_distributed_runtime<'a>(
-    flow: &'a FlowBuilder<'a, CLIRuntime>,
+    flow: FlowBuilder<'a, CLIRuntime>,
     cli: RuntimeData<&'a HydroCLI<HydroflowPlusMeta>>,
 ) -> impl Quoted<'a, Hydroflow<'a>> {
-    first_ten_distributed(flow, &cli);
+    first_ten_distributed(&flow, &cli);
     flow.extract()
         .optimize_default()
         .with_dynamic_id(q!(cli.meta.subgraph_id))

--- a/docs/docs/hydroflow_plus/quickstart/structure.mdx
+++ b/docs/docs/hydroflow_plus/quickstart/structure.mdx
@@ -31,7 +31,7 @@ use hydroflow_plus::*;
 use stageleft::*;
 
 pub fn first_ten<'a, D: LocalDeploy<'a>>(
-    flow: &'a FlowBuilder<'a, D>,
+    flow: &FlowBuilder<'a, D>,
     process_spec: &impl ProcessSpec<'a, D>
 ) {}
 ```
@@ -40,7 +40,7 @@ To build a Hydroflow+ application, we need to define a dataflow that spans multi
 
 ```rust
 pub fn first_ten<'a, D: LocalDeploy<'a>>(
-    flow: &'a FlowBuilder<'a, D>,
+    flow: &FlowBuilder<'a, D>,
     process_spec: &impl ProcessSpec<'a, D>
 ) {
     let process = flow.process(process_spec);
@@ -72,9 +72,9 @@ Having done that, we can use some simple defaults for "distributing" this single
 ```rust title="flow/src/first_ten.rs"
 #[stageleft::entry]
 pub fn first_ten_runtime<'a>(
-    flow: &'a FlowBuilder<'a, SingleProcessGraph>
+    flow: FlowBuilder<'a, SingleProcessGraph>
 ) -> impl Quoted<'a, Hydroflow<'a>> {
-    first_ten(flow, &() /* for a single process graph */);
+    first_ten(&flow, &() /* for a single process graph */);
     flow.extract().optimize_default() // : impl Quoted<'a, Hydroflow<'a>>
 }
 ```

--- a/hydro_deploy/hydroflow_plus_cli_integration/src/runtime.rs
+++ b/hydro_deploy/hydroflow_plus_cli_integration/src/runtime.rs
@@ -29,7 +29,7 @@ impl<'a> Deploy<'a> for CLIRuntime {
 #[derive(Clone)]
 pub struct CLIRuntimeNode<'a> {
     id: usize,
-    builder: &'a FlowBuilder<'a, CLIRuntime>,
+    ir_leaves: Rc<RefCell<Vec<HfPlusLeaf>>>,
     cycle_counter: Rc<RefCell<usize>>,
     next_port: Rc<RefCell<usize>>,
     cli: RuntimeData<&'a HydroCLI<HydroflowPlusMeta>>,
@@ -43,8 +43,8 @@ impl<'a> Location<'a> for CLIRuntimeNode<'a> {
         self.id
     }
 
-    fn ir_leaves(&self) -> &'a RefCell<Vec<HfPlusLeaf>> {
-        self.builder.ir_leaves()
+    fn ir_leaves(&self) -> &Rc<RefCell<Vec<HfPlusLeaf>>> {
+        &self.ir_leaves
     }
 
     fn cycle_counter(&self) -> &RefCell<usize> {
@@ -63,7 +63,7 @@ impl<'a> Location<'a> for CLIRuntimeNode<'a> {
 #[derive(Clone)]
 pub struct CLIRuntimeCluster<'a> {
     id: usize,
-    builder: &'a FlowBuilder<'a, CLIRuntime>,
+    ir_leaves: Rc<RefCell<Vec<HfPlusLeaf>>>,
     cycle_counter: Rc<RefCell<usize>>,
     next_port: Rc<RefCell<usize>>,
     cli: RuntimeData<&'a HydroCLI<HydroflowPlusMeta>>,
@@ -77,8 +77,8 @@ impl<'a> Location<'a> for CLIRuntimeCluster<'a> {
         self.id
     }
 
-    fn ir_leaves(&self) -> &'a RefCell<Vec<HfPlusLeaf>> {
-        self.builder.ir_leaves()
+    fn ir_leaves(&self) -> &Rc<RefCell<Vec<HfPlusLeaf>>> {
+        &self.ir_leaves
     }
 
     fn cycle_counter(&self) -> &RefCell<usize> {
@@ -226,12 +226,12 @@ impl<'cli> ProcessSpec<'cli, CLIRuntime> for RuntimeData<&'cli HydroCLI<Hydroflo
     fn build(
         &self,
         id: usize,
-        builder: &'cli FlowBuilder<'cli, CLIRuntime>,
+        builder: &FlowBuilder<'cli, CLIRuntime>,
         _meta: &mut (),
     ) -> CLIRuntimeNode<'cli> {
         CLIRuntimeNode {
             id,
-            builder,
+            ir_leaves: builder.ir_leaves().clone(),
             cycle_counter: Rc::new(RefCell::new(0)),
             next_port: Rc::new(RefCell::new(0)),
             cli: *self,
@@ -243,12 +243,12 @@ impl<'cli> ClusterSpec<'cli, CLIRuntime> for RuntimeData<&'cli HydroCLI<Hydroflo
     fn build(
         &self,
         id: usize,
-        builder: &'cli FlowBuilder<'cli, CLIRuntime>,
+        builder: &FlowBuilder<'cli, CLIRuntime>,
         _meta: &mut (),
     ) -> CLIRuntimeCluster<'cli> {
         CLIRuntimeCluster {
             id,
-            builder,
+            ir_leaves: builder.ir_leaves().clone(),
             cycle_counter: Rc::new(RefCell::new(0)),
             next_port: Rc::new(RefCell::new(0)),
             cli: *self,

--- a/hydroflow_plus/src/cycle.rs
+++ b/hydroflow_plus/src/cycle.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::marker::PhantomData;
+use std::rc::Rc;
 
 use crate::ir::HfPlusLeaf;
 use crate::location::Location;
@@ -12,8 +13,8 @@ use crate::Stream;
 pub struct HfCycle<'a, T, W, N: Location<'a>> {
     pub(crate) ident: syn::Ident,
     pub(crate) node: N,
-    pub(crate) ir_leaves: &'a RefCell<Vec<HfPlusLeaf>>,
-    pub(crate) _phantom: PhantomData<(T, W)>,
+    pub(crate) ir_leaves: Rc<RefCell<Vec<HfPlusLeaf>>>,
+    pub(crate) _phantom: PhantomData<(&'a mut &'a (), T, W)>,
 }
 
 impl<'a, T, W, N: Location<'a>> HfCycle<'a, T, W, N> {

--- a/hydroflow_plus/src/lib.rs
+++ b/hydroflow_plus/src/lib.rs
@@ -50,18 +50,18 @@ impl<'a> FreeVariable<&'a Context> for RuntimeContext<'a> {
     }
 }
 
-pub struct HfBuilt<'a, ID> {
+pub struct HfCompiled<'a, ID> {
     hydroflow_ir: BTreeMap<usize, HydroflowGraph>,
     _phantom: PhantomData<&'a mut &'a ID>,
 }
 
-impl<'a, ID> HfBuilt<'a, ID> {
+impl<'a, ID> HfCompiled<'a, ID> {
     pub fn hydroflow_ir(&self) -> &BTreeMap<usize, HydroflowGraph> {
         &self.hydroflow_ir
     }
 }
 
-impl<'a> HfBuilt<'a, usize> {
+impl<'a> HfCompiled<'a, usize> {
     pub fn with_dynamic_id(self, id: impl Quoted<'a, usize>) -> HfBuiltWithID<'a> {
         let hydroflow_crate = proc_macro_crate::crate_name("hydroflow_plus")
             .expect("hydroflow_plus should be present in `Cargo.toml`");
@@ -117,9 +117,9 @@ impl<'a> HfBuilt<'a, usize> {
     }
 }
 
-impl<'a> Quoted<'a, Hydroflow<'a>> for HfBuilt<'a, ()> {}
+impl<'a> Quoted<'a, Hydroflow<'a>> for HfCompiled<'a, ()> {}
 
-impl<'a> FreeVariable<Hydroflow<'a>> for HfBuilt<'a, ()> {
+impl<'a> FreeVariable<Hydroflow<'a>> for HfCompiled<'a, ()> {
     fn to_tokens(mut self) -> (Option<TokenStream>, Option<TokenStream>) {
         let hydroflow_crate = proc_macro_crate::crate_name("hydroflow_plus")
             .expect("hydroflow_plus should be present in `Cargo.toml`");

--- a/hydroflow_plus/src/location/graphs.rs
+++ b/hydroflow_plus/src/location/graphs.rs
@@ -11,8 +11,8 @@ pub struct SingleProcessGraph {}
 
 impl<'a> LocalDeploy<'a> for SingleProcessGraph {
     type ClusterId = ();
-    type Process = SingleNode<'a>;
-    type Cluster = SingleNode<'a>;
+    type Process = SingleNode;
+    type Cluster = SingleNode;
     type Meta = ();
     type GraphId = ();
 }
@@ -21,23 +21,23 @@ impl<'a> ProcessSpec<'a, SingleProcessGraph> for () {
     fn build(
         &self,
         _id: usize,
-        builder: &'a FlowBuilder<'a, SingleProcessGraph>,
+        builder: &FlowBuilder<'a, SingleProcessGraph>,
         _meta: &mut (),
-    ) -> SingleNode<'a> {
+    ) -> SingleNode {
         SingleNode {
-            builder,
+            ir_leaves: builder.ir_leaves().clone(),
             cycle_counter: Rc::new(RefCell::new(0)),
         }
     }
 }
 
 #[derive(Clone)]
-pub struct SingleNode<'a> {
-    builder: &'a FlowBuilder<'a, SingleProcessGraph>,
+pub struct SingleNode {
+    ir_leaves: Rc<RefCell<Vec<HfPlusLeaf>>>,
     cycle_counter: Rc<RefCell<usize>>,
 }
 
-impl<'a> Location<'a> for SingleNode<'a> {
+impl<'a> Location<'a> for SingleNode {
     type Port = ();
     type Meta = ();
 
@@ -45,8 +45,8 @@ impl<'a> Location<'a> for SingleNode<'a> {
         0
     }
 
-    fn ir_leaves(&self) -> &'a RefCell<Vec<HfPlusLeaf>> {
-        self.builder.ir_leaves()
+    fn ir_leaves(&self) -> &Rc<RefCell<Vec<HfPlusLeaf>>> {
+        &self.ir_leaves
     }
 
     fn cycle_counter(&self) -> &RefCell<usize> {
@@ -60,7 +60,7 @@ impl<'a> Location<'a> for SingleNode<'a> {
     fn update_meta(&mut self, _meta: &Self::Meta) {}
 }
 
-impl<'a> Cluster<'a> for SingleNode<'a> {
+impl<'a> Cluster<'a> for SingleNode {
     type Id = ();
 
     fn ids(&self) -> impl Quoted<'a, &'a Vec<()>> + Copy + 'a {
@@ -74,21 +74,16 @@ pub struct MultiGraph {}
 
 impl<'a> LocalDeploy<'a> for MultiGraph {
     type ClusterId = u32;
-    type Process = MultiNode<'a>;
-    type Cluster = MultiNode<'a>;
+    type Process = MultiNode;
+    type Cluster = MultiNode;
     type Meta = ();
     type GraphId = usize;
 }
 
 impl<'a> ProcessSpec<'a, MultiGraph> for () {
-    fn build(
-        &self,
-        id: usize,
-        builder: &'a FlowBuilder<'a, MultiGraph>,
-        _meta: &mut (),
-    ) -> MultiNode<'a> {
+    fn build(&self, id: usize, builder: &FlowBuilder<'a, MultiGraph>, _meta: &mut ()) -> MultiNode {
         MultiNode {
-            builder,
+            ir_leaves: builder.ir_leaves().clone(),
             id,
             cycle_counter: Rc::new(RefCell::new(0)),
         }
@@ -96,13 +91,13 @@ impl<'a> ProcessSpec<'a, MultiGraph> for () {
 }
 
 #[derive(Clone)]
-pub struct MultiNode<'a> {
-    builder: &'a FlowBuilder<'a, MultiGraph>,
+pub struct MultiNode {
+    ir_leaves: Rc<RefCell<Vec<HfPlusLeaf>>>,
     id: usize,
     cycle_counter: Rc<RefCell<usize>>,
 }
 
-impl<'a> Location<'a> for MultiNode<'a> {
+impl<'a> Location<'a> for MultiNode {
     type Port = ();
     type Meta = ();
 
@@ -110,8 +105,8 @@ impl<'a> Location<'a> for MultiNode<'a> {
         self.id
     }
 
-    fn ir_leaves(&self) -> &'a RefCell<Vec<HfPlusLeaf>> {
-        self.builder.ir_leaves()
+    fn ir_leaves(&self) -> &Rc<RefCell<Vec<HfPlusLeaf>>> {
+        &self.ir_leaves
     }
 
     fn cycle_counter(&self) -> &RefCell<usize> {
@@ -125,7 +120,7 @@ impl<'a> Location<'a> for MultiNode<'a> {
     fn update_meta(&mut self, _meta: &Self::Meta) {}
 }
 
-impl<'a> Cluster<'a> for MultiNode<'a> {
+impl<'a> Cluster<'a> for MultiNode {
     type Id = u32;
 
     fn ids(&self) -> impl Quoted<'a, &'a Vec<u32>> + Copy + 'a {

--- a/hydroflow_plus/src/stream.rs
+++ b/hydroflow_plus/src/stream.rs
@@ -43,7 +43,7 @@ pub struct Windowed {}
 pub struct Stream<'a, T, W, N: Location<'a>> {
     node: N,
 
-    ir_leaves: &'a RefCell<Vec<HfPlusLeaf>>,
+    ir_leaves: Rc<RefCell<Vec<HfPlusLeaf>>>,
     pub(crate) ir_node: RefCell<HfPlusNode>,
 
     _phantom: PhantomData<(&'a mut &'a (), T, W)>,
@@ -52,7 +52,7 @@ pub struct Stream<'a, T, W, N: Location<'a>> {
 impl<'a, T, W, N: Location<'a>> Stream<'a, T, W, N> {
     pub(crate) fn new(
         node: N,
-        ir_leaves: &'a RefCell<Vec<HfPlusLeaf>>,
+        ir_leaves: Rc<RefCell<Vec<HfPlusLeaf>>>,
         ir_node: HfPlusNode,
     ) -> Self {
         Stream {
@@ -75,7 +75,7 @@ impl<'a, T: Clone, W, N: Location<'a>> Clone for Stream<'a, T, W, N> {
 
         Stream::new(
             self.node.clone(),
-            self.ir_leaves,
+            self.ir_leaves.clone(),
             self.ir_node.borrow().clone(),
         )
     }

--- a/hydroflow_plus_test/src/cluster.rs
+++ b/hydroflow_plus_test/src/cluster.rs
@@ -4,7 +4,7 @@ use hydroflow_plus::*;
 use stageleft::*;
 
 pub fn simple_cluster<'a, D: Deploy<'a, ClusterId = u32>>(
-    flow: &'a FlowBuilder<'a, D>,
+    flow: &FlowBuilder<'a, D>,
     process_spec: &impl ProcessSpec<'a, D>,
     cluster_spec: &impl ClusterSpec<'a, D>,
 ) -> (D::Process, D::Cluster) {
@@ -25,7 +25,7 @@ pub fn simple_cluster<'a, D: Deploy<'a, ClusterId = u32>>(
 }
 
 pub fn many_to_many<'a, D: Deploy<'a>>(
-    flow: &'a FlowBuilder<'a, D>,
+    flow: &FlowBuilder<'a, D>,
     cluster_spec: &impl ClusterSpec<'a, D>,
 ) -> D::Cluster
 where
@@ -41,7 +41,7 @@ where
 }
 
 pub fn map_reduce<'a, D: Deploy<'a, ClusterId = u32>>(
-    flow: &'a FlowBuilder<'a, D>,
+    flow: &FlowBuilder<'a, D>,
     process_spec: &impl ProcessSpec<'a, D>,
     cluster_spec: &impl ClusterSpec<'a, D>,
 ) -> (D::Process, D::Cluster) {
@@ -75,7 +75,7 @@ pub fn map_reduce<'a, D: Deploy<'a, ClusterId = u32>>(
 }
 
 pub fn compute_pi<'a, D: Deploy<'a>>(
-    flow: &'a FlowBuilder<'a, D>,
+    flow: &FlowBuilder<'a, D>,
     process_spec: &impl ProcessSpec<'a, D>,
     cluster_spec: &impl ClusterSpec<'a, D>,
 ) -> D::Process {
@@ -121,10 +121,10 @@ use hydroflow_plus_cli_integration::{CLIRuntime, HydroflowPlusMeta};
 
 #[stageleft::entry]
 pub fn simple_cluster_runtime<'a>(
-    flow: &'a FlowBuilder<'a, CLIRuntime>,
+    flow: FlowBuilder<'a, CLIRuntime>,
     cli: RuntimeData<&'a HydroCLI<HydroflowPlusMeta>>,
 ) -> impl Quoted<'a, Hydroflow<'a>> {
-    let _ = simple_cluster(flow, &cli, &cli);
+    let _ = simple_cluster(&flow, &cli, &cli);
     flow.extract()
         .optimize_default()
         .with_dynamic_id(q!(cli.meta.subgraph_id))
@@ -132,10 +132,10 @@ pub fn simple_cluster_runtime<'a>(
 
 #[stageleft::entry]
 pub fn many_to_many_runtime<'a>(
-    flow: &'a FlowBuilder<'a, CLIRuntime>,
+    flow: FlowBuilder<'a, CLIRuntime>,
     cli: RuntimeData<&'a HydroCLI<HydroflowPlusMeta>>,
 ) -> impl Quoted<'a, Hydroflow<'a>> {
-    let _ = many_to_many(flow, &cli);
+    let _ = many_to_many(&flow, &cli);
     flow.extract()
         .optimize_default()
         .with_dynamic_id(q!(cli.meta.subgraph_id))
@@ -143,10 +143,10 @@ pub fn many_to_many_runtime<'a>(
 
 #[stageleft::entry]
 pub fn map_reduce_runtime<'a>(
-    flow: &'a FlowBuilder<'a, CLIRuntime>,
+    flow: FlowBuilder<'a, CLIRuntime>,
     cli: RuntimeData<&'a HydroCLI<HydroflowPlusMeta>>,
 ) -> impl Quoted<'a, Hydroflow<'a>> {
-    let _ = map_reduce(flow, &cli, &cli);
+    let _ = map_reduce(&flow, &cli, &cli);
     flow.extract()
         .optimize_default()
         .with_dynamic_id(q!(cli.meta.subgraph_id))
@@ -154,10 +154,10 @@ pub fn map_reduce_runtime<'a>(
 
 #[stageleft::entry]
 pub fn compute_pi_runtime<'a>(
-    flow: &'a FlowBuilder<'a, CLIRuntime>,
+    flow: FlowBuilder<'a, CLIRuntime>,
     cli: RuntimeData<&'a HydroCLI<HydroflowPlusMeta>>,
 ) -> impl Quoted<'a, Hydroflow<'a>> {
-    let _ = compute_pi(flow, &cli, &cli);
+    let _ = compute_pi(&flow, &cli, &cli);
     flow.extract()
         .optimize_default()
         .with_dynamic_id(q!(cli.meta.subgraph_id))

--- a/hydroflow_plus_test/src/lib.rs
+++ b/hydroflow_plus_test/src/lib.rs
@@ -13,7 +13,7 @@ pub mod networked;
 
 #[stageleft::entry(UnboundedReceiverStream<u32>)]
 pub fn teed_join<'a, S: Stream<Item = u32> + Unpin + 'a>(
-    flow: &'a FlowBuilder<'a, MultiGraph>,
+    flow: FlowBuilder<'a, MultiGraph>,
     input_stream: RuntimeData<S>,
     output: RuntimeData<&'a UnboundedSender<u32>>,
     send_twice: bool,
@@ -50,7 +50,7 @@ pub fn teed_join<'a, S: Stream<Item = u32> + Unpin + 'a>(
 
 #[stageleft::entry]
 pub fn chat_app<'a>(
-    flow: &'a FlowBuilder<'a, SingleProcessGraph>,
+    flow: FlowBuilder<'a, SingleProcessGraph>,
     users_stream: RuntimeData<UnboundedReceiverStream<u32>>,
     messages: RuntimeData<UnboundedReceiverStream<String>>,
     output: RuntimeData<&'a UnboundedSender<(u32, String)>>,
@@ -83,7 +83,7 @@ pub fn chat_app<'a>(
 
 #[stageleft::entry]
 pub fn graph_reachability<'a>(
-    flow: &'a FlowBuilder<'a, SingleProcessGraph>,
+    flow: FlowBuilder<'a, SingleProcessGraph>,
     roots: RuntimeData<UnboundedReceiverStream<u32>>,
     edges: RuntimeData<UnboundedReceiverStream<(u32, u32)>>,
     reached_out: RuntimeData<&'a UnboundedSender<u32>>,
@@ -112,7 +112,7 @@ pub fn graph_reachability<'a>(
 
 #[stageleft::entry(String)]
 pub fn count_elems<'a, T: 'a>(
-    flow: &'a FlowBuilder<'a, SingleProcessGraph>,
+    flow: FlowBuilder<'a, SingleProcessGraph>,
     input_stream: RuntimeData<UnboundedReceiverStream<T>>,
     output: RuntimeData<&'a UnboundedSender<u32>>,
 ) -> impl Quoted<'a, Hydroflow<'a>> {

--- a/hydroflow_plus_test/src/negation.rs
+++ b/hydroflow_plus_test/src/negation.rs
@@ -4,7 +4,7 @@ use stageleft::{q, Quoted, RuntimeData};
 
 #[stageleft::entry]
 pub fn test_difference<'a>(
-    flow: &'a FlowBuilder<'a, SingleProcessGraph>,
+    flow: FlowBuilder<'a, SingleProcessGraph>,
     output: RuntimeData<&'a UnboundedSender<u32>>,
     persist1: bool,
     persist2: bool,
@@ -30,7 +30,7 @@ pub fn test_difference<'a>(
 
 #[stageleft::entry]
 pub fn test_anti_join<'a>(
-    flow: &'a FlowBuilder<'a, SingleProcessGraph>,
+    flow: FlowBuilder<'a, SingleProcessGraph>,
     output: RuntimeData<&'a UnboundedSender<u32>>,
     persist1: bool,
     persist2: bool,

--- a/hydroflow_plus_test/src/networked.rs
+++ b/hydroflow_plus_test/src/networked.rs
@@ -13,7 +13,7 @@ pub struct NetworkedBasicIO<'a, D: Deploy<'a>> {
 }
 
 pub fn networked_basic<'a, D: Deploy<'a>>(
-    flow: &'a FlowBuilder<'a, D>,
+    flow: &FlowBuilder<'a, D>,
     process_spec: &impl ProcessSpec<'a, D>,
     cluster_spec: &impl ClusterSpec<'a, D>,
 ) -> NetworkedBasicIO<'a, D> {
@@ -45,10 +45,10 @@ pub fn networked_basic<'a, D: Deploy<'a>>(
 
 #[stageleft::entry]
 pub fn networked_basic_runtime<'a>(
-    flow: &'a FlowBuilder<'a, CLIRuntime>,
+    flow: FlowBuilder<'a, CLIRuntime>,
     cli: RuntimeData<&'a HydroCLI<HydroflowPlusMeta>>,
 ) -> impl Quoted<'a, Hydroflow<'a>> {
-    let _ = networked_basic(flow, &cli, &cli);
+    let _ = networked_basic(&flow, &cli, &cli);
     flow.extract()
         .optimize_default()
         .with_dynamic_id(q!(cli.meta.subgraph_id))

--- a/stageleft/README.md
+++ b/stageleft/README.md
@@ -5,10 +5,10 @@ Stageleft brings the magic of staged programming to Rust, making it easy to writ
 Stageleft makes it easy to write type-safe code generators. For example, consider a function that raises a number to a power, but the power is known at compile time. Then, we can compile away the power into repeatedly squaring the base. We can implement a staged program for this:
 
 ```rust
-use stageleft::{q, IntoQuotedOnce, Quoted, RuntimeData};
+use stageleft::{q, BorrowBounds, IntoQuotedOnce, Quoted, RuntimeData};
 
 #[stageleft::entry]
-fn raise_to_power(_ctx: &(), value: RuntimeData<i32>, power: u32) -> impl Quoted<i32> {
+fn raise_to_power(_ctx: BorrowBounds<'_>, value: RuntimeData<i32>, power: u32) -> impl Quoted<i32> {
     if power == 1 {
         q!(value).boxed()
     } else if power % 2 == 0 {

--- a/stageleft/src/lib.rs
+++ b/stageleft/src/lib.rs
@@ -86,8 +86,16 @@ pub trait QuotedContext {
     fn create() -> Self;
 }
 
-impl QuotedContext for () {
-    fn create() -> Self {}
+pub struct BorrowBounds<'a> {
+    _marker: PhantomData<&'a &'a mut ()>,
+}
+
+impl<'a> QuotedContext for BorrowBounds<'a> {
+    fn create() -> Self {
+        BorrowBounds {
+            _marker: PhantomData,
+        }
+    }
 }
 
 pub trait Quoted<'a, T>: FreeVariable<T> {

--- a/stageleft_macro/src/lib.rs
+++ b/stageleft_macro/src/lib.rs
@@ -154,8 +154,8 @@ pub fn runtime(
 /// The entrypoint must be a function that returns `impl Quoted<T>` for some type `T`.
 ///
 /// The first parameter must always be a context, which defines lifetime bounds for
-/// the generated code. This can usually just be a parameter of type `&()`, but can
-/// be another borrowed type for domain specific staging.
+/// the generated code. This can usually just be a parameter of type `BorrowBounds<'_>`,
+/// but can be another borrowed type for domain specific staging.
 ///
 /// The rest of the parameters need to be passed in when invoking the macro. These
 /// can be either a `RuntimeData<T>` value for arbitrary values or a static value
@@ -325,9 +325,7 @@ pub fn entry(
             #(#param_parsing)*
 
             let output_core = {
-                #[allow(clippy::let_unit_value)]
-                let graph = #root::QuotedContext::create();
-                #root::Quoted::splice(#input_name #passed_generics(&graph, #(#params_to_pass),*))
+                #root::Quoted::splice(#input_name #passed_generics(#root::QuotedContext::create(), #(#params_to_pass),*))
             };
 
             let final_crate_name = env!("STAGELEFT_FINAL_CRATE_NAME");

--- a/stageleft_test/src/lib.rs
+++ b/stageleft_test/src/lib.rs
@@ -1,11 +1,11 @@
 stageleft::stageleft_crate!(stageleft_test_macro);
 
-use stageleft::{q, IntoQuotedOnce, Quoted, RuntimeData};
+use stageleft::{q, BorrowBounds, IntoQuotedOnce, Quoted, RuntimeData};
 
 pub(crate) mod submodule;
 
 #[stageleft::entry]
-fn raise_to_power(_ctx: &(), value: RuntimeData<i32>, power: u32) -> impl Quoted<i32> {
+fn raise_to_power(_ctx: BorrowBounds<'_>, value: RuntimeData<i32>, power: u32) -> impl Quoted<i32> {
     if power == 1 {
         q!(value).boxed()
     } else if power % 2 == 0 {
@@ -27,7 +27,7 @@ fn raise_to_power(_ctx: &(), value: RuntimeData<i32>, power: u32) -> impl Quoted
 
 #[stageleft::entry(bool)]
 fn closure_capture_lifetime<'a, I: Copy + Into<u32> + 'a>(
-    _ctx: &'a (),
+    _ctx: BorrowBounds<'a>,
     v: RuntimeData<I>,
 ) -> impl Quoted<Box<dyn Fn() -> u32 + 'a>> {
     q!(Box::new(move || { v.into() }) as Box<dyn Fn() -> u32 + 'a>)

--- a/stageleft_test/src/submodule.rs
+++ b/stageleft_test/src/submodule.rs
@@ -1,4 +1,4 @@
-use stageleft::{q, Quoted};
+use stageleft::{q, BorrowBounds, Quoted};
 
 struct PrivateStruct {
     a: u32,
@@ -12,7 +12,7 @@ pub struct PublicStruct {
 }
 
 #[stageleft::entry]
-pub fn private_struct(_ctx: &()) -> impl Quoted<u32> {
+pub fn private_struct(_ctx: BorrowBounds<'_>) -> impl Quoted<u32> {
     q!({
         let my_struct = PrivateStruct { a: 1 };
         my_struct.a
@@ -20,6 +20,6 @@ pub fn private_struct(_ctx: &()) -> impl Quoted<u32> {
 }
 
 #[stageleft::entry]
-pub fn public_struct(_ctx: &()) -> impl Quoted<PublicStruct> {
+pub fn public_struct(_ctx: BorrowBounds<'_>) -> impl Quoted<PublicStruct> {
     q!(PublicStruct { a: 1 })
 }


### PR DESCRIPTION
feat(hydroflow_plus): simplify lifetime bounds for processes and clusters

This allows `extract` to move the flow builder, which is a prerequisite for having developers run the optimizer during deployment as well in case it changes the network topology.
