### PR TITLE
fix(hydroflow_plus): allow BuiltFlow to be cloned even if the deploy flavor can't

### DIFF
--- a/hydroflow_plus/src/builder.rs
+++ b/hydroflow_plus/src/builder.rs
@@ -279,13 +279,23 @@ impl<'a, D: LocalDeploy<'a>> FlowBuilder<'a, D> {
     }
 }
 
-#[derive(Clone)]
 pub struct BuiltFlow<'a, D: LocalDeploy<'a>> {
     pub(crate) ir: Vec<HfPlusLeaf>,
     nodes: Vec<D::Process>,
     clusters: Vec<D::Cluster>,
 
     _phantom: PhantomData<&'a mut &'a D>,
+}
+
+impl<'a, D: LocalDeploy<'a>> Clone for BuiltFlow<'a, D> {
+    fn clone(&self) -> Self {
+        BuiltFlow {
+            ir: self.ir.clone(),
+            nodes: self.nodes.clone(),
+            clusters: self.clusters.clone(),
+            _phantom: PhantomData,
+        }
+    }
 }
 
 impl<'a, D: LocalDeploy<'a>> BuiltFlow<'a, D> {


### PR DESCRIPTION
fix(hydroflow_plus): allow BuiltFlow to be cloned even if the deploy flavor can't
