### PR TITLE
chore: use workaround for `cargo smart-release` not properly ordering `dev-`/`build-dependencies`

### DIFF
--- a/hydro_deploy/hydroflow_plus_cli_integration/Cargo.toml
+++ b/hydro_deploy/hydroflow_plus_cli_integration/Cargo.toml
@@ -21,5 +21,8 @@ serde = { version = "1", features = [ "derive" ] }
 hydro_deploy = { path = "../core", version = "^0.6.1", optional = true }
 async-channel = { version = "1.8.0", optional = true }
 
+# added to workaround `cargo smart-release` https://github.com/Byron/cargo-smart-release/issues/16
+stageleft_tool = { path = "../../stageleft_tool", version = "^0.1.1", optional = true }
+
 [build-dependencies]
 stageleft_tool = { path = "../../stageleft_tool", version = "^0.1.1" }

--- a/hydroflow/Cargo.toml
+++ b/hydroflow/Cargo.toml
@@ -52,6 +52,9 @@ tracing = "0.1"
 variadics = { path = "../variadics", version = "^0.0.4" }
 web-time = "1.1.0"
 
+# added to workaround `cargo smart-release` https://github.com/Byron/cargo-smart-release/issues/16
+multiplatform_test = { path = "../multiplatform_test", version = "0.0.0", optional = true }
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.16", features = [ "full" ] }
 tokio-util = { version = "0.7.4", features = [ "net", "codec" ] }

--- a/hydroflow_plus/Cargo.toml
+++ b/hydroflow_plus/Cargo.toml
@@ -27,6 +27,9 @@ bincode = "1.3"
 stageleft = { path = "../stageleft", version = "^0.2.1" }
 dyn-clone = "1.0.17"
 
+# added to workaround `cargo smart-release` https://github.com/Byron/cargo-smart-release/issues/16
+stageleft_tool = { path = "../stageleft_tool", version = "^0.1.1", optional = true }
+
 [build-dependencies]
 stageleft_tool = { path = "../stageleft_tool", version = "^0.1.1" }
 


### PR DESCRIPTION
https://github.com/Byron/cargo-smart-release/issues/16