### PR TITLE
fix(lattices)!: use `new()` instead of `From::from` for `KeyedBimorphism` to prevent bad type inference, fix #1228

### DIFF
--- a/hydroflow/tests/snapshots/surface_lattice_bimorphism__join@graphvis_dot.snap
+++ b/hydroflow/tests/snapshots/surface_lattice_bimorphism__join@graphvis_dot.snap
@@ -11,7 +11,7 @@ digraph {
     n4v1 [label="(n4v1) source_iter_delta([(7, 0), (7, 1), (7, 2)])", shape=invhouse, fillcolor="#88aaff"]
     n5v1 [label="(n5v1) map(|(k, v)| MapUnionSingletonMap::new_from((k, SetUnionSingletonSet::new_from(v))))", shape=invhouse, fillcolor="#88aaff"]
     n6v1 [label="(n6v1) state::<'static, MapUnionHashMap<usize, SetUnionHashSet<usize>>>()", shape=invhouse, fillcolor="#88aaff"]
-    n7v1 [label="(n7v1) lattice_bimorphism(\l    KeyedBimorphism::<\l        HashMap<_, _>,\l        _,\l    >::from(CartesianProductBimorphism::<HashSet<_>>::default()),\l    lhs,\l    rhs,\l)\l", shape=invhouse, fillcolor="#88aaff"]
+    n7v1 [label="(n7v1) lattice_bimorphism(\l    KeyedBimorphism::<\l        HashMap<_, _>,\l        _,\l    >::new(CartesianProductBimorphism::<HashSet<_>>::default()),\l    lhs,\l    rhs,\l)\l", shape=invhouse, fillcolor="#88aaff"]
     n8v1 [label="(n8v1) lattice_reduce()", shape=invhouse, fillcolor="#88aaff"]
     n9v1 [label="(n9v1) for_each(|x| out_send.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
     n10v1 [label="(n10v1) handoff", shape=parallelogram, fillcolor="#ddddff"]

--- a/hydroflow/tests/snapshots/surface_lattice_bimorphism__join@graphvis_mermaid.snap
+++ b/hydroflow/tests/snapshots/surface_lattice_bimorphism__join@graphvis_mermaid.snap
@@ -14,7 +14,7 @@ linkStyle default stroke:#aaa
 4v1[\"(4v1) <code>source_iter_delta([(7, 0), (7, 1), (7, 2)])</code>"/]:::pullClass
 5v1[\"(5v1) <code>map(|(k, v)| MapUnionSingletonMap::new_from((k, SetUnionSingletonSet::new_from(v))))</code>"/]:::pullClass
 6v1[\"(6v1) <code>state::&lt;'static, MapUnionHashMap&lt;usize, SetUnionHashSet&lt;usize&gt;&gt;&gt;()</code>"/]:::pullClass
-7v1[\"<div style=text-align:center>(7v1)</div> <code>lattice_bimorphism(<br>    KeyedBimorphism::&lt;<br>        HashMap&lt;_, _&gt;,<br>        _,<br>    &gt;::from(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default()),<br>    lhs,<br>    rhs,<br>)</code>"/]:::pullClass
+7v1[\"<div style=text-align:center>(7v1)</div> <code>lattice_bimorphism(<br>    KeyedBimorphism::&lt;<br>        HashMap&lt;_, _&gt;,<br>        _,<br>    &gt;::new(CartesianProductBimorphism::&lt;HashSet&lt;_&gt;&gt;::default()),<br>    lhs,<br>    rhs,<br>)</code>"/]:::pullClass
 8v1[\"(8v1) <code>lattice_reduce()</code>"/]:::pullClass
 9v1[/"(9v1) <code>for_each(|x| out_send.send(x).unwrap())</code>"\]:::pushClass
 10v1["(10v1) <code>handoff</code>"]:::otherClass

--- a/hydroflow/tests/surface_lattice_bimorphism.rs
+++ b/hydroflow/tests/surface_lattice_bimorphism.rs
@@ -57,7 +57,7 @@ pub fn test_join() {
         lhs[items] -> [0]my_join;
         rhs[items] -> [1]my_join;
 
-        my_join = lattice_bimorphism(KeyedBimorphism::<HashMap<_, _>, _>::from(CartesianProductBimorphism::<HashSet<_>>::default()), #lhs, #rhs)
+        my_join = lattice_bimorphism(KeyedBimorphism::<HashMap<_, _>, _>::new(CartesianProductBimorphism::<HashSet<_>>::default()), #lhs, #rhs)
             -> lattice_reduce()
             -> for_each(|x| out_send.send(x).unwrap());
     };

--- a/lattices/src/map_union.rs
+++ b/lattices/src/map_union.rs
@@ -277,8 +277,9 @@ pub struct KeyedBimorphism<MapOut, Bimorphism> {
     bimorphism: Bimorphism,
     _phantom: PhantomData<fn() -> MapOut>,
 }
-impl<MapOut, Bimorphism> From<Bimorphism> for KeyedBimorphism<MapOut, Bimorphism> {
-    fn from(bimorphism: Bimorphism) -> Self {
+impl<MapOut, Bimorphism> KeyedBimorphism<MapOut, Bimorphism> {
+    /// Create a `KeyedBimorphism` using `bimorphism` for handling values.
+    pub fn new(bimorphism: Bimorphism) -> Self {
         Self {
             bimorphism,
             _phantom: PhantomData,
@@ -398,28 +399,28 @@ mod test {
         ];
 
         check_lattice_bimorphism(
-            KeyedBimorphism::<HashMap<_, _>, _>::from(
+            KeyedBimorphism::<HashMap<_, _>, _>::new(
                 CartesianProductBimorphism::<HashSet<_>>::default(),
             ),
             items_a,
             items_a,
         );
         check_lattice_bimorphism(
-            KeyedBimorphism::<HashMap<_, _>, _>::from(
+            KeyedBimorphism::<HashMap<_, _>, _>::new(
                 CartesianProductBimorphism::<HashSet<_>>::default(),
             ),
             items_a,
             items_b,
         );
         check_lattice_bimorphism(
-            KeyedBimorphism::<HashMap<_, _>, _>::from(
+            KeyedBimorphism::<HashMap<_, _>, _>::new(
                 CartesianProductBimorphism::<HashSet<_>>::default(),
             ),
             items_b,
             items_a,
         );
         check_lattice_bimorphism(
-            KeyedBimorphism::<HashMap<_, _>, _>::from(
+            KeyedBimorphism::<HashMap<_, _>, _>::new(
                 CartesianProductBimorphism::<HashSet<_>>::default(),
             ),
             items_b,
@@ -427,28 +428,28 @@ mod test {
         );
 
         check_lattice_bimorphism(
-            KeyedBimorphism::<BTreeMap<_, _>, _>::from(
+            KeyedBimorphism::<BTreeMap<_, _>, _>::new(
                 CartesianProductBimorphism::<HashSet<_>>::default(),
             ),
             items_a,
             items_a,
         );
         check_lattice_bimorphism(
-            KeyedBimorphism::<BTreeMap<_, _>, _>::from(
+            KeyedBimorphism::<BTreeMap<_, _>, _>::new(
                 CartesianProductBimorphism::<HashSet<_>>::default(),
             ),
             items_a,
             items_b,
         );
         check_lattice_bimorphism(
-            KeyedBimorphism::<BTreeMap<_, _>, _>::from(
+            KeyedBimorphism::<BTreeMap<_, _>, _>::new(
                 CartesianProductBimorphism::<HashSet<_>>::default(),
             ),
             items_b,
             items_a,
         );
         check_lattice_bimorphism(
-            KeyedBimorphism::<BTreeMap<_, _>, _>::from(
+            KeyedBimorphism::<BTreeMap<_, _>, _>::new(
                 CartesianProductBimorphism::<HashSet<_>>::default(),
             ),
             items_b,


### PR DESCRIPTION
BREAKING CHANGE: use `KeyedBimorphism::new` instead of `KeyedBimorphism::from`