### PR TITLE
`source_interval` no longer emits Instant instances on output.

### DIFF
--- a/docs/docs/hydroflow/syntax/surface_data.mdx
+++ b/docs/docs/hydroflow/syntax/surface_data.mdx
@@ -49,7 +49,7 @@ in from outside the flow:
 
 <CodeBlock language="rust" showLineNumbers>{exampleCodeInput}</CodeBlock>
 
-Sometimes we want to trigger activity based on timing, not data. To achieve this, we can use the [`source_interval()`](./surface_ops_gen.md#source_interval) operator, which takes a `Duration` `d` as an argument, and outputs a Tokio time Instant after every `d` units of time pass.
+Sometimes we want to trigger activity based on timing, not data. To achieve this, we can use the [`source_interval()`](./surface_ops_gen.md#source_interval) operator, which takes a `Duration` `d` as an argument, and outputs a unit `()` after every `d` units of time pass.
 
 ## Destinations
 As duals to our data source operators, we also have data destination operators. The dest operators you'll likely use

--- a/hydroflow/tests/surface_book.rs
+++ b/hydroflow/tests/surface_book.rs
@@ -1,5 +1,6 @@
 use hydroflow::assert_graphvis_snapshots;
 use multiplatform_test::multiplatform_test;
+use tokio::time::Instant;
 
 #[multiplatform_test]
 fn test_surface_flows_1() {
@@ -21,6 +22,7 @@ async fn test_source_interval() {
 
     let mut hf = hydroflow_syntax! {
         source_interval(Duration::from_secs(1))
+            -> map(|_| { Instant::now() } )
             -> for_each(|time| println!("This runs every second: {:?}", time));
     };
 

--- a/hydroflow_lang/src/graph/ops/source_interval.rs
+++ b/hydroflow_lang/src/graph/ops/source_interval.rs
@@ -10,9 +10,8 @@ use super::{
 ///
 /// > Arguments: A [`Duration`](https://doc.rust-lang.org/stable/std/time/struct.Duration.html) for this interval.
 ///
-/// Emits [Tokio time `Instant`s](https://docs.rs/tokio/1/tokio/time/struct.Instant.html) on a
-/// repeated interval. The first tick completes imediately. Missed ticks will be scheduled as soon
-/// as possible, and the `Instant` will be the missed time, not the late time.
+/// Emits units `()` on a repeated interval. The first tick completes immediately. Missed ticks will
+/// be scheduled as soon as possible.
 ///
 /// Note that this requires the hydroflow instance be run within a [Tokio `Runtime`](https://docs.rs/tokio/1/tokio/runtime/struct.Runtime.html).
 /// The easiest way to do this is with a [`#[hydroflow::main]`](https://hydro-project.github.io/hydroflow/doc/hydroflow/macro.hydroflow_main.html)
@@ -20,13 +19,14 @@ use super::{
 ///
 /// ```rustbook
 /// use std::time::Duration;
-///
+/// use std::time::Instant;
 /// use hydroflow::hydroflow_syntax;
 ///
 /// #[hydroflow::main]
 /// async fn main() {
 ///     let mut hf = hydroflow_syntax! {
 ///         source_interval(Duration::from_secs(1))
+///             -> map(|_| { Instant::now() } )
 ///             -> for_each(|time| println!("This runs every second: {:?}", time));
 ///     };
 ///
@@ -68,7 +68,10 @@ pub const SOURCE_INTERVAL: OperatorConstraints = OperatorConstraints {
         let ident_intervalstream = wc.make_ident("intervalstream");
         let mut write_prologue = quote_spanned! {op_span=>
             let #ident_intervalstream =
-                #root::tokio_stream::wrappers::IntervalStream::new(#root::tokio::time::interval(#arguments));
+                #root::tokio_stream::StreamExt::map(
+                    #root::tokio_stream::wrappers::IntervalStream::new(#root::tokio::time::interval(#arguments)),
+                    |_| {  }
+                );
         };
         let wc = WriteContextArgs {
             arguments: &parse_quote_spanned!(op_span=> #ident_intervalstream),


### PR DESCRIPTION
Addresses #1186.

`source_interval` emits instances of `tokio::time::instant`. Clocks in the Context (like `current_tick_start`) also indicate the time the tick started. There's some potential for users to confuse these timestamps or fall into the trap of reasoning about the semantics of these clocks/comparability, etc.

`source_interval` should just emit unit instances `()` when it has data. If someone still needs a clock reading, they can `map` it to something that makes sense for their application.