### PR TITLE
fix(lattices): Make inner for `WithTop` & `WithBot` private

### DIFF
--- a/hydroflow/examples/kvs_bench/protocol/serialization/lattices/with_bot.rs
+++ b/hydroflow/examples/kvs_bench/protocol/serialization/lattices/with_bot.rs
@@ -19,7 +19,7 @@ impl<'a, const SIZE: usize> Serialize for WithBotWrapper<'a, SIZE> {
     where
         S: Serializer,
     {
-        if let Some(inner) = &self.0 .0 {
+        if let Some(inner) = self.0.as_reveal_ref() {
             serializer.serialize_some(&PointWrapper(inner))
         } else {
             serializer.serialize_none()

--- a/lattices/src/with_bot.rs
+++ b/lattices/src/with_bot.rs
@@ -2,15 +2,15 @@ use std::cmp::Ordering::{self, *};
 
 use crate::{Atomize, DeepReveal, IsBot, IsTop, LatticeFrom, LatticeOrd, Merge};
 
-/// Wraps a lattice in [`Option`], treating [`None`] as a new bottom element which compares as less
-/// than to all other values.
+/// Given an existing lattice, wrap it into a new lattice with a new bottom element. The new bottom
+/// element compares as less than all the values of the wrapped lattice.  This can be used for
+/// giving a sensible default/bottom element to lattices that don't necessarily have one.
 ///
-/// This can be used for giving a sensible default/bottom element to lattices that don't
-/// necessarily have one.
+/// The implementation wraps an [`Option`], with [`None`] representing the bottom element.
 #[repr(transparent)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct WithBot<Inner>(pub Option<Inner>);
+pub struct WithBot<Inner>(Option<Inner>);
 impl<Inner> WithBot<Inner> {
     /// Create a new `WithBot` lattice instance from a value.
     pub fn new(val: Option<Inner>) -> Self {

--- a/lattices/src/with_top.rs
+++ b/lattices/src/with_top.rs
@@ -2,15 +2,15 @@ use std::cmp::Ordering::{self, *};
 
 use crate::{Atomize, DeepReveal, IsBot, IsTop, LatticeFrom, LatticeOrd, Merge};
 
-/// Wraps a lattice in [`Option`], treating [`None`] as a new top element which compares as greater
-/// than to all other values.
+/// Given an existing lattice, wrap it into a new lattice with a new top element. The new top
+/// element compares as less than all the values of the wrapped lattice.  This can be used for
+/// giving a sensible default/bottom element to lattices that don't necessarily have one.
 ///
-/// This can be used for giving a sensible top element to lattices that don't
-/// necessarily have one. Can be used to implement 'tombstones'
+/// The implementation wraps an [`Option`], with [`None`] representing the top element.
 #[repr(transparent)]
 #[derive(Copy, Clone, Debug, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct WithTop<Inner>(pub Option<Inner>);
+pub struct WithTop<Inner>(Option<Inner>);
 impl<Inner> WithTop<Inner> {
     /// Create a new `WithTop` lattice instance from a value.
     pub fn new(val: Option<Inner>) -> Self {


### PR DESCRIPTION
`Option<T>` is not a lattice, so it is unsafe to expose as public.

I also updated documentation to lead with intention before implementation (minor cleanup).