### PR TITLE
ci: enable sccache on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,38 +63,28 @@ jobs:
 
       - name: Run sccache-cache
         if: matrix.rust_release == 'pinned-nightly'
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.4
 
       - name: Set Rust caching env vars
         if: matrix.rust_release == 'pinned-nightly'
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+        uses: actions/github-script@v6
+        with:
+          script: |
+            core.exportVariable('SCCACHE_GHA_ENABLED', 'true');
+            core.exportVariable('RUSTC_WRAPPER', 'sccache');
 
       - name: Run cargo fmt
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --features python -- -D warnings
+        run: cargo clippy --all-targets --features python -- -D warnings
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-targets --features python
+        run: cargo check --all-targets --features python
 
       - name: Run cargo check (no default features)
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-targets --no-default-features
+        run: cargo check --all-targets --no-default-features
 
   check-wasm:
     name: Check WebAssembly
@@ -169,13 +159,15 @@ jobs:
 
       - name: Run sccache-cache
         if: matrix.rust_release == 'pinned-nightly'
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.4
 
       - name: Set Rust caching env vars
         if: matrix.rust_release == 'pinned-nightly'
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+        uses: actions/github-script@v6
+        with:
+          script: |
+            core.exportVariable('SCCACHE_GHA_ENABLED', 'true');
+            core.exportVariable('RUSTC_WRAPPER', 'sccache');
 
       - name: Install cargo-nextest (linux)
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -187,16 +179,10 @@ jobs:
         run: curl -LsSf https://get.nexte.st/latest/windows-tar | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
       - name: Run cargo nextest on all targets
-        uses: actions-rs/cargo@v1
-        with:
-          command: nextest
-          args: run --no-fail-fast --features python --all-targets
+        run: cargo nextest run --no-fail-fast --features python --all-targets
 
       - name: Run doctests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-fail-fast --features python --doc
+        run: cargo test --no-fail-fast --features python --doc
 
       - name: Install Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
ci: enable sccache on windows

Due to cross-platform incompatibilities with `GITHUB_ENV` it was never enabled on Windows.
