### PR TITLE
feat(hydroflow)!: Introduce newtypes for working with ticks

### DIFF
--- a/hydroflow/examples/kvs_bench/server.rs
+++ b/hydroflow/examples/kvs_bench/server.rs
@@ -8,6 +8,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 use futures::Stream;
 use hydroflow::compiled::pull::HalfMultisetJoinState;
 use hydroflow::hydroflow_syntax;
+use hydroflow::scheduled::ticks::TickInstant;
 use hydroflow_lang::graph::{WriteConfig, WriteGraphType};
 use lattices::map_union::{MapUnionHashMap, MapUnionSingletonMap};
 use lattices::set_union::SetUnionSingletonSet;
@@ -122,15 +123,15 @@ pub fn run_server<RX>(
             let mut pre_gen_index = 0;
             let pre_gen_random_numbers: Vec<u64> = (0..(128*1024)).map(|_| rng.sample(dist) as u64).collect();
 
-            let create_unique_id = move |server_id: u128, tick: usize, e: u128| -> u128 {
-                assert!(tick < 1_000_000_000);
+            let create_unique_id = move |server_id: u128, tick: TickInstant, e: u128| -> u128 {
+                assert!(tick < TickInstant(1_000_000_000));
                 assert!(e < 1_000_000_000);
 
                 (relatively_recent_timestamp.load(Ordering::Relaxed) as u128)
                     .checked_mul(100).unwrap()
                     .checked_add(server_id).unwrap()
                     .checked_mul(1_000_000_000).unwrap()
-                    .checked_add(tick as u128).unwrap()
+                    .checked_add(tick.0 as u128).unwrap()
                     .checked_mul(1_000_000_000).unwrap()
                     .checked_add(e).unwrap()
             };

--- a/hydroflow/src/scheduled/context.rs
+++ b/hydroflow/src/scheduled/context.rs
@@ -12,6 +12,7 @@ use tokio::task::JoinHandle;
 use super::graph::StateData;
 use super::state::StateHandle;
 use super::{StateId, SubgraphId};
+use crate::scheduled::ticks::TickInstant;
 
 /// The main state of the Hydroflow instance, which is provided as a reference
 /// to each operator as it is run.
@@ -27,11 +28,11 @@ pub struct Context {
     // Second field (bool) is for if the event is an external "important" event (true).
     pub(crate) event_queue_send: UnboundedSender<(SubgraphId, bool)>,
 
-    pub(crate) current_tick: usize,
+    pub(crate) current_tick: TickInstant,
     pub(crate) current_stratum: usize,
 
     pub(crate) current_tick_start: Instant,
-    pub(crate) subgraph_last_tick_run_in: Option<usize>,
+    pub(crate) subgraph_last_tick_run_in: Option<TickInstant>,
 
     /// The SubgraphId of the currently running operator. When this context is
     /// not being forwarded to a running operator, this field is (mostly)
@@ -45,7 +46,7 @@ pub struct Context {
 }
 impl Context {
     /// Gets the current tick (local time) count.
-    pub fn current_tick(&self) -> usize {
+    pub fn current_tick(&self) -> TickInstant {
         self.current_tick
     }
 

--- a/hydroflow/src/scheduled/mod.rs
+++ b/hydroflow/src/scheduled/mod.rs
@@ -19,6 +19,8 @@ pub mod reactor;
 pub mod state;
 pub(crate) mod subgraph;
 
+pub mod ticks;
+
 /// A subgraph's ID. Invalid if used in a different [`graph::Hydroflow`]
 /// instance than the original that created it.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize)]

--- a/hydroflow/src/scheduled/ticks.rs
+++ b/hydroflow/src/scheduled/ticks.rs
@@ -59,7 +59,7 @@ pub struct TickInstant(pub u64);
     Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Default, Debug, Serialize, Deserialize,
 )]
 pub struct TickDuration {
-    ticks: i64,
+    pub ticks: i64,
 }
 
 impl TickInstant {

--- a/hydroflow/src/scheduled/ticks.rs
+++ b/hydroflow/src/scheduled/ticks.rs
@@ -59,6 +59,7 @@ pub struct TickInstant(pub u64);
     Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Default, Debug, Serialize, Deserialize,
 )]
 pub struct TickDuration {
+    /// The length of the duration, measured in ticks.
     pub ticks: i64,
 }
 

--- a/hydroflow/src/scheduled/ticks.rs
+++ b/hydroflow/src/scheduled/ticks.rs
@@ -1,0 +1,246 @@
+//! This module contains types to work with ticks.
+//!
+//! Each iteration of a Hydroflow transducer loop is called a tick. Associated with the transducer
+//! is a clock value, which tells you how many ticks were executed by this transducer prior to the
+//! current tick. Each transducer produces totally ordered, sequentially increasing clock values,
+//! which you can think of as the "local logical time" at the transducer.
+
+use std::fmt::{Display, Formatter};
+use std::ops::{Add, AddAssign, Neg, Sub, SubAssign};
+
+use serde::{Deserialize, Serialize};
+
+/// A point in time during execution on transducer.
+///
+/// `TickInstant` instances can be subtracted to calculate the `TickDuration` between them.
+///
+/// ```
+/// # use hydroflow::scheduled::ticks::{TickDuration, TickInstant};
+///
+/// assert_eq!(TickInstant(1) - TickInstant(0), TickDuration::SINGLE_TICK);
+/// assert_eq!(TickInstant(0) - TickInstant(1), -TickDuration::SINGLE_TICK);
+/// ```
+#[derive(
+    Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Default, Debug, Serialize, Deserialize,
+)]
+pub struct TickInstant(pub u64);
+
+/// The duration between two ticks.
+///
+/// `TickDuration` instances can be negative to allow for calculation of `TickInstant` instances in the past.
+///
+/// ```
+/// # use hydroflow::scheduled::ticks::{TickDuration, TickInstant};
+/// assert_eq!(TickInstant(1) + TickDuration::new(-1), TickInstant(0))
+/// ```
+/// `TickDuration` instances can be added/subtracted to/from other `TickDuration` instances
+///
+/// ```
+/// # use hydroflow::scheduled::ticks::TickDuration;
+/// assert_eq!(TickDuration::ZERO + TickDuration::ZERO, TickDuration::ZERO);
+/// assert_eq!(
+///     TickDuration::ZERO + TickDuration::SINGLE_TICK,
+///     TickDuration::SINGLE_TICK
+/// );
+/// assert_eq!(
+///     TickDuration::SINGLE_TICK - TickDuration::ZERO,
+///     TickDuration::SINGLE_TICK
+/// );
+/// assert_eq!(
+///     TickDuration::SINGLE_TICK - TickDuration::SINGLE_TICK,
+///     TickDuration::ZERO
+/// );
+/// assert_eq!(
+///     TickDuration::ZERO - TickDuration::SINGLE_TICK,
+///     -TickDuration::SINGLE_TICK
+/// );
+/// ```
+#[derive(
+    Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Default, Debug, Serialize, Deserialize,
+)]
+pub struct TickDuration {
+    ticks: i64,
+}
+
+impl TickInstant {
+    /// Create a new TickInstant
+    ///
+    /// The specified parameter indicates the number of ticks that have elapsed on the transducer,
+    /// prior to this one.
+    pub fn new(ticks: u64) -> Self {
+        TickInstant(ticks)
+    }
+}
+
+impl TickDuration {
+    /// A zero duration
+    ///
+    /// It is the identity element for addition for both `TickDuration` and
+    /// `TickInstant` (i.e. adding zero duration to a `TickInstant` or `TickDuration` results in
+    /// the same `TickInstant` or `TickDuration`.
+    ///
+    /// ```
+    /// # use hydroflow::scheduled::ticks::{TickDuration, TickInstant};
+    /// # use hydroflow_lang::graph::ops::DelayType::Tick;
+    /// let ticks = TickInstant::new(100);
+    /// assert_eq!(ticks + TickDuration::ZERO, ticks);
+    /// assert_eq!(ticks - TickDuration::ZERO, ticks);
+    ///
+    /// let duration = TickDuration::new(100);
+    /// assert_eq!(duration + TickDuration::ZERO, duration);
+    /// assert_eq!(duration - TickDuration::ZERO, duration);
+    /// ```
+    pub const ZERO: Self = TickDuration { ticks: 0 };
+
+    /// A single tick duration.
+    ///
+    /// It is the duration between two consecutive `TickInstant` instances.
+    ///
+    /// ```
+    /// # use hydroflow::scheduled::ticks::{TickDuration, TickInstant};
+    /// assert_eq!(TickInstant(0) + TickDuration::SINGLE_TICK, TickInstant(1))
+    /// ```
+    pub const SINGLE_TICK: Self = TickDuration { ticks: 1 };
+
+    /// Create a new `TickDuration` for the specified tick interval.
+    ///
+    /// A negative duration allows for calculating `TickInstants` in the past and represents a
+    /// backward movement in time.
+    pub fn new(ticks: i64) -> TickDuration {
+        TickDuration { ticks }
+    }
+}
+
+impl Add<TickDuration> for TickInstant {
+    type Output = TickInstant;
+
+    fn add(self, rhs: TickDuration) -> Self::Output {
+        let mut result = self;
+        result += rhs;
+        result
+    }
+}
+
+impl AddAssign<TickDuration> for TickInstant {
+    fn add_assign(&mut self, rhs: TickDuration) {
+        self.0 = self
+            .0
+            .checked_add_signed(rhs.ticks)
+            .expect("overflow while adding tick duration to tick instant.");
+    }
+}
+
+impl Sub<TickDuration> for TickInstant {
+    type Output = TickInstant;
+
+    fn sub(self, rhs: TickDuration) -> Self::Output {
+        let mut result = self;
+        result -= rhs;
+        result
+    }
+}
+
+impl SubAssign<TickDuration> for TickInstant {
+    fn sub_assign(&mut self, rhs: TickDuration) {
+        if rhs.ticks.is_positive() {
+            self.0 = self
+                .0
+                .checked_sub(rhs.ticks.unsigned_abs())
+                .expect("overflow while subtracting duration from instant.");
+        } else if rhs.ticks.is_negative() {
+            self.0 = self
+                .0
+                .checked_add(rhs.ticks.unsigned_abs())
+                .expect("overflow while subtracting duration from instant.")
+        }
+    }
+}
+
+impl Sub for TickInstant {
+    type Output = TickDuration;
+
+    fn sub(self, rhs: TickInstant) -> Self::Output {
+        let minuend = (self.0 as i64).wrapping_add(i64::MIN);
+        let subtrahend = (rhs.0 as i64).wrapping_add(i64::MIN);
+        let (difference, overflowed) = minuend.overflowing_sub(subtrahend);
+        if overflowed {
+            panic!("overflow while subtracting two TickInstants.")
+        }
+        TickDuration { ticks: difference }
+    }
+}
+
+impl Add for TickDuration {
+    type Output = TickDuration;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let mut result = self;
+        result += rhs;
+        result
+    }
+}
+
+impl AddAssign for TickDuration {
+    fn add_assign(&mut self, rhs: Self) {
+        self.ticks = self
+            .ticks
+            .checked_add(rhs.ticks)
+            .expect("Overflow occurred while adding TickDuration instances.")
+    }
+}
+
+impl Sub for TickDuration {
+    type Output = TickDuration;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        let mut result = self;
+        result -= rhs;
+        result
+    }
+}
+
+impl SubAssign for TickDuration {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.ticks = self
+            .ticks
+            .checked_sub(rhs.ticks)
+            .expect("Overflow occurred while subtracting TickDuration instances.");
+    }
+}
+
+impl Neg for TickDuration {
+    type Output = TickDuration;
+
+    fn neg(self) -> Self::Output {
+        TickDuration {
+            ticks: self
+                .ticks
+                .checked_neg()
+                .expect("Overflow while negating duration."),
+        }
+    }
+}
+
+impl Display for TickInstant {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}]", self.0)
+    }
+}
+
+impl Display for TickDuration {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<{}>", self.ticks)
+    }
+}
+
+impl From<TickInstant> for u64 {
+    fn from(value: TickInstant) -> Self {
+        value.0
+    }
+}
+
+impl From<TickDuration> for i64 {
+    fn from(value: TickDuration) -> Self {
+        value.ticks
+    }
+}

--- a/hydroflow/tests/snapshots/surface_scheduling__stratum_loop@graphvis_dot.snap
+++ b/hydroflow/tests/snapshots/surface_scheduling__stratum_loop@graphvis_dot.snap
@@ -5,11 +5,11 @@ expression: "df.meta_graph().unwrap().to_dot(&Default::default())"
 digraph {
     node [fontname="Monaco,Menlo,Consolas,&quot;Droid Sans Mono&quot;,Inconsolata,&quot;Courier New&quot;,monospace", style=filled];
     edge [fontname="Monaco,Menlo,Consolas,&quot;Droid Sans Mono&quot;,Inconsolata,&quot;Courier New&quot;,monospace"];
-    n1v1 [label="(n1v1) source_iter([0])", shape=invhouse, fillcolor="#88aaff"]
+    n1v1 [label="(n1v1) source_iter([TickInstant::new(0)])", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) union()", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) tee()", shape=house, fillcolor="#ffff88"]
-    n4v1 [label="(n4v1) map(|n| n + 1)", shape=house, fillcolor="#ffff88"]
-    n5v1 [label="(n5v1) filter(|&n| n < 10)", shape=invhouse, fillcolor="#88aaff"]
+    n4v1 [label="(n4v1) map(|n| n + TickDuration::SINGLE_TICK)", shape=house, fillcolor="#ffff88"]
+    n5v1 [label="(n5v1) filter(|&n| n < TickInstant::new(10))", shape=invhouse, fillcolor="#88aaff"]
     n6v1 [label="(n6v1) next_stratum()", shape=invhouse, fillcolor="#88aaff"]
     n7v1 [label="(n7v1) for_each(|v| out_send.send(v).unwrap())", shape=house, fillcolor="#ffff88"]
     n8v1 [label="(n8v1) handoff", shape=parallelogram, fillcolor="#ddddff"]

--- a/hydroflow/tests/snapshots/surface_scheduling__stratum_loop@graphvis_mermaid.snap
+++ b/hydroflow/tests/snapshots/surface_scheduling__stratum_loop@graphvis_mermaid.snap
@@ -8,11 +8,11 @@ classDef pullClass fill:#8af,stroke:#000,text-align:left,white-space:pre
 classDef pushClass fill:#ff8,stroke:#000,text-align:left,white-space:pre
 classDef otherClass fill:#fdc,stroke:#000,text-align:left,white-space:pre
 linkStyle default stroke:#aaa
-1v1[\"(1v1) <code>source_iter([0])</code>"/]:::pullClass
+1v1[\"(1v1) <code>source_iter([TickInstant::new(0)])</code>"/]:::pullClass
 2v1[\"(2v1) <code>union()</code>"/]:::pullClass
 3v1[/"(3v1) <code>tee()</code>"\]:::pushClass
-4v1[/"(4v1) <code>map(|n| n + 1)</code>"\]:::pushClass
-5v1[\"(5v1) <code>filter(|&amp;n| n &lt; 10)</code>"/]:::pullClass
+4v1[/"(4v1) <code>map(|n| n + TickDuration::SINGLE_TICK)</code>"\]:::pushClass
+5v1[\"(5v1) <code>filter(|&amp;n| n &lt; TickInstant::new(10))</code>"/]:::pullClass
 6v1[\"(6v1) <code>next_stratum()</code>"/]:::pullClass
 7v1[/"(7v1) <code>for_each(|v| out_send.send(v).unwrap())</code>"\]:::pushClass
 8v1["(8v1) <code>handoff</code>"]:::otherClass

--- a/hydroflow/tests/snapshots/surface_scheduling__tick_loop@graphvis_dot.snap
+++ b/hydroflow/tests/snapshots/surface_scheduling__tick_loop@graphvis_dot.snap
@@ -5,11 +5,11 @@ expression: "df.meta_graph().unwrap().to_dot(&Default::default())"
 digraph {
     node [fontname="Monaco,Menlo,Consolas,&quot;Droid Sans Mono&quot;,Inconsolata,&quot;Courier New&quot;,monospace", style=filled];
     edge [fontname="Monaco,Menlo,Consolas,&quot;Droid Sans Mono&quot;,Inconsolata,&quot;Courier New&quot;,monospace"];
-    n1v1 [label="(n1v1) source_iter([0])", shape=invhouse, fillcolor="#88aaff"]
+    n1v1 [label="(n1v1) source_iter([TickInstant::new(0)])", shape=invhouse, fillcolor="#88aaff"]
     n2v1 [label="(n2v1) union()", shape=invhouse, fillcolor="#88aaff"]
     n3v1 [label="(n3v1) tee()", shape=house, fillcolor="#ffff88"]
-    n4v1 [label="(n4v1) map(|n| n + 1)", shape=house, fillcolor="#ffff88"]
-    n5v1 [label="(n5v1) filter(|&n| n < 10)", shape=invhouse, fillcolor="#88aaff"]
+    n4v1 [label="(n4v1) map(|n| n + TickDuration::SINGLE_TICK)", shape=house, fillcolor="#ffff88"]
+    n5v1 [label="(n5v1) filter(|&n| n < TickInstant::new(10))", shape=invhouse, fillcolor="#88aaff"]
     n6v1 [label="(n6v1) defer_tick()", shape=invhouse, fillcolor="#88aaff"]
     n7v1 [label="(n7v1) for_each(|v| out_send.send(v).unwrap())", shape=house, fillcolor="#ffff88"]
     n8v1 [label="(n8v1) handoff", shape=parallelogram, fillcolor="#ddddff"]

--- a/hydroflow/tests/snapshots/surface_scheduling__tick_loop@graphvis_mermaid.snap
+++ b/hydroflow/tests/snapshots/surface_scheduling__tick_loop@graphvis_mermaid.snap
@@ -8,11 +8,11 @@ classDef pullClass fill:#8af,stroke:#000,text-align:left,white-space:pre
 classDef pushClass fill:#ff8,stroke:#000,text-align:left,white-space:pre
 classDef otherClass fill:#fdc,stroke:#000,text-align:left,white-space:pre
 linkStyle default stroke:#aaa
-1v1[\"(1v1) <code>source_iter([0])</code>"/]:::pullClass
+1v1[\"(1v1) <code>source_iter([TickInstant::new(0)])</code>"/]:::pullClass
 2v1[\"(2v1) <code>union()</code>"/]:::pullClass
 3v1[/"(3v1) <code>tee()</code>"\]:::pushClass
-4v1[/"(4v1) <code>map(|n| n + 1)</code>"\]:::pushClass
-5v1[\"(5v1) <code>filter(|&amp;n| n &lt; 10)</code>"/]:::pullClass
+4v1[/"(4v1) <code>map(|n| n + TickDuration::SINGLE_TICK)</code>"\]:::pushClass
+5v1[\"(5v1) <code>filter(|&amp;n| n &lt; TickInstant::new(10))</code>"/]:::pullClass
 6v1[\"(6v1) <code>defer_tick()</code>"/]:::pullClass
 7v1[/"(7v1) <code>for_each(|v| out_send.send(v).unwrap())</code>"\]:::pushClass
 8v1["(8v1) <code>handoff</code>"]:::otherClass

--- a/hydroflow/tests/surface_codegen.rs
+++ b/hydroflow/tests/surface_codegen.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use hydroflow::scheduled::graph::Hydroflow;
+use hydroflow::scheduled::ticks::TickInstant;
 use hydroflow::util::collect_ready;
 use hydroflow::util::multiset::HashMultiSet;
 use hydroflow::{assert_graphvis_snapshots, hydroflow_syntax};
@@ -856,7 +857,9 @@ pub fn test_iter_stream_batches() {
     let stream = hydroflow::util::iter_batches_stream(0..ITEMS, BATCH);
 
     // expect 5 items per tick.
-    let expected: Vec<_> = (0..ITEMS).map(|n| (n / BATCH, n)).collect();
+    let expected: Vec<_> = (0..ITEMS)
+        .map(|n| (TickInstant::new((n / BATCH).try_into().unwrap()), n))
+        .collect();
 
     let mut df = hydroflow_syntax! {
         source_stream(stream)

--- a/hydroflow/tests/surface_fold.rs
+++ b/hydroflow/tests/surface_fold.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use hydroflow::scheduled::ticks::TickInstant;
 use hydroflow::util::collect_ready;
 use hydroflow::{assert_graphvis_snapshots, hydroflow_syntax};
 use multiplatform_test::multiplatform_test;
@@ -16,13 +17,19 @@ pub fn test_fold_tick() {
     };
     assert_graphvis_snapshots!(df);
 
-    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(0), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     items_send.send(vec![1, 2]).unwrap();
     items_send.send(vec![3, 4]).unwrap();
     df.run_tick();
 
-    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(1), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     assert_eq!(
         &[vec![1, 2, 3, 4]],
         &*collect_ready::<Vec<_>, _>(&mut result_recv)
@@ -32,7 +39,10 @@ pub fn test_fold_tick() {
     items_send.send(vec![7, 8]).unwrap();
     df.run_tick();
 
-    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(2), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     assert_eq!(
         &[vec![5, 6, 7, 8]],
         &*collect_ready::<Vec<_>, _>(&mut result_recv)
@@ -53,13 +63,19 @@ pub fn test_fold_static() {
     };
     assert_graphvis_snapshots!(df);
 
-    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(0), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     items_send.send(vec![1, 2]).unwrap();
     items_send.send(vec![3, 4]).unwrap();
     df.run_tick();
 
-    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(1), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     assert_eq!(
         &[vec![1, 2, 3, 4]],
         &*collect_ready::<Vec<_>, _>(&mut result_recv)
@@ -69,7 +85,10 @@ pub fn test_fold_static() {
     items_send.send(vec![7, 8]).unwrap();
     df.run_tick();
 
-    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(2), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     assert_eq!(
         &[vec![1, 2, 3, 4, 5, 6, 7, 8]],
         &*collect_ready::<Vec<_>, _>(&mut result_recv)
@@ -92,9 +111,15 @@ pub fn test_fold_flatten() {
             -> for_each(|(k,v)| out_send.send((k,v)).unwrap());
     };
 
-    assert_eq!((0, 0), (df_pull.current_tick(), df_pull.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(0), 0),
+        (df_pull.current_tick(), df_pull.current_stratum())
+    );
     df_pull.run_tick();
-    assert_eq!((1, 0), (df_pull.current_tick(), df_pull.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(1), 0),
+        (df_pull.current_tick(), df_pull.current_stratum())
+    );
 
     let out: HashSet<_> = collect_ready(&mut out_recv);
     for pair in [(1, 3), (2, 7)] {
@@ -113,9 +138,15 @@ pub fn test_fold_flatten() {
             -> for_each(|(k,v)| out_send.send((k,v)).unwrap());
         datagen[1] -> null();
     };
-    assert_eq!((0, 0), (df_push.current_tick(), df_push.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(0), 0),
+        (df_push.current_tick(), df_push.current_stratum())
+    );
     df_push.run_tick();
-    assert_eq!((1, 0), (df_push.current_tick(), df_push.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(1), 0),
+        (df_push.current_tick(), df_push.current_stratum())
+    );
 
     let out: HashSet<_> = collect_ready(&mut out_recv);
     for pair in [(1, 4), (2, 8)] {
@@ -137,9 +168,15 @@ pub fn test_fold_sort() {
             -> for_each(|v| print!("{:?}, ", v));
     };
     assert_graphvis_snapshots!(df);
-    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(0), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(1), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     print!("\nA: ");
 
@@ -147,7 +184,10 @@ pub fn test_fold_sort() {
     items_send.send(2).unwrap();
     items_send.send(5).unwrap();
     df.run_tick();
-    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(2), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     print!("\nB: ");
 
@@ -157,7 +197,10 @@ pub fn test_fold_sort() {
     items_send.send(0).unwrap();
     items_send.send(3).unwrap();
     df.run_tick();
-    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(3), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     println!();
 

--- a/hydroflow/tests/surface_join.rs
+++ b/hydroflow/tests/surface_join.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use hydroflow::scheduled::ticks::TickInstant;
 use hydroflow::{assert_graphvis_snapshots, hydroflow_syntax};
 use multiplatform_test::multiplatform_test;
 
@@ -23,7 +24,7 @@ macro_rules! assert_contains_each_by_tick {
 
 #[multiplatform_test]
 pub fn tick_tick() {
-    let results = Rc::new(RefCell::new(HashMap::<usize, Vec<_>>::new()));
+    let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
     let mut df = hydroflow_syntax! {
@@ -42,13 +43,13 @@ pub fn tick_tick() {
     assert_graphvis_snapshots!(df);
     df.run_available();
 
-    assert_contains_each_by_tick!(results, 0, &[(7, (1, 0)), (7, (2, 0))]);
-    assert_contains_each_by_tick!(results, 1, &[]);
+    assert_contains_each_by_tick!(results, TickInstant::new(0), &[(7, (1, 0)), (7, (2, 0))]);
+    assert_contains_each_by_tick!(results, TickInstant::new(1), &[]);
 }
 
 #[multiplatform_test]
 pub fn tick_static() {
-    let results = Rc::new(RefCell::new(HashMap::<usize, Vec<_>>::new()));
+    let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
     let mut df = hydroflow_syntax! {
@@ -67,13 +68,13 @@ pub fn tick_static() {
     assert_graphvis_snapshots!(df);
     df.run_available();
 
-    assert_contains_each_by_tick!(results, 0, &[(7, (1, 0)), (7, (2, 0))]);
-    assert_contains_each_by_tick!(results, 1, &[]);
+    assert_contains_each_by_tick!(results, TickInstant::new(0), &[(7, (1, 0)), (7, (2, 0))]);
+    assert_contains_each_by_tick!(results, TickInstant::new(1), &[]);
 }
 
 #[multiplatform_test]
 pub fn static_tick() {
-    let results = Rc::new(RefCell::new(HashMap::<usize, Vec<_>>::new()));
+    let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
     let mut df = hydroflow_syntax! {
@@ -92,15 +93,15 @@ pub fn static_tick() {
     assert_graphvis_snapshots!(df);
     df.run_available();
 
-    assert_contains_each_by_tick!(results, 0, &[(7, (1, 0)), (7, (2, 0))]);
-    assert_contains_each_by_tick!(results, 1, &[(7, (1, 1)), (7, (2, 1))]);
-    assert_contains_each_by_tick!(results, 2, &[(7, (1, 2)), (7, (2, 2))]);
-    assert_contains_each_by_tick!(results, 3, &[]);
+    assert_contains_each_by_tick!(results, TickInstant::new(0), &[(7, (1, 0)), (7, (2, 0))]);
+    assert_contains_each_by_tick!(results, TickInstant::new(1), &[(7, (1, 1)), (7, (2, 1))]);
+    assert_contains_each_by_tick!(results, TickInstant::new(2), &[(7, (1, 2)), (7, (2, 2))]);
+    assert_contains_each_by_tick!(results, TickInstant::new(3), &[]);
 }
 
 #[multiplatform_test]
 pub fn static_static() {
-    let results = Rc::new(RefCell::new(HashMap::<usize, Vec<_>>::new()));
+    let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
     let mut df = hydroflow_syntax! {
@@ -121,9 +122,9 @@ pub fn static_static() {
 
     #[rustfmt::skip]
     {
-        assert_contains_each_by_tick!(results, 0, &[(7, (1, 0)), (7, (2, 0))]);
-        assert_contains_each_by_tick!(results, 1, &[(7, (1, 0)), (7, (2, 0)), (7, (1, 1)), (7, (2, 1))]);
-        assert_contains_each_by_tick!(results, 2, &[(7, (1, 0)), (7, (2, 0)), (7, (1, 1)), (7, (2, 1)), (7, (1, 2)), (7, (2, 2))]);
-        assert_contains_each_by_tick!(results, 3, &[]);
+        assert_contains_each_by_tick!(results, TickInstant::new(0), &[(7, (1, 0)), (7, (2, 0))]);
+        assert_contains_each_by_tick!(results, TickInstant::new(1), &[(7, (1, 0)), (7, (2, 0)), (7, (1, 1)), (7, (2, 1))]);
+        assert_contains_each_by_tick!(results, TickInstant::new(2), &[(7, (1, 0)), (7, (2, 0)), (7, (1, 1)), (7, (2, 1)), (7, (1, 2)), (7, (2, 2))]);
+        assert_contains_each_by_tick!(results, TickInstant::new(3), &[]);
     };
 }

--- a/hydroflow/tests/surface_join_fused.rs
+++ b/hydroflow/tests/surface_join_fused.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use hydroflow::lattices::set_union::SetUnionSingletonSet;
+use hydroflow::scheduled::ticks::TickInstant;
 use hydroflow::{assert_graphvis_snapshots, hydroflow_syntax};
 use lattices::set_union::SetUnionHashSet;
 use lattices::Merge;
@@ -23,7 +24,7 @@ macro_rules! assert_contains_each_by_tick {
 
 #[multiplatform_test]
 pub fn tick_tick_lhs_blocking_rhs_streaming() {
-    let results = Rc::new(RefCell::new(HashMap::<usize, Vec<_>>::new()));
+    let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
     let mut df = hydroflow_syntax! {
@@ -43,12 +44,16 @@ pub fn tick_tick_lhs_blocking_rhs_streaming() {
     assert_graphvis_snapshots!(df);
     df.run_available();
 
-    assert_contains_each_by_tick!(results, 0, &[(7, (SetUnionHashSet::new_from([1, 2]), 0))]);
+    assert_contains_each_by_tick!(
+        results,
+        TickInstant::new(0),
+        &[(7, (SetUnionHashSet::new_from([1, 2]), 0))]
+    );
 }
 
 #[multiplatform_test]
 pub fn static_tick_lhs_blocking_rhs_streaming() {
-    let results = Rc::new(RefCell::new(HashMap::<usize, Vec<_>>::new()));
+    let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
     let mut df = hydroflow_syntax! {
@@ -68,14 +73,26 @@ pub fn static_tick_lhs_blocking_rhs_streaming() {
     assert_graphvis_snapshots!(df);
     df.run_available();
 
-    assert_contains_each_by_tick!(results, 0, &[(7, (SetUnionHashSet::new_from([1, 2]), 0))]);
-    assert_contains_each_by_tick!(results, 1, &[(7, (SetUnionHashSet::new_from([1, 2]), 1))]);
-    assert_contains_each_by_tick!(results, 2, &[(7, (SetUnionHashSet::new_from([1, 2]), 2))]);
+    assert_contains_each_by_tick!(
+        results,
+        TickInstant::new(0),
+        &[(7, (SetUnionHashSet::new_from([1, 2]), 0))]
+    );
+    assert_contains_each_by_tick!(
+        results,
+        TickInstant::new(1),
+        &[(7, (SetUnionHashSet::new_from([1, 2]), 1))]
+    );
+    assert_contains_each_by_tick!(
+        results,
+        TickInstant::new(2),
+        &[(7, (SetUnionHashSet::new_from([1, 2]), 2))]
+    );
 }
 
 #[multiplatform_test]
 pub fn static_static_lhs_blocking_rhs_streaming() {
-    let results = Rc::new(RefCell::new(HashMap::<usize, Vec<_>>::new()));
+    let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
     let mut df = hydroflow_syntax! {
@@ -97,15 +114,15 @@ pub fn static_static_lhs_blocking_rhs_streaming() {
 
     #[rustfmt::skip]
     {
-        assert_contains_each_by_tick!(results, 0, &[(7, (SetUnionHashSet::new_from([1, 2]), 0))]);
-        assert_contains_each_by_tick!(results, 1, &[(7, (SetUnionHashSet::new_from([1, 2]), 0)), (7, (SetUnionHashSet::new_from([1, 2]), 1))]);
-        assert_contains_each_by_tick!(results, 2, &[(7, (SetUnionHashSet::new_from([1, 2]), 0)), (7, (SetUnionHashSet::new_from([1, 2]), 1)), (7, (SetUnionHashSet::new_from([1, 2]), 2))]);
+        assert_contains_each_by_tick!(results, TickInstant::new(0), &[(7, (SetUnionHashSet::new_from([1, 2]), 0))]);
+        assert_contains_each_by_tick!(results, TickInstant::new(1), &[(7, (SetUnionHashSet::new_from([1, 2]), 0)), (7, (SetUnionHashSet::new_from([1, 2]), 1))]);
+        assert_contains_each_by_tick!(results, TickInstant::new(2), &[(7, (SetUnionHashSet::new_from([1, 2]), 0)), (7, (SetUnionHashSet::new_from([1, 2]), 1)), (7, (SetUnionHashSet::new_from([1, 2]), 2))]);
     };
 }
 
 #[multiplatform_test]
 pub fn tick_tick_lhs_streaming_rhs_blocking() {
-    let results = Rc::new(RefCell::new(HashMap::<usize, Vec<_>>::new()));
+    let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
     let mut df = hydroflow_syntax! {
@@ -125,12 +142,16 @@ pub fn tick_tick_lhs_streaming_rhs_blocking() {
     assert_graphvis_snapshots!(df);
     df.run_available();
 
-    assert_contains_each_by_tick!(results, 0, &[(7, (0, (SetUnionHashSet::new_from([1, 2]))))]);
+    assert_contains_each_by_tick!(
+        results,
+        TickInstant::new(0),
+        &[(7, (0, (SetUnionHashSet::new_from([1, 2]))))]
+    );
 }
 
 #[multiplatform_test]
 pub fn static_tick_lhs_streaming_rhs_blocking() {
-    let results = Rc::new(RefCell::new(HashMap::<usize, Vec<_>>::new()));
+    let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
     let mut df = hydroflow_syntax! {
@@ -150,14 +171,26 @@ pub fn static_tick_lhs_streaming_rhs_blocking() {
     assert_graphvis_snapshots!(df);
     df.run_available();
 
-    assert_contains_each_by_tick!(results, 0, &[(7, (0, SetUnionHashSet::new_from([1, 2])))]);
-    assert_contains_each_by_tick!(results, 1, &[(7, (1, SetUnionHashSet::new_from([1, 2])))]);
-    assert_contains_each_by_tick!(results, 2, &[(7, (2, SetUnionHashSet::new_from([1, 2])))]);
+    assert_contains_each_by_tick!(
+        results,
+        TickInstant::new(0),
+        &[(7, (0, SetUnionHashSet::new_from([1, 2])))]
+    );
+    assert_contains_each_by_tick!(
+        results,
+        TickInstant::new(1),
+        &[(7, (1, SetUnionHashSet::new_from([1, 2])))]
+    );
+    assert_contains_each_by_tick!(
+        results,
+        TickInstant::new(2),
+        &[(7, (2, SetUnionHashSet::new_from([1, 2])))]
+    );
 }
 
 #[multiplatform_test]
 pub fn static_static_lhs_streaming_rhs_blocking() {
-    let results = Rc::new(RefCell::new(HashMap::<usize, Vec<_>>::new()));
+    let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
     let mut df = hydroflow_syntax! {
@@ -180,15 +213,15 @@ pub fn static_static_lhs_streaming_rhs_blocking() {
 
     #[rustfmt::skip]
     {
-        assert_contains_each_by_tick!(results, 0, &[(7, (0, SetUnionHashSet::new_from([1, 2])))]);
-        assert_contains_each_by_tick!(results, 1, &[(7, (0, SetUnionHashSet::new_from([1, 2]))), (7, (1, SetUnionHashSet::new_from([1, 2])))]);
-        assert_contains_each_by_tick!(results, 2, &[(7, (0, SetUnionHashSet::new_from([1, 2]))), (7, (1, SetUnionHashSet::new_from([1, 2]))), (7, (2, SetUnionHashSet::new_from([1, 2])))]);
+        assert_contains_each_by_tick!(results, TickInstant::new(0), &[(7, (0, SetUnionHashSet::new_from([1, 2])))]);
+        assert_contains_each_by_tick!(results, TickInstant::new(1), &[(7, (0, SetUnionHashSet::new_from([1, 2]))), (7, (1, SetUnionHashSet::new_from([1, 2])))]);
+        assert_contains_each_by_tick!(results, TickInstant::new(2), &[(7, (0, SetUnionHashSet::new_from([1, 2]))), (7, (1, SetUnionHashSet::new_from([1, 2]))), (7, (2, SetUnionHashSet::new_from([1, 2])))]);
     };
 }
 
 #[multiplatform_test]
 pub fn tick_tick_lhs_fold_rhs_reduce() {
-    let results = Rc::new(RefCell::new(HashMap::<usize, Vec<_>>::new()));
+    let results = Rc::new(RefCell::new(HashMap::<TickInstant, Vec<_>>::new()));
     let results_inner = Rc::clone(&results);
 
     let mut df = hydroflow_syntax! {
@@ -208,5 +241,9 @@ pub fn tick_tick_lhs_fold_rhs_reduce() {
     assert_graphvis_snapshots!(df);
     df.run_available();
 
-    assert_contains_each_by_tick!(results, 0, &[(7, (SetUnionHashSet::new_from([1, 2]), 0))]);
+    assert_contains_each_by_tick!(
+        results,
+        TickInstant::new(0),
+        &[(7, (SetUnionHashSet::new_from([1, 2]), 0))]
+    );
 }

--- a/hydroflow/tests/surface_keyed_fold.rs
+++ b/hydroflow/tests/surface_keyed_fold.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 
 use hydroflow::assert_graphvis_snapshots;
+use hydroflow::scheduled::ticks::TickInstant;
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]
@@ -25,9 +26,15 @@ pub fn test_fold_keyed_infer_basic() {
             -> for_each(|kv| result_send.send(kv).unwrap());
     };
     assert_graphvis_snapshots!(df);
-    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(0), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(1), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     df.run_available(); // Should return quickly and not hang
 
@@ -48,9 +55,15 @@ pub fn test_fold_keyed_tick() {
             -> for_each(|v| result_send.send(v).unwrap());
     };
     assert_graphvis_snapshots!(df);
-    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(0), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(1), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     items_send.send((0, vec![1, 2])).unwrap();
     items_send.send((0, vec![3, 4])).unwrap();
@@ -58,7 +71,10 @@ pub fn test_fold_keyed_tick() {
     items_send.send((1, vec![1, 2])).unwrap();
     df.run_tick();
 
-    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(2), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     assert_eq!(
         [(0, vec![1, 2, 3, 4]), (1, vec![1, 1, 2])]
             .into_iter()
@@ -72,7 +88,10 @@ pub fn test_fold_keyed_tick() {
     items_send.send((1, vec![11, 12])).unwrap();
     df.run_tick();
 
-    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(3), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     assert_eq!(
         [(0, vec![5, 6, 7, 8]), (1, vec![10, 11, 12])]
             .into_iter()
@@ -94,9 +113,15 @@ pub fn test_fold_keyed_static() {
             -> for_each(|v| result_send.send(v).unwrap());
     };
     assert_graphvis_snapshots!(df);
-    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(0), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(1), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     items_send.send((0, vec![1, 2])).unwrap();
     items_send.send((0, vec![3, 4])).unwrap();
@@ -104,7 +129,10 @@ pub fn test_fold_keyed_static() {
     items_send.send((1, vec![1, 2])).unwrap();
     df.run_tick();
 
-    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(2), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     assert_eq!(
         [(0, vec![1, 2, 3, 4]), (1, vec![1, 1, 2])]
             .into_iter()
@@ -118,7 +146,10 @@ pub fn test_fold_keyed_static() {
     items_send.send((1, vec![11, 12])).unwrap();
     df.run_tick();
 
-    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(3), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     assert_eq!(
         [
             (0, vec![1, 2, 3, 4, 5, 6, 7, 8]),

--- a/hydroflow/tests/surface_persist.rs
+++ b/hydroflow/tests/surface_persist.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use hydroflow::compiled::pull::HalfMultisetJoinState;
+use hydroflow::scheduled::ticks::TickInstant;
 use hydroflow::util::collect_ready;
 use hydroflow::{assert_graphvis_snapshots, hydroflow_syntax};
 use multiplatform_test::multiplatform_test;
@@ -19,7 +20,7 @@ pub fn test_persist_basic() {
     assert_graphvis_snapshots!(hf);
 
     for tick in 0..10 {
-        assert_eq!(tick, hf.current_tick());
+        assert_eq!(TickInstant::new(tick), hf.current_tick());
         hf.run_tick();
     }
     assert_eq!(
@@ -45,7 +46,7 @@ pub fn test_persist_pull() {
     assert_graphvis_snapshots!(hf);
 
     for tick in 0..10 {
-        assert_eq!(tick, hf.current_tick());
+        assert_eq!(TickInstant::new(tick), hf.current_tick());
         hf.run_tick();
     }
     assert_eq!(
@@ -68,7 +69,7 @@ pub fn test_persist_push() {
     assert_graphvis_snapshots!(hf);
 
     for tick in 0..10 {
-        assert_eq!(tick, hf.current_tick());
+        assert_eq!(TickInstant::new(tick), hf.current_tick());
         hf.run_tick();
     }
     assert_eq!(

--- a/hydroflow/tests/surface_reduce.rs
+++ b/hydroflow/tests/surface_reduce.rs
@@ -1,3 +1,4 @@
+use hydroflow::scheduled::ticks::TickInstant;
 use hydroflow::{assert_graphvis_snapshots, hydroflow_syntax};
 use multiplatform_test::multiplatform_test;
 
@@ -12,13 +13,19 @@ pub fn test_reduce_tick() {
             -> for_each(|v| result_send.send(v).unwrap());
     };
     assert_graphvis_snapshots!(df);
-    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(0), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     items_send.send(1).unwrap();
     items_send.send(2).unwrap();
     df.run_tick();
 
-    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(1), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     assert_eq!(
         &[3],
         &*hydroflow::util::collect_ready::<Vec<_>, _>(&mut result_recv)
@@ -28,7 +35,10 @@ pub fn test_reduce_tick() {
     items_send.send(4).unwrap();
     df.run_tick();
 
-    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(2), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     assert_eq!(
         &[7],
         &*hydroflow::util::collect_ready::<Vec<_>, _>(&mut result_recv)
@@ -46,13 +56,19 @@ pub fn test_reduce_static() {
             -> for_each(|v| result_send.send(v).unwrap());
     };
     assert_graphvis_snapshots!(df);
-    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(0), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     items_send.send(1).unwrap();
     items_send.send(2).unwrap();
     df.run_tick();
 
-    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(1), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     assert_eq!(
         &[3],
         &*hydroflow::util::collect_ready::<Vec<_>, _>(&mut result_recv)
@@ -62,7 +78,10 @@ pub fn test_reduce_static() {
     items_send.send(4).unwrap();
     df.run_tick();
 
-    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(2), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     assert_eq!(
         &[10],
         &*hydroflow::util::collect_ready::<Vec<_>, _>(&mut result_recv)
@@ -79,9 +98,15 @@ pub fn test_reduce_sum() {
             -> for_each(|v| print!("{:?}", v));
     };
     assert_graphvis_snapshots!(df);
-    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(0), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(1), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     print!("\nA: ");
 
@@ -89,7 +114,10 @@ pub fn test_reduce_sum() {
     items_send.send(2).unwrap();
     items_send.send(5).unwrap();
     df.run_tick();
-    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(2), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     print!("\nB: ");
 
@@ -99,7 +127,10 @@ pub fn test_reduce_sum() {
     items_send.send(0).unwrap();
     items_send.send(3).unwrap();
     df.run_tick();
-    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(3), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     println!();
 }
@@ -123,9 +154,15 @@ pub fn test_reduce() {
         my_join_tee[1] -> reduce(|a: &mut _, b| *a += b) -> for_each(|sum| println!("{}", sum));
     };
     assert_graphvis_snapshots!(df);
-    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(0), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(1), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     println!("A");
 
@@ -134,12 +171,18 @@ pub fn test_reduce() {
     pairs_send.send((3, 4)).unwrap();
     pairs_send.send((1, 2)).unwrap();
     df.run_tick();
-    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(2), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     println!("B");
 
     pairs_send.send((0, 3)).unwrap();
     pairs_send.send((0, 3)).unwrap();
     df.run_tick();
-    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(3), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 }

--- a/hydroflow/tests/surface_scheduling.rs
+++ b/hydroflow/tests/surface_scheduling.rs
@@ -1,48 +1,77 @@
 use std::error::Error;
 use std::time::Duration;
 
+use hydroflow::scheduled::ticks::{TickDuration, TickInstant};
 use hydroflow::{assert_graphvis_snapshots, hydroflow_syntax, rassert_eq};
 use multiplatform_test::multiplatform_test;
 use tokio::time::timeout;
 
 #[multiplatform_test(test, wasm, env_tracing)]
 pub fn test_stratum_loop() {
-    let (out_send, mut out_recv) = hydroflow::util::unbounded_channel::<usize>();
+    let (out_send, mut out_recv) = hydroflow::util::unbounded_channel::<TickInstant>();
 
     let mut df = hydroflow_syntax! {
-        source_iter([0]) -> union_tee;
+        source_iter([TickInstant::new(0)]) -> union_tee;
         union_tee = union() -> tee();
-        union_tee -> map(|n| n + 1) -> filter(|&n| n < 10) -> next_stratum() -> union_tee;
+        union_tee -> map(|n| n + TickDuration::SINGLE_TICK) -> filter(|&n| n < TickInstant::new(10)) -> next_stratum() -> union_tee;
         union_tee -> for_each(|v| out_send.send(v).unwrap());
     };
     assert_graphvis_snapshots!(df);
     df.run_available();
 
     assert_eq!(
-        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        &[
+            TickInstant::new(0),
+            TickInstant::new(1),
+            TickInstant::new(2),
+            TickInstant::new(3),
+            TickInstant::new(4),
+            TickInstant::new(5),
+            TickInstant::new(6),
+            TickInstant::new(7),
+            TickInstant::new(8),
+            TickInstant::new(9)
+        ],
         &*hydroflow::util::collect_ready::<Vec<_>, _>(&mut out_recv)
     );
-    assert_eq!((11, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(11), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 }
 
 #[multiplatform_test(test, wasm, env_tracing)]
 pub fn test_tick_loop() {
-    let (out_send, mut out_recv) = hydroflow::util::unbounded_channel::<usize>();
+    let (out_send, mut out_recv) = hydroflow::util::unbounded_channel::<TickInstant>();
 
     let mut df = hydroflow_syntax! {
-        source_iter([0]) -> union_tee;
+        source_iter([TickInstant::new(0)]) -> union_tee;
         union_tee = union() -> tee();
-        union_tee -> map(|n| n + 1) -> filter(|&n| n < 10) -> defer_tick() -> union_tee;
+        union_tee -> map(|n| n + TickDuration::SINGLE_TICK) -> filter(|&n| n < TickInstant::new(10)) -> defer_tick() -> union_tee;
         union_tee -> for_each(|v| out_send.send(v).unwrap());
     };
     assert_graphvis_snapshots!(df);
     df.run_available();
 
     assert_eq!(
-        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        &[
+            TickInstant::new(0),
+            TickInstant::new(1),
+            TickInstant::new(2),
+            TickInstant::new(3),
+            TickInstant::new(4),
+            TickInstant::new(5),
+            TickInstant::new(6),
+            TickInstant::new(7),
+            TickInstant::new(8),
+            TickInstant::new(9)
+        ],
         &*hydroflow::util::collect_ready::<Vec<_>, _>(&mut out_recv)
     );
-    assert_eq!((10, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(10), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 }
 
 #[multiplatform_test(hydroflow, env_tracing)]

--- a/hydroflow/tests/surface_singleton.rs
+++ b/hydroflow/tests/surface_singleton.rs
@@ -1,12 +1,14 @@
 use hydroflow::assert_graphvis_snapshots;
+use hydroflow::scheduled::ticks::TickInstant;
 use hydroflow::util::collect_ready;
 use lattices::Max;
 use multiplatform_test::multiplatform_test;
 
 #[multiplatform_test]
 pub fn test_state() {
-    let (filter_send, mut filter_recv) = hydroflow::util::unbounded_channel::<(usize, usize)>();
-    let (max_send, mut max_recv) = hydroflow::util::unbounded_channel::<(usize, usize)>();
+    let (filter_send, mut filter_recv) =
+        hydroflow::util::unbounded_channel::<(TickInstant, usize)>();
+    let (max_send, mut max_recv) = hydroflow::util::unbounded_channel::<(TickInstant, usize)>();
 
     let mut df = hydroflow::hydroflow_syntax! {
         stream1 = source_iter(1..=10);
@@ -32,11 +34,21 @@ pub fn test_state() {
     df.run_available();
 
     assert_eq!(
-        &[(0, 1), (0, 2), (0, 3), (0, 4), (0, 5)],
+        &[
+            (TickInstant::new(0), 1),
+            (TickInstant::new(0), 2),
+            (TickInstant::new(0), 3),
+            (TickInstant::new(0), 4),
+            (TickInstant::new(0), 5)
+        ],
         &*collect_ready::<Vec<_>, _>(&mut filter_recv)
     );
     assert_eq!(
-        &[(0, 3), (0, 4), (0, 5)],
+        &[
+            (TickInstant::new(0), 3),
+            (TickInstant::new(0), 4),
+            (TickInstant::new(0), 5)
+        ],
         &*collect_ready::<Vec<_>, _>(&mut max_recv)
     );
 }
@@ -56,8 +68,9 @@ pub fn test_state_unused() {
 
 #[multiplatform_test]
 pub fn test_fold_cross() {
-    let (filter_send, mut filter_recv) = hydroflow::util::unbounded_channel::<(usize, usize)>();
-    let (max_send, mut max_recv) = hydroflow::util::unbounded_channel::<(usize, usize)>();
+    let (filter_send, mut filter_recv) =
+        hydroflow::util::unbounded_channel::<(TickInstant, usize)>();
+    let (max_send, mut max_recv) = hydroflow::util::unbounded_channel::<(TickInstant, usize)>();
 
     let mut df = hydroflow::hydroflow_syntax! {
         stream1 = source_iter(1..=10);
@@ -87,16 +100,26 @@ pub fn test_fold_cross() {
     df.run_available();
 
     assert_eq!(
-        &[(0, 1), (0, 2), (0, 3), (0, 4), (0, 5)],
+        &[
+            (TickInstant::new(0), 1),
+            (TickInstant::new(0), 2),
+            (TickInstant::new(0), 3),
+            (TickInstant::new(0), 4),
+            (TickInstant::new(0), 5)
+        ],
         &*collect_ready::<Vec<_>, _>(&mut filter_recv)
     );
-    assert_eq!(&[(0, 5)], &*collect_ready::<Vec<_>, _>(&mut max_recv));
+    assert_eq!(
+        &[(TickInstant::new(0), 5)],
+        &*collect_ready::<Vec<_>, _>(&mut max_recv)
+    );
 }
 
 #[multiplatform_test]
 pub fn test_fold_singleton() {
-    let (filter_send, mut filter_recv) = hydroflow::util::unbounded_channel::<(usize, usize)>();
-    let (max_send, mut max_recv) = hydroflow::util::unbounded_channel::<(usize, usize)>();
+    let (filter_send, mut filter_recv) =
+        hydroflow::util::unbounded_channel::<(TickInstant, usize)>();
+    let (max_send, mut max_recv) = hydroflow::util::unbounded_channel::<(TickInstant, usize)>();
 
     let mut df = hydroflow::hydroflow_syntax! {
         stream1 = source_iter(1..=10);
@@ -121,15 +144,25 @@ pub fn test_fold_singleton() {
     df.run_available();
 
     assert_eq!(
-        &[(0, 1), (0, 2), (0, 3), (0, 4), (0, 5)],
+        &[
+            (TickInstant::new(0), 1),
+            (TickInstant::new(0), 2),
+            (TickInstant::new(0), 3),
+            (TickInstant::new(0), 4),
+            (TickInstant::new(0), 5)
+        ],
         &*collect_ready::<Vec<_>, _>(&mut filter_recv)
     );
-    assert_eq!(&[(0, 5)], &*collect_ready::<Vec<_>, _>(&mut max_recv));
+    assert_eq!(
+        &[(TickInstant::new(0), 5)],
+        &*collect_ready::<Vec<_>, _>(&mut max_recv)
+    );
 }
 
 #[multiplatform_test]
 pub fn test_fold_singleton_push() {
-    let (filter_send, mut filter_recv) = hydroflow::util::unbounded_channel::<(usize, usize)>();
+    let (filter_send, mut filter_recv) =
+        hydroflow::util::unbounded_channel::<(TickInstant, usize)>();
 
     let mut df = hydroflow::hydroflow_syntax! {
         stream1 = source_iter(1..=10);
@@ -150,15 +183,22 @@ pub fn test_fold_singleton_push() {
     df.run_available();
 
     assert_eq!(
-        &[(0, 1), (0, 2), (0, 3), (0, 4), (0, 5)],
+        &[
+            (TickInstant::new(0), 1),
+            (TickInstant::new(0), 2),
+            (TickInstant::new(0), 3),
+            (TickInstant::new(0), 4),
+            (TickInstant::new(0), 5)
+        ],
         &*collect_ready::<Vec<_>, _>(&mut filter_recv)
     );
 }
 
 #[multiplatform_test]
 pub fn test_reduce_singleton() {
-    let (filter_send, mut filter_recv) = hydroflow::util::unbounded_channel::<(usize, usize)>();
-    let (max_send, mut max_recv) = hydroflow::util::unbounded_channel::<(usize, usize)>();
+    let (filter_send, mut filter_recv) =
+        hydroflow::util::unbounded_channel::<(TickInstant, usize)>();
+    let (max_send, mut max_recv) = hydroflow::util::unbounded_channel::<(TickInstant, usize)>();
 
     let mut df = hydroflow::hydroflow_syntax! {
         stream1 = source_iter(1..=10);
@@ -183,15 +223,25 @@ pub fn test_reduce_singleton() {
     df.run_available();
 
     assert_eq!(
-        &[(0, 1), (0, 2), (0, 3), (0, 4), (0, 5)],
+        &[
+            (TickInstant::new(0), 1),
+            (TickInstant::new(0), 2),
+            (TickInstant::new(0), 3),
+            (TickInstant::new(0), 4),
+            (TickInstant::new(0), 5)
+        ],
         &*collect_ready::<Vec<_>, _>(&mut filter_recv)
     );
-    assert_eq!(&[(0, 5)], &*collect_ready::<Vec<_>, _>(&mut max_recv));
+    assert_eq!(
+        &[(TickInstant::new(0), 5)],
+        &*collect_ready::<Vec<_>, _>(&mut max_recv)
+    );
 }
 
 #[multiplatform_test]
 pub fn test_reduce_singleton_push() {
-    let (filter_send, mut filter_recv) = hydroflow::util::unbounded_channel::<(usize, usize)>();
+    let (filter_send, mut filter_recv) =
+        hydroflow::util::unbounded_channel::<(TickInstant, usize)>();
 
     let mut df = hydroflow::hydroflow_syntax! {
         stream1 = source_iter(1..=10);
@@ -212,7 +262,13 @@ pub fn test_reduce_singleton_push() {
     df.run_available();
 
     assert_eq!(
-        &[(0, 1), (0, 2), (0, 3), (0, 4), (0, 5)],
+        &[
+            (TickInstant::new(0), 1),
+            (TickInstant::new(0), 2),
+            (TickInstant::new(0), 3),
+            (TickInstant::new(0), 4),
+            (TickInstant::new(0), 5)
+        ],
         &*collect_ready::<Vec<_>, _>(&mut filter_recv)
     );
 }

--- a/hydroflow/tests/surface_state_scheduling.rs
+++ b/hydroflow/tests/surface_state_scheduling.rs
@@ -1,4 +1,5 @@
 use hydroflow::hydroflow_syntax;
+use hydroflow::scheduled::ticks::TickInstant;
 use hydroflow::util::collect_ready;
 use multiplatform_test::multiplatform_test;
 
@@ -9,13 +10,25 @@ pub fn test_repeat_iter() {
     let mut df = hydroflow_syntax! {
         source_iter([1]) -> persist() -> for_each(|v| out_send.send(v).unwrap());
     };
-    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(0), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(1), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(2), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(3), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     assert_eq!(&[1, 1, 1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
@@ -29,13 +42,25 @@ pub fn test_fold_tick() {
     let mut df = hydroflow_syntax! {
         source_iter([1]) -> fold::<'tick>(|| 0, |accum: &mut _, elem| *accum += elem) -> for_each(|v| out_send.send(v).unwrap());
     };
-    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(0), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(1), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(2), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(3), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     assert_eq!(&[1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
@@ -49,13 +74,25 @@ pub fn test_fold_static() {
     let mut df = hydroflow_syntax! {
         source_iter([1]) -> fold::<'static>(|| 0, |accum: &mut _, elem| *accum += elem) -> for_each(|v| out_send.send(v).unwrap());
     };
-    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(0), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(1), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(2), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(3), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     assert_eq!(&[1, 1, 1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
@@ -69,13 +106,25 @@ pub fn test_reduce_tick() {
     let mut df = hydroflow_syntax! {
         source_iter([1]) -> reduce::<'tick>(|a: &mut _, b| *a += b) -> for_each(|v| out_send.send(v).unwrap());
     };
-    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(0), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(1), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(2), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(3), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     assert_eq!(&[1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
@@ -89,13 +138,25 @@ pub fn test_reduce_static() {
     let mut df = hydroflow_syntax! {
         source_iter([1]) -> reduce::<'static>(|a: &mut _, b| *a += b) -> for_each(|v| out_send.send(v).unwrap());
     };
-    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(0), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(1), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(2), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(3), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     assert_eq!(&[1, 1, 1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
@@ -109,13 +170,25 @@ pub fn test_fold_keyed_tick() {
     let mut df = hydroflow_syntax! {
         source_iter([('a', 1), ('a', 2)]) -> fold_keyed::<'tick>(|| 0, |acc: &mut usize, item| { *acc += item; }) -> for_each(|v| out_send.send(v).unwrap());
     };
-    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(0), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(1), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(2), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(3), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     assert_eq!(&[('a', 3)], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
@@ -129,13 +202,25 @@ pub fn test_fold_keyed_static() {
     let mut df = hydroflow_syntax! {
         source_iter([('a', 1), ('a', 2)]) -> fold_keyed::<'static>(|| 0, |acc: &mut usize, item| { *acc += item; }) -> for_each(|v| out_send.send(v).unwrap());
     };
-    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(0), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(1), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(2), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     df.run_tick();
-    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(3), 0),
+        (df.current_tick(), df.current_stratum())
+    );
 
     assert_eq!(
         &[('a', 3), ('a', 3), ('a', 3)],
@@ -156,36 +241,60 @@ pub fn test_resume_external_event() {
         source_stream(in_recv) -> fold::<'static>(|| 0, |a: &mut _, b| *a += b) -> for_each(|v| out_send.send(v).unwrap());
     };
 
-    assert_eq!((0, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(0), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     assert_eq!(&[] as &[usize], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     df.run_tick();
-    assert_eq!((1, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(1), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     assert_eq!(&[0], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     df.run_tick();
-    assert_eq!((2, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(2), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     assert_eq!(&[0], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     df.run_tick();
-    assert_eq!((3, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(3), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     assert_eq!(&[0], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     df.run_available();
-    assert_eq!((4, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(4), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     assert_eq!(&[0], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     in_send.send(1).unwrap();
     df.run_tick();
-    assert_eq!((5, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(5), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     assert_eq!(&[1], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     in_send.send(2).unwrap();
     df.run_available();
-    assert_eq!((6, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(6), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     assert_eq!(&[3], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 
     df.run_available();
-    assert_eq!((7, 0), (df.current_tick(), df.current_stratum()));
+    assert_eq!(
+        (TickInstant::new(7), 0),
+        (df.current_tick(), df.current_stratum())
+    );
     assert_eq!(&[3], &*collect_ready::<Vec<_>, _>(&mut out_recv));
 }

--- a/hydroflow_lang/src/graph/ops/defer_tick.rs
+++ b/hydroflow_lang/src/graph/ops/defer_tick.rs
@@ -20,7 +20,7 @@ use super::{
 ///         source_iter(vec!(true))
 ///                 -> state;
 ///         state = union()
-///                 -> assert(|x| if context.current_tick() % 2 == 0 { *x == true } else { *x == false })
+///                 -> assert(|x| if context.current_tick().0 % 2 == 0 { *x == true } else { *x == false })
 ///                 -> map(|x| !x)
 ///                 -> defer_tick()
 ///                 -> state;

--- a/hydroflow_lang/src/graph/ops/zip.rs
+++ b/hydroflow_lang/src/graph/ops/zip.rs
@@ -75,7 +75,7 @@ pub const ZIP: OperatorConstraints = OperatorConstraints {
         let write_prologue = quote_spanned! {op_span=>
             let #zipbuf_ident = #hydroflow.add_state(::std::cell::RefCell::new(
                 #root::util::monotonic_map::MonotonicMap::<
-                    usize,
+                    #root::scheduled::ticks::TickInstant,
                     (::std::vec::Vec<_>, ::std::vec::Vec<_>),
                 >::default()
             ));

--- a/topolotree/src/pn.rs
+++ b/topolotree/src/pn.rs
@@ -4,6 +4,7 @@ use std::ops::Deref;
 use std::rc::Rc;
 
 use hydroflow::hydroflow_syntax;
+use hydroflow::scheduled::ticks::TickInstant;
 use hydroflow::serde::{Deserialize, Serialize};
 use hydroflow::util::cli::{
     ConnectedDemux, ConnectedDirect, ConnectedSink, ConnectedSource, ConnectedTagged,
@@ -66,7 +67,7 @@ async fn main() {
 
     let df = hydroflow_syntax! {
         next_state = union()
-            -> fold::<'static>(|| (HashMap::<u64, Rc<RefCell<(Vec<u64>, Vec<u64>)>>>::new(), HashSet::new(), 0), |(cur_state, modified_tweets, last_tick): &mut (HashMap<_, _>, HashSet<_>, _), goi| {
+            -> fold::<'static>(|| (HashMap::<u64, Rc<RefCell<(Vec<u64>, Vec<u64>)>>>::new(), HashSet::new(), TickInstant::default()), |(cur_state, modified_tweets, last_tick): &mut (HashMap<_, _>, HashSet<_>, _), goi| {
                 if context.current_tick() != *last_tick {
                     modified_tweets.clear();
                 }

--- a/topolotree/src/pn_delta.rs
+++ b/topolotree/src/pn_delta.rs
@@ -4,6 +4,7 @@ use std::ops::Deref;
 use std::rc::Rc;
 
 use hydroflow::hydroflow_syntax;
+use hydroflow::scheduled::ticks::TickInstant;
 use hydroflow::serde::{Deserialize, Serialize};
 use hydroflow::util::cli::{
     ConnectedDemux, ConnectedDirect, ConnectedSink, ConnectedSource, ConnectedTagged,
@@ -66,7 +67,7 @@ async fn main() {
 
     let df = hydroflow_syntax! {
         next_state = union()
-            -> fold::<'static>(|| (HashMap::<u64, Rc<RefCell<(Vec<u64>, Vec<u64>)>>>::new(), HashMap::new(), 0), |(cur_state, modified_tweets, last_tick): &mut (HashMap<_, _>, HashMap<_, _>, _), goi| {
+            -> fold::<'static>(|| (HashMap::<u64, Rc<RefCell<(Vec<u64>, Vec<u64>)>>>::new(), HashMap::new(), TickInstant::default()), |(cur_state, modified_tweets, last_tick): &mut (HashMap<_, _>, HashMap<_, _>, _), goi| {
                 if context.current_tick() != *last_tick {
                     modified_tweets.clear();
                 }


### PR DESCRIPTION
Addresses #1185.

This change introduces a couple of newtypes and associated arithmetic operations:
1. `TickInstant`
2. `TickDuration`

Using newtypes should prevent mixing/accidental swap of clock values in user code.

Additionally, the numeric type of the clock has been changed from `usize`, which can be of a different size based on compilation target. It has been replaced by `u64`.