### PR TITLE
Extend Chat Example w/ Gossip Based Backend

### DIFF
--- a/hydroflow/examples/chat/README.md
+++ b/hydroflow/examples/chat/README.md
@@ -1,22 +1,95 @@
-Simple chat example, with a single central server broadcasting to clients.
+## Chat Examples
+There are two flavors of the chat example. The first is a broadcast-based example in which multiple clients connect to a
+single server. Whenever a client wishes to send a message, it sends it to the server and the server broadcasts it to
+the other clients. The second example is a gossip-based, multi-server example. The example is compatible with the same
+client used in the broadcast-based example. Clients can connect to any one of the  running servers. As before, when a 
+client wishes to send a message, it sends it to the server. The server gossips the message to other servers using a 
+gossip algorithm. Whenever a server learns of a new message, it is broadcast to all the clients connected to it.
+
+### Broadcast Example
 
 To run the example, open 3 terminals.
 
+#### Running the Server
 In one terminal run the server like so:
-```
-cargo run -p hydroflow --example chat -- --name "_" --role server --addr 127.0.0.1:12347
+```shell
+cargo run -p hydroflow --example chat -- --name "_" --role server
 ```
 
+#### Running the Clients
 In another terminal run the first client:
-```
-cargo run -p hydroflow --example chat -- --name "alice" --role client --server-addr 127.0.0.1:12347
+```shell
+cargo run -p hydroflow --example chat -- --name "alice" --role client
 ```
 
 In the third terminal run the second client:
-```
-cargo run -p hydroflow --example chat -- --name "bob" --role client --server-addr 127.0.0.1:12347
+```shell
+cargo run -p hydroflow --example chat -- --name "bob" --role client
 ```
 
 If you type in the client terminals the messages should appear everywhere.
 
-Adding the `--graph <graph_type>` flag to the end of the command lines above will print out a node-and-edge diagram of the program. Supported values for `<graph_type>` include [mermaid](https://mermaid-js.github.io/) and [dot](https://graphviz.org/doc/info/lang.html).
+### Gossip Example
+#### Running the Servers
+The gossip-based servers rely on static membership for discovery. The servers run a gossip protocol (parallel to the 
+client-server protocol). The roles `gossiping-server1`, ..., `gossiping-server5` determine which pre-configured port
+will be used by the server to send/receive gossip protocol messages.
+
+In (up to) five separate tabs, run the following servers. 
+
+##### First
+```shell
+cargo run -p hydroflow --example chat -- --name "_" --address 127.0.0.1:12345  --role gossiping-server1 
+```
+##### Second
+```shell
+cargo run -p hydroflow --example chat -- --name "_" --address 127.0.0.1:12346  --role gossiping-server2 
+```
+##### Third
+```shell
+cargo run -p hydroflow --example chat -- --name "_" --address 127.0.0.1:12347  --role gossiping-server3 
+```
+
+##### Fourth
+```shell
+cargo run -p hydroflow --example chat -- --name "_" --address 127.0.0.1:12348  --role gossiping-server4 
+```
+
+##### Fifth
+```shell
+cargo run -p hydroflow --example chat -- --name "_" --address 127.0.0.1:12349  --role gossiping-server5 
+```
+#### Running the Clients
+In another terminal run the first client:
+```shell
+cargo run -p hydroflow --example chat -- --name "alice" --address 127.0.0.1:12345 --role client
+```
+
+In another terminal run the second client:
+```shell
+cargo run -p hydroflow --example chat -- --name "bob" --address 127.0.0.1:12349 --role client
+```
+
+If you type in the client terminals the messages should appear everywhere. Give it a few seconds though - unlike the
+broadcast example, the message delivery isn't instantaneous. The gossip protocol runs in cycles and it could take a few
+cycles for the message to be delivered everywhere.
+
+### Dump Graphs of the Flows
+#### Client
+```shell
+cargo run -p hydroflow --example chat -- --name "alice" --role client --graph mermaid
+```
+#### Broadcast Server
+```shell
+cargo run -p hydroflow --example chat -- --name "_" --role server --graph mermaid
+```
+
+#### Gossip Server
+```shell
+cargo run -p hydroflow --example chat -- --name "_" --role gossiping-server1 --graph mermaid
+```
+
+### Display Help
+```shell
+cargo run -p hydroflow --example chat -- --help
+```

--- a/hydroflow/examples/chat/client.rs
+++ b/hydroflow/examples/chat/client.rs
@@ -25,7 +25,7 @@ pub(crate) async fn run_client(opts: Opts) {
 
     // Use the server address that was provided in the command-line arguments, or use the default
     // if one was not provided.
-    let server_addr = opts.address.unwrap_or_else(|| default_server_address());
+    let server_addr = opts.address.unwrap_or_else(default_server_address);
 
     let (outbound, inbound, allocated_client_addr) = bind_udp_bytes(client_addr).await;
 

--- a/hydroflow/examples/chat/client.rs
+++ b/hydroflow/examples/chat/client.rs
@@ -25,9 +25,7 @@ pub(crate) async fn run_client(opts: Opts) {
 
     // Use the server address that was provided in the command-line arguments, or use the default
     // if one was not provided.
-    let server_addr = opts
-        .address
-        .unwrap_or_else(|| default_server_address());
+    let server_addr = opts.address.unwrap_or_else(|| default_server_address());
 
     let (outbound, inbound, allocated_client_addr) = bind_udp_bytes(client_addr).await;
 

--- a/hydroflow/examples/chat/main.rs
+++ b/hydroflow/examples/chat/main.rs
@@ -13,7 +13,7 @@ mod protocol;
 mod randomized_gossiping_server;
 mod server;
 
-#[derive(Clone, ValueEnum, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, ValueEnum, Debug, Eq, PartialEq)]
 enum Role {
     Client,
     Server,

--- a/hydroflow/examples/chat/main.rs
+++ b/hydroflow/examples/chat/main.rs
@@ -126,7 +126,7 @@ fn test_gossip() {
 
     let (_server1, _, mut server1_output) = run_cargo_example(
         "chat",
-        "--role gossiping-server1 --name server --address 127.0.0.1:11247",
+        "--role gossiping-server1 --name server --address 127.0.0.1:11248",
     );
 
     let mut server1_output_so_far = String::new();
@@ -138,7 +138,7 @@ fn test_gossip() {
 
     let (_server2, _, mut server2_output) = run_cargo_example(
         "chat",
-        "--role gossiping-server2 --name server --address 127.0.0.1:11248",
+        "--role gossiping-server2 --name server --address 127.0.0.1:11249",
     );
 
     let mut server2_output_so_far = String::new();
@@ -150,12 +150,12 @@ fn test_gossip() {
 
     let (_client1, mut client1_input, mut client1_output) = run_cargo_example(
         "chat",
-        "--role client --name client1 --address 127.0.0.1:11247",
+        "--role client --name client1 --address 127.0.0.1:11248",
     );
 
     let (_client2, _, mut client2_output) = run_cargo_example(
         "chat",
-        "--role client --name client2 --address 127.0.0.1:11248",
+        "--role client --name client2 --address 127.0.0.1:11249",
     );
 
     let mut client1_output_so_far = String::new();

--- a/hydroflow/examples/chat/main.rs
+++ b/hydroflow/examples/chat/main.rs
@@ -2,15 +2,16 @@ use std::net::SocketAddr;
 
 use clap::{Parser, ValueEnum};
 use client::run_client;
-use hydroflow::util::{ipv4_resolve};
+use hydroflow::util::ipv4_resolve;
 use hydroflow_lang::graph::{WriteConfig, WriteGraphType};
 use server::run_server;
+
 use crate::randomized_gossiping_server::run_gossiping_server;
 
 mod client;
 mod protocol;
-mod server;
 mod randomized_gossiping_server;
+mod server;
 
 #[derive(Clone, ValueEnum, Debug, Eq, PartialEq)]
 enum Role {
@@ -28,7 +29,6 @@ enum Role {
 pub fn default_server_address() -> SocketAddr {
     ipv4_resolve("localhost:54321").unwrap()
 }
-
 
 #[derive(Parser, Debug)]
 struct Opts {
@@ -55,9 +55,11 @@ async fn main() {
         Role::Server => {
             run_server(opts).await;
         }
-        Role::GossipingServer1 | Role::GossipingServer2 | Role::GossipingServer3 | Role::GossipingServer4 | Role::GossipingServer5 => {
-            run_gossiping_server(opts).await
-        }
+        Role::GossipingServer1
+        | Role::GossipingServer2
+        | Role::GossipingServer3
+        | Role::GossipingServer4
+        | Role::GossipingServer5 => run_gossiping_server(opts).await,
     }
 }
 

--- a/hydroflow/examples/chat/main.rs
+++ b/hydroflow/examples/chat/main.rs
@@ -69,8 +69,10 @@ fn test() {
 
     use hydroflow::util::{run_cargo_example, wait_for_process_output};
 
-    let (_server, _, mut server_output) =
-        run_cargo_example("chat", "--role server --name server --address 127.0.0.1:11247");
+    let (_server, _, mut server_output) = run_cargo_example(
+        "chat",
+        "--role server --name server --address 127.0.0.1:11247",
+    );
 
     let mut server_output_so_far = String::new();
     wait_for_process_output(
@@ -122,8 +124,10 @@ fn test_gossip() {
 
     use hydroflow::util::{run_cargo_example, wait_for_process_output};
 
-    let (_server1, _, mut server1_output) =
-        run_cargo_example("chat", "--role gossiping-server1 --name server --address 127.0.0.1:11247");
+    let (_server1, _, mut server1_output) = run_cargo_example(
+        "chat",
+        "--role gossiping-server1 --name server --address 127.0.0.1:11247",
+    );
 
     let mut server1_output_so_far = String::new();
     wait_for_process_output(
@@ -132,8 +136,10 @@ fn test_gossip() {
         "Server is live!",
     );
 
-    let (_server2, _, mut server2_output) =
-        run_cargo_example("chat", "--role gossiping-server2 --name server --address 127.0.0.1:11248");
+    let (_server2, _, mut server2_output) = run_cargo_example(
+        "chat",
+        "--role gossiping-server2 --name server --address 127.0.0.1:11248",
+    );
 
     let mut server2_output_so_far = String::new();
     wait_for_process_output(

--- a/hydroflow/examples/chat/randomized_gossiping_server.rs
+++ b/hydroflow/examples/chat/randomized_gossiping_server.rs
@@ -1,0 +1,206 @@
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::time::Duration;
+use chrono::{DateTime, Utc};
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+use serde::{Deserialize, Serialize};
+use hydroflow::scheduled::graph::Hydroflow;
+use hydroflow::util::{bind_udp_bytes, ipv4_resolve};
+use hydroflow_macro::hydroflow_syntax;
+
+use crate::{default_server_address, Opts, Role};
+use crate::protocol::{Message, MessageWithAddr};
+use crate::Role::{GossipingServer1, GossipingServer2, GossipingServer3, GossipingServer4, GossipingServer5, Client, Server};
+
+
+#[derive(PartialEq, Eq, Clone, Serialize, Deserialize, Debug, Hash)]
+pub struct ChatMessage {
+    nickname: String,
+    message: String,
+    ts: DateTime<Utc>,
+}
+
+/// Used to model add and remove operations on a set of infecting messages.
+enum InfectionOperation {
+    /// Add an infecting message to the current set
+    InfectWithMessage { msg: ChatMessage },
+
+    /// Remove an infecting message from the current set
+    RemoveForMessage { msg: ChatMessage },
+}
+
+pub const REMOVAL_PROBABILITY: f32 = 1.0 / 4.0;
+
+/// Runs an instance of a server that gossips new chat messages with other instances of the server.
+///
+/// The servers are protocol-compatible with the broadcast-based server run by
+/// [crate::server::run_server], so can be used with the existing client
+/// ([crate::client::run_client]).
+///
+/// The implementation is based on "Epidemic algorithms for replicated database maintenance"
+/// (https://dl.acm.org/doi/epdf/10.1145/41840.41841). Specifically, it implements push-based
+/// "rumor-mongering" with a blind-coin removal process described below.
+///
+/// At every "cycle" a server chooses, randomly, one peer from a group of five servers. It then
+/// "pushes" all the "rumors" (messages) that it has heard so far to that peer. This is how new
+/// messages propagate through the system. Without a removal process, the messages would bounce
+/// around forever.
+///
+/// A "blind-coin" removal process is used. After a server gossips the known rumors with randomly
+/// selected peers, each message is dropped with a 1/K probability. K can be configured by changing
+/// [REMOVAL_PROBABILITY]. The removal is "blind" because the server doesn't check if the receiving
+/// peer already knew the message, i.e. it doesn't rely on a feedback mechanism from the peer to
+/// drive the process. The removal is "coin" based because it relies on pure chance (instead of
+/// keeping track using a counter).
+///
+/// To keep things simple, the peer-group of servers is based on static membership - it contains
+/// 5 members that communicate with each other on fixed ports.
+pub(crate) async fn run_gossiping_server(opts: Opts) {
+    // If a server address & port are provided as command-line inputs, use those, else use the
+    // default.
+    let server_address = opts
+        .address
+        .unwrap_or_else(|| default_server_address());
+
+    let all_members = vec![GossipingServer1,
+                           GossipingServer2,
+                           GossipingServer3,
+                           GossipingServer4,
+                           GossipingServer5];
+
+    let other_members : Vec<Role> = all_members.iter().filter(|role| **role != opts.role)
+        .cloned()
+        .collect();
+
+    let gossip_listening_addr = gossip_address(&opts.role);
+
+    println!("Starting server on {:?}", server_address);
+
+    // Separate sinks and streams for client-server protocol & gossip protocol.
+    let (client_outbound, client_inbound, actual_server_addr) = bind_udp_bytes(server_address).await;
+    let (gossip_outbound, gossip_inbound, _) = bind_udp_bytes(gossip_listening_addr).await;
+
+    println!("Server is live! Listening on {:?}. Gossiping On: {:?}", actual_server_addr, gossip_listening_addr);
+    let mut hf: Hydroflow = hydroflow_syntax! {
+        // Define shared inbound and outbound channels
+        client_out = union() -> dest_sink_serde(client_outbound);
+        client_in = source_stream_serde(client_inbound)
+            -> map(Result::unwrap)
+            -> map(|(msg, addr)| MessageWithAddr::from_message(msg, addr))
+            -> demux_enum::<MessageWithAddr>();
+        clients = client_in[ConnectRequest] -> map(|(addr,)| addr) -> tee();
+        client_in[ConnectResponse] -> for_each(|(addr,)| println!("Received unexpected `ConnectResponse` as server from addr {}.", addr));
+
+        // Pipeline 1: Acknowledge client connections
+        clients[0] -> map(|addr| (Message::ConnectResponse, addr)) -> [0]client_out;
+
+        // Pipeline 2: When a message arrives from a client, it is the first time the message is
+        // seen. Still, send it to the "maybe_new_messages" flow for simplicity.
+        messages_from_connected_client = client_in[ChatMsg]
+            -> map(|(_addr, nickname, message, ts)| ChatMessage { nickname, message, ts })
+            -> maybe_new_messages;
+
+        // Pipeline 3: When you want to send a message to all the connected clients, send it to
+        // "broadcast"
+        clients[1] -> [1]broadcast;
+        broadcast = cross_join::<'tick, 'static>() -> [1]client_out;
+
+        // Pipeline 3: Gossip-based broadcast to other servers.
+        gossip_out = dest_sink_serde(gossip_outbound);
+        gossip_in = source_stream_serde(gossip_inbound)
+            -> map(Result::unwrap)
+            -> map(|(message, _)| message)
+            -> maybe_new_messages;
+
+        // If you think there may be a new message, send it here.
+        maybe_new_messages = union();
+
+        // actually_new_messages are a stream of messages that the server is definitely seeing
+        // for the first time.
+        actually_new_messages = difference() -> tee();
+        maybe_new_messages -> [pos]actually_new_messages;
+        all_messages -> [neg]actually_new_messages;
+
+        // When we have a new message, we should do 3 things
+        // 1. Add it to the set of known messages.
+        // 2. Broadcast it to the clients connected locally.
+        // 3. Add it to the set of messages currently infecting this server.
+        actually_new_messages -> defer_tick() -> all_messages; // Add to known messages
+        actually_new_messages
+            -> map(|chat_msg: ChatMessage| Message::ChatMsg {
+                    nickname: chat_msg.nickname,
+                    message: chat_msg.message,
+                    ts: chat_msg.ts})
+            -> [0]broadcast; // Broadcast to locally connected clients.
+        actually_new_messages
+            -> map(|msg: ChatMessage| InfectionOperation::InfectWithMessage { msg })
+            -> infecting_messages;
+
+        // Holds all the known messages.
+        all_messages = fold::<'static>(HashSet::<ChatMessage>::new, |accum, message| {
+            accum.insert(message)
+        }) -> flatten();
+
+        // Holds a set of messages that are currently infecting this server
+        infecting_messages = union() -> fold::<'static>(HashSet::<ChatMessage>::new, |accum, op| {
+            match op {
+                InfectionOperation::InfectWithMessage{ msg } => {accum.insert(msg)},
+                InfectionOperation::RemoveForMessage{ msg } => { accum.remove(&msg) }
+            }
+        });
+
+        // Infection process.
+        // Every 1 second, the infecting messages are dispatched to a randomly selected peer. They
+        // are blindly removed with a 1/K probability after this.
+        source_interval(Duration::from_secs(1)) -> [0]triggered_messages; // The time trigger to perform a round of gossip
+        triggered_messages = cross_join()
+            -> map(|(_, message)| {
+                    // Choose a random peer
+                    let random_peer = other_members.choose(&mut thread_rng()).unwrap();
+                    (message, gossip_address(random_peer))
+               })
+            -> tee();
+
+        infecting_messages -> flatten() -> [1]triggered_messages;
+
+        triggered_messages
+            -> inspect(|(msg, addr)| println!("Gossiping {:?} to {:?}", msg, addr))
+            -> gossip_out;
+
+        triggered_messages
+            -> filter_map(|(msg, _addr)| {
+                if rand::random::<f32>() < REMOVAL_PROBABILITY{
+                    println!("Dropping Message {:?}", msg);
+                    Some(InfectionOperation::RemoveForMessage{ msg })
+                } else {
+                    None
+                }
+            })
+            -> defer_tick()
+            -> infecting_messages;
+
+    };
+
+    if let Some(graph) = opts.graph {
+        let serde_graph = hf
+            .meta_graph()
+            .expect("No graph found, maybe failed to parse.");
+        serde_graph.open_graph(graph, opts.write_config).unwrap();
+    }
+
+    hf.run_async().await.unwrap();
+}
+
+/// The address on which the gossip protocol runs. Servers communicate with each other using these
+/// addresses. This is different from the ports on which clients connect to servers.
+fn gossip_address(role: &Role) -> SocketAddr {
+    match role {
+        Client | Server => { panic!("Incorrect role {:?} for gossip server.", role) }
+        GossipingServer1 => ipv4_resolve("localhost:54322"),
+        GossipingServer2 => ipv4_resolve("localhost:54323"),
+        GossipingServer3 => ipv4_resolve("localhost:54324"),
+        GossipingServer4 => ipv4_resolve("localhost:54325"),
+        GossipingServer5 => ipv4_resolve("localhost:54326"),
+    }.unwrap()
+}

--- a/hydroflow/examples/chat/randomized_gossiping_server.rs
+++ b/hydroflow/examples/chat/randomized_gossiping_server.rs
@@ -147,14 +147,14 @@ pub(crate) async fn run_gossiping_server(opts: Opts) {
 
         // Holds all the known messages.
         all_messages = fold::<'static>(HashSet::<ChatMessage>::new, |accum, message| {
-            accum.insert(message)
+            accum.insert(message);
         }) -> flatten();
 
         // Holds a set of messages that are currently infecting this server
         infecting_messages = union() -> fold::<'static>(HashSet::<ChatMessage>::new, |accum, op| {
             match op {
-                InfectionOperation::InfectWithMessage{ msg } => {accum.insert(msg)},
-                InfectionOperation::RemoveForMessage{ msg } => { accum.remove(&msg) }
+                InfectionOperation::InfectWithMessage{ msg } => {accum.insert(msg);},
+                InfectionOperation::RemoveForMessage{ msg } => { accum.remove(&msg);}
             }
         });
 

--- a/hydroflow/examples/chat/randomized_gossiping_server.rs
+++ b/hydroflow/examples/chat/randomized_gossiping_server.rs
@@ -73,9 +73,8 @@ pub(crate) async fn run_gossiping_server(opts: Opts) {
     ];
 
     let other_members: Vec<Role> = all_members
-        .iter()
-        .filter(|role| **role != opts.role)
-        .cloned()
+        .into_iter()
+        .filter(|role| *role != opts.role)
         .collect();
 
     let gossip_listening_addr = gossip_address(&opts.role);

--- a/hydroflow/examples/chat/randomized_gossiping_server.rs
+++ b/hydroflow/examples/chat/randomized_gossiping_server.rs
@@ -62,9 +62,9 @@ pub const REMOVAL_PROBABILITY: f32 = 1.0 / 4.0;
 pub(crate) async fn run_gossiping_server(opts: Opts) {
     // If a server address & port are provided as command-line inputs, use those, else use the
     // default.
-    let server_address = opts.address.unwrap_or_else(|| default_server_address());
+    let server_address = opts.address.unwrap_or_else(default_server_address);
 
-    let all_members = vec![
+    let all_members = [
         GossipingServer1,
         GossipingServer2,
         GossipingServer3,

--- a/hydroflow/examples/chat/server.rs
+++ b/hydroflow/examples/chat/server.rs
@@ -1,6 +1,6 @@
 use hydroflow::hydroflow_syntax;
 use hydroflow::scheduled::graph::Hydroflow;
-use hydroflow::util::{bind_udp_bytes};
+use hydroflow::util::bind_udp_bytes;
 
 use crate::protocol::{Message, MessageWithAddr};
 use crate::{default_server_address, Opts};
@@ -10,9 +10,7 @@ pub(crate) async fn run_server(opts: Opts) {
 
     // If a server address & port are provided as command-line inputs, use those, else use the
     // default.
-    let server_address = opts
-        .address
-        .unwrap_or_else(|| default_server_address());
+    let server_address = opts.address.unwrap_or_else(|| default_server_address());
 
     println!("Starting server on {:?}", server_address);
 

--- a/hydroflow/examples/chat/server.rs
+++ b/hydroflow/examples/chat/server.rs
@@ -1,12 +1,24 @@
 use hydroflow::hydroflow_syntax;
 use hydroflow::scheduled::graph::Hydroflow;
-use hydroflow::util::{UdpSink, UdpStream};
+use hydroflow::util::{bind_udp_bytes};
 
 use crate::protocol::{Message, MessageWithAddr};
-use crate::Opts;
+use crate::{default_server_address, Opts};
 
-pub(crate) async fn run_server(outbound: UdpSink, inbound: UdpStream, opts: Opts) {
+pub(crate) async fn run_server(opts: Opts) {
     println!("Server live!");
+
+    // If a server address & port are provided as command-line inputs, use those, else use the
+    // default.
+    let server_address = opts
+        .address
+        .unwrap_or_else(|| default_server_address());
+
+    println!("Starting server on {:?}", server_address);
+
+    let (outbound, inbound, actual_server_addr) = bind_udp_bytes(server_address).await;
+
+    println!("Server is live! Listening on {:?}", actual_server_addr);
 
     let mut hf: Hydroflow = hydroflow_syntax! {
         // Define shared inbound and outbound channels

--- a/hydroflow/examples/chat/server.rs
+++ b/hydroflow/examples/chat/server.rs
@@ -10,7 +10,7 @@ pub(crate) async fn run_server(opts: Opts) {
 
     // If a server address & port are provided as command-line inputs, use those, else use the
     // default.
-    let server_address = opts.address.unwrap_or_else(|| default_server_address());
+    let server_address = opts.address.unwrap_or_else(default_server_address);
 
     println!("Starting server on {:?}", server_address);
 


### PR DESCRIPTION
Added a gossip-based backend for the chat example.

The implementation is based on ["Epidemic algorithms for replicated database maintenance"](https://dl.acm.org/doi/epdf/10.1145/41840.41841). Specifically, it implements push-based "rumor-mongering" with a blind-coin removal process.