### PR TITLE
fix: validate the PR title rather than the commit message

### DIFF
--- a/.github/workflows/conventional_commits.yml
+++ b/.github/workflows/conventional_commits.yml
@@ -1,13 +1,20 @@
 name: Conventional Commits
 
 on:
-  pull_request:
-    branches: [ main ]
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
 
 jobs:
-  build:
+  main:
     name: Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: webiny/action-conventional-commits@v1.1.0
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
fix: validate the PR title rather than the commit message

If we switch the repository to require squash-and-merge strategy with the commit using the PR title, then this makes it a lot easier to enforce conventional commits.
