### PR TITLE
feat(lattices_macro): add `#[derive(Lattice)]` derive macros, fix #1247

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
                 // Make sure all snapshots are written instead of just the first failure.
                 "INSTA_FORCE_PASS": "1",
                 "INSTA_UPDATE": "always",
+                "TRYBUILD": "overwrite",
             }
         }
     ],

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,8 +1772,22 @@ name = "lattices"
 version = "0.5.5"
 dependencies = [
  "cc-traits",
+ "lattices_macro",
  "sealed",
  "serde",
+ "trybuild",
+]
+
+[[package]]
+name = "lattices_macro"
+version = "0.5.5"
+dependencies = [
+ "insta",
+ "prettyplease",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2311,9 +2325,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.15"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
  "syn 2.0.60",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "hydroflow_plus_test",
     "hydroflow_plus_test_macro",
     "lattices",
+    "lattices_macro",
     "multiplatform_test",
     "pusherator",
     "relalg",

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__aggregations_and_comments@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__aggregations_and_comments@datalog_program.snap
@@ -412,8 +412,7 @@ fn main() {
                                 entry,
                                 kv.1,
                                 |old: &mut (Option<_>,), val: (_,)| {
-                                    old
-                                        .0 = if let Some(prev) = old.0.take() {
+                                    old.0 = if let Some(prev) = old.0.take() {
                                         Some({
                                             let prev: (hydroflow::rustc_hash::FxHashSet<_>, _) = prev;
                                             let mut set: hydroflow::rustc_hash::FxHashSet<_> = prev.0;
@@ -724,8 +723,7 @@ fn main() {
                                 entry,
                                 kv.1,
                                 |old: &mut (Option<_>,), val: (_,)| {
-                                    old
-                                        .0 = if let Some(prev) = old.0.take() {
+                                    old.0 = if let Some(prev) = old.0.take() {
                                         Some(prev)
                                     } else {
                                         Some(val.0)
@@ -943,8 +941,7 @@ fn main() {
                                 entry,
                                 kv.1,
                                 |old: &mut (Option<_>,), val: (_,)| {
-                                    old
-                                        .0 = if let Some(prev) = old.0.take() {
+                                    old.0 = if let Some(prev) = old.0.take() {
                                         Some(prev + val.0)
                                     } else {
                                         Some(val.0)

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__aggregations_fold_keyed_expr@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__aggregations_fold_keyed_expr@datalog_program.snap
@@ -247,8 +247,7 @@ fn main() {
                                 entry,
                                 kv.1,
                                 |old: &mut (Option<_>,), val: (_,)| {
-                                    old
-                                        .0 = if let Some(prev) = old.0.take() {
+                                    old.0 = if let Some(prev) = old.0.take() {
                                         Some(prev + val.0)
                                     } else {
                                         Some(val.0)

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__collect_vec@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__collect_vec@datalog_program.snap
@@ -557,8 +557,7 @@ fn main() {
                                 entry,
                                 kv.1,
                                 |old: &mut (Option<_>,), val: (_,)| {
-                                    old
-                                        .0 = if let Some(prev) = old.0.take() {
+                                    old.0 = if let Some(prev) = old.0.take() {
                                         Some({
                                             let mut set: hydroflow::rustc_hash::FxHashSet<_> = prev;
                                             set.insert(val.0);

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__index@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__index@datalog_program.snap
@@ -787,8 +787,7 @@ fn main() {
                                 entry,
                                 kv.1,
                                 |old: &mut (Option<_>,), val: (_,)| {
-                                    old
-                                        .0 = if let Some(prev) = old.0.take() {
+                                    old.0 = if let Some(prev) = old.0.take() {
                                         Some({
                                             let prev: (hydroflow::rustc_hash::FxHashSet<_>, _) = prev;
                                             let mut set: hydroflow::rustc_hash::FxHashSet<_> = prev.0;
@@ -1625,8 +1624,7 @@ fn main() {
                                 entry,
                                 kv.1,
                                 |old: &mut (Option<_>,), val: (_,)| {
-                                    old
-                                        .0 = if let Some(prev) = old.0.take() {
+                                    old.0 = if let Some(prev) = old.0.take() {
                                         Some({
                                             let prev: (hydroflow::rustc_hash::FxHashSet<_>, _) = prev;
                                             let mut set: hydroflow::rustc_hash::FxHashSet<_> = prev.0;

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__max@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__max@datalog_program.snap
@@ -247,8 +247,7 @@ fn main() {
                                 entry,
                                 kv.1,
                                 |old: &mut (Option<_>,), val: (_,)| {
-                                    old
-                                        .0 = if let Some(prev) = old.0.take() {
+                                    old.0 = if let Some(prev) = old.0.take() {
                                         Some(std::cmp::max(prev, val.0))
                                     } else {
                                         Some(val.0)

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__max_all@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__max_all@datalog_program.snap
@@ -250,14 +250,12 @@ fn main() {
                                 entry,
                                 kv.1,
                                 |old: &mut (Option<_>, Option<_>), val: (_, _)| {
-                                    old
-                                        .0 = if let Some(prev) = old.0.take() {
+                                    old.0 = if let Some(prev) = old.0.take() {
                                         Some(std::cmp::max(prev, val.0))
                                     } else {
                                         Some(val.0)
                                     };
-                                    old
-                                        .1 = if let Some(prev) = old.1.take() {
+                                    old.1 = if let Some(prev) = old.1.take() {
                                         Some(std::cmp::max(prev, val.1))
                                     } else {
                                         Some(val.1)

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist_uniqueness@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__persist_uniqueness@datalog_program.snap
@@ -267,8 +267,7 @@ fn main() {
                                 entry,
                                 kv.1,
                                 |old: &mut (Option<_>,), val: (_,)| {
-                                    old
-                                        .0 = if let Some(prev) = old.0.take() {
+                                    old.0 = if let Some(prev) = old.0.take() {
                                         Some({
                                             let prev: (hydroflow::rustc_hash::FxHashSet<_>, _) = prev;
                                             let mut set: hydroflow::rustc_hash::FxHashSet<_> = prev.0;

--- a/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__wildcard_join_count@datalog_program.snap
+++ b/hydroflow_datalog_core/src/snapshots/hydroflow_datalog_core__tests__wildcard_join_count@datalog_program.snap
@@ -501,8 +501,7 @@ fn main() {
                                 entry,
                                 kv.1,
                                 |old: &mut (Option<_>,), val: (_,)| {
-                                    old
-                                        .0 = if let Some(prev) = old.0.take() {
+                                    old.0 = if let Some(prev) = old.0.take() {
                                         Some(prev + 1)
                                     } else {
                                         Some(1)
@@ -715,8 +714,7 @@ fn main() {
                                 entry,
                                 kv.1,
                                 |old: &mut (Option<_>,), val: (_,)| {
-                                    old
-                                        .0 = if let Some(prev) = old.0.take() {
+                                    old.0 = if let Some(prev) = old.0.take() {
                                         Some({
                                             let prev: (hydroflow::rustc_hash::FxHashSet<_>, _) = prev;
                                             let mut set: hydroflow::rustc_hash::FxHashSet<_> = prev.0;

--- a/lattices/Cargo.toml
+++ b/lattices/Cargo.toml
@@ -15,3 +15,5 @@ serde = ["dep:serde"]
 cc-traits = "2.0.0"
 sealed = "0.5"
 serde = { version = "1.0.160", features = ["derive"], optional = true }
+trybuild = "1.0.80"
+lattices_macro = { path = "../lattices_macro", version = "^0.5.5" }

--- a/lattices/src/lib.rs
+++ b/lattices/src/lib.rs
@@ -28,6 +28,7 @@ mod with_top;
 
 pub use conflict::Conflict;
 pub use dom_pair::DomPair;
+pub use lattices_macro::*;
 pub use ord::{Max, Min};
 pub use pair::{Pair, PairBimorphism};
 pub use point::Point;

--- a/lattices/src/map_union.rs
+++ b/lattices/src/map_union.rs
@@ -137,17 +137,14 @@ where
         for k in self_keys.chain(other_keys) {
             match (self.0.get(k), other.0.get(k)) {
                 (Some(self_value), Some(other_value)) => {
-                    match self_value.partial_cmp(&*other_value) {
-                        None => {
-                            return None;
-                        }
-                        Some(Less) => {
+                    match self_value.partial_cmp(&*other_value)? {
+                        Less => {
                             other_any_greater = true;
                         }
-                        Some(Greater) => {
+                        Greater => {
                             self_any_greater = true;
                         }
-                        Some(Equal) => {}
+                        Equal => {}
                     }
                 }
                 (Some(_), None) => {

--- a/lattices/src/map_union_with_tombstones.rs
+++ b/lattices/src/map_union_with_tombstones.rs
@@ -187,17 +187,14 @@ where
         for k in self_keys.chain(other_keys) {
             match (self.map.get(k), other.map.get(k)) {
                 (Some(self_value), Some(other_value)) => {
-                    match self_value.partial_cmp(&*other_value) {
-                        None => {
-                            return None;
-                        }
-                        Some(Less) => {
+                    match self_value.partial_cmp(&*other_value)? {
+                        Less => {
                             other_any_greater = true;
                         }
-                        Some(Greater) => {
+                        Greater => {
                             self_any_greater = true;
                         }
-                        Some(Equal) => {}
+                        Equal => {}
                     }
                 }
                 (Some(_), None) => {

--- a/lattices/tests/compile-fail/non_lattice_field.rs
+++ b/lattices/tests/compile-fail/non_lattice_field.rs
@@ -1,0 +1,8 @@
+use lattices::Lattice;
+
+#[derive(Lattice)]
+struct NotALattice {
+    not_a_lattice_field: String,
+}
+
+fn main() {}

--- a/lattices/tests/compile-fail/non_lattice_field.stderr
+++ b/lattices/tests/compile-fail/non_lattice_field.stderr
@@ -1,0 +1,91 @@
+error[E0277]: the trait bound `String: Merge<String>` is not satisfied
+ --> tests/compile-fail/non_lattice_field.rs:3:10
+  |
+3 | #[derive(Lattice)]
+  |          ^^^^^^^ the trait `Merge<String>` is not implemented for `String`
+  |
+  = help: the following other types implement trait `Merge<Other>`:
+            <() as Merge<()>>
+            <Conflict<T> as Merge<Conflict<O>>>
+            <DomPair<KeySelf, ValSelf> as Merge<DomPair<KeyOther, ValOther>>>
+            <MapUnion<MapSelf> as Merge<MapUnion<MapOther>>>
+            <MapUnionWithTombstones<MapSelf, TombstoneSetSelf> as Merge<MapUnionWithTombstones<MapOther, TombstoneSetOther>>>
+            <Max<T> as Merge<Max<T>>>
+            <Min<T> as Merge<Min<T>>>
+            <NotALattice as Merge<NotALattice>>
+          and $N others
+  = help: see issue #48214
+  = note: this error originates in the derive macro `Lattice` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+  |
+1 + #![feature(trivial_bounds)]
+  |
+
+error[E0277]: the trait bound `String: IsBot` is not satisfied
+ --> tests/compile-fail/non_lattice_field.rs:3:10
+  |
+3 | #[derive(Lattice)]
+  |          ^^^^^^^ the trait `IsBot` is not implemented for `String`
+  |
+  = help: the following other types implement trait `IsBot`:
+            ()
+            Conflict<T>
+            DomPair<Key, Val>
+            MapUnion<Map>
+            MapUnionWithTombstones<Map, TombstoneSet>
+            Max<()>
+            Max<bool>
+            Max<char>
+          and $N others
+  = help: see issue #48214
+  = note: this error originates in the derive macro `Lattice` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+  |
+1 + #![feature(trivial_bounds)]
+  |
+
+error[E0277]: the trait bound `String: IsTop` is not satisfied
+ --> tests/compile-fail/non_lattice_field.rs:3:10
+  |
+3 | #[derive(Lattice)]
+  |          ^^^^^^^ the trait `IsTop` is not implemented for `String`
+  |
+  = help: the following other types implement trait `IsTop`:
+            ()
+            Conflict<T>
+            DomPair<Key, Val>
+            MapUnion<Map>
+            MapUnionWithTombstones<Map, TombstoneSet>
+            Max<()>
+            Max<bool>
+            Max<char>
+          and $N others
+  = help: see issue #48214
+  = note: this error originates in the derive macro `Lattice` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+  |
+1 + #![feature(trivial_bounds)]
+  |
+
+error[E0277]: the trait bound `String: LatticeFrom<String>` is not satisfied
+ --> tests/compile-fail/non_lattice_field.rs:3:10
+  |
+3 | #[derive(Lattice)]
+  |          ^^^^^^^ the trait `LatticeFrom<String>` is not implemented for `String`
+  |
+  = help: the following other types implement trait `LatticeFrom<Other>`:
+            <() as LatticeFrom<()>>
+            <Conflict<T> as LatticeFrom<Conflict<T>>>
+            <DomPair<KeySelf, ValSelf> as LatticeFrom<DomPair<KeyOther, ValOther>>>
+            <MapUnion<MapSelf> as LatticeFrom<MapUnion<MapOther>>>
+            <MapUnionWithTombstones<MapSelf, TombstoneSetSelf> as LatticeFrom<MapUnionWithTombstones<MapOther, TombstoneSetOther>>>
+            <Max<T> as LatticeFrom<Max<T>>>
+            <Min<T> as LatticeFrom<Min<T>>>
+            <NotALattice as LatticeFrom<NotALattice>>
+          and $N others
+  = help: see issue #48214
+  = note: this error originates in the derive macro `Lattice` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+  |
+1 + #![feature(trivial_bounds)]
+  |

--- a/lattices/tests/compile_fail.rs
+++ b/lattices/tests/compile_fail.rs
@@ -1,0 +1,5 @@
+#[test]
+fn test_all() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile-fail/*.rs");
+}

--- a/lattices/tests/macro.rs
+++ b/lattices/tests/macro.rs
@@ -1,0 +1,70 @@
+use cc_traits::Collection;
+use lattices::map_union::MapUnionHashMap;
+use lattices::set_union::SetUnion;
+use lattices::{DomPair, IsBot, IsTop, Lattice, LatticeFrom, LatticeOrd, Max, Merge};
+
+type Table<C> = MapUnionHashMap<RowKey, RowValEntry<C>>;
+type RowKey = String;
+type RowValEntry<C> = DomPair<C, RowVal>;
+type RowVal = Max<String>;
+
+/// Macro to test all the different derives on the same set of structs.
+macro_rules! test_derive_all {
+    ( $( $m:ident => $i:ident, )* ) => {
+        $(
+            #[allow(dead_code)]
+            mod $m {
+                use super::*;
+
+                #[derive($i)]
+                struct Pair<LatA, LatB> {
+                    pub a: LatA,
+                    pub b: LatB,
+                }
+
+                #[derive($i)]
+                struct MyTables<C> {
+                    system: Table<C>,
+                    user: Table<C>,
+                }
+
+                #[derive($i)]
+                struct Empty;
+
+                #[derive($i)]
+                struct Tuple(Max<usize>);
+
+                #[derive($i)]
+                struct TupleGeneric<O>(Max<O>, Max<O>)
+                where
+                    O: Ord;
+
+                #[derive($i)]
+                struct MyLattice<KeySet, Epoch>
+                where
+                    KeySet: Collection,
+                    Epoch: Ord,
+                {
+                    keys: SetUnion<KeySet>,
+                    epoch: Max<Epoch>,
+                }
+
+                #[derive($i)]
+                pub struct SimilarFields {
+                    a: Max<usize>,
+                    b: Max<usize>,
+                    c: Max<usize>,
+                }
+            }
+        )*
+    };
+}
+test_derive_all! {
+    // module_name => DeriveName,
+    lattice => Lattice,
+    merge => Merge,
+    lattice_ord => LatticeOrd,
+    is_top => IsTop,
+    is_bot => IsBot,
+    lattice_from => LatticeFrom,
+}

--- a/lattices_macro/Cargo.toml
+++ b/lattices_macro/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "lattices_macro"
+publish = true
+version = "0.5.5"
+edition = "2021"
+license = "Apache-2.0"
+documentation = "https://docs.rs/lattices/"
+description = "Procedural macros for the `lattices` crate."
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.63"
+proc-macro-crate = "1.1.0"
+quote = "1.0.0"
+syn = { version = "2.0.0", features = [ "full", "parsing", "visit-mut" ] }
+
+[dev-dependencies]
+insta = "1.7.1"
+prettyplease = "0.2.20"

--- a/lattices_macro/README.md
+++ b/lattices_macro/README.md
@@ -1,0 +1,1 @@
+Procedural macros for the `lattices` crate.

--- a/lattices_macro/src/lib.rs
+++ b/lattices_macro/src/lib.rs
@@ -1,0 +1,575 @@
+//! Macros for the `lattices` crate.
+#![warn(missing_docs)]
+
+use proc_macro2::{Span, TokenStream};
+use quote::{format_ident, quote};
+use syn::punctuated::Punctuated;
+use syn::visit_mut::VisitMut;
+use syn::{
+    parse_macro_input, Field, FieldsNamed, FieldsUnnamed, Generics, Ident, Index, ItemStruct,
+    Member, Token, WhereClause, WherePredicate,
+};
+
+/// Tokens to reference the `lattices` crate.
+fn root() -> TokenStream {
+    use std::env::{var as env_var, VarError};
+
+    use proc_macro_crate::FoundCrate;
+
+    if let Ok(FoundCrate::Itself) = proc_macro_crate::crate_name("lattices_macro") {
+        return quote! { lattices };
+    }
+
+    let lattices_crate = proc_macro_crate::crate_name("lattices")
+        .expect("`lattices` should be present in `Cargo.toml`");
+    match lattices_crate {
+        FoundCrate::Itself => {
+            if Err(VarError::NotPresent) == env_var("CARGO_BIN_NAME")
+                && Ok("lattices") == env_var("CARGO_CRATE_NAME").as_deref()
+            {
+                // In the crate itself, including unit tests.
+                quote! { crate }
+            } else {
+                // In an integration test, example, bench, etc.
+                quote! { ::lattices }
+            }
+        }
+        FoundCrate::Name(name) => {
+            let ident = Ident::new(&name, Span::call_site());
+            quote! { ::#ident }
+        }
+    }
+}
+
+/// Renames the generics and returns the updated `WherePredicate`s.
+fn rename_generics(
+    item_struct: &mut ItemStruct,
+    rename: impl FnMut(&Ident) -> Ident,
+) -> Vec<WherePredicate> {
+    struct RenameGenerics<F> {
+        rename: F,
+        names: Vec<Ident>,
+        pub triggered: bool,
+    }
+    impl<F> VisitMut for RenameGenerics<F>
+    where
+        F: FnMut(&Ident) -> Ident,
+    {
+        fn visit_ident_mut(&mut self, i: &mut Ident) {
+            if self.names.contains(i) {
+                *i = (self.rename)(i);
+                self.triggered = true;
+            }
+        }
+    }
+
+    let names = item_struct
+        .generics
+        .type_params()
+        .map(|type_param| type_param.ident.clone())
+        .collect();
+    let mut visit = RenameGenerics {
+        rename,
+        names,
+        triggered: false,
+    };
+
+    let mut out = Vec::new();
+    if let Some(where_clause) = &mut item_struct.generics.where_clause {
+        for where_predicate in where_clause.predicates.iter_mut() {
+            visit.visit_where_predicate_mut(where_predicate);
+            if std::mem::take(&mut visit.triggered) {
+                out.push(where_predicate.clone());
+            }
+        }
+    }
+    for type_param in item_struct.generics.type_params_mut() {
+        visit.visit_type_param_mut(type_param);
+    }
+    for field in item_struct.fields.iter_mut() {
+        visit.visit_type_mut(&mut field.ty);
+    }
+    out
+}
+
+/// Ensures that `punctuated` has trailing punctuation (or is empty).
+fn ensure_trailing<T, P>(punctuated: &mut Punctuated<T, P>)
+where
+    P: Default,
+{
+    if !punctuated.empty_or_trailing() {
+        punctuated.push_punct(Default::default());
+    }
+}
+
+/// Derives `Merge`, `PartialEq`, `PartialOrd`, `LatticeOrd`, `IsBot`, `IsTop`, and `LatticeFrom`,
+/// and therefore `Lattice` too. Can be thought of as shorthand for `#[derive(Merge, LatticeOrd,
+/// IsBot, IsTop, LatticeFrom)]`.
+///
+/// The lattice derived will be the _product lattice_ of all the fields of the struct. I.e a `Pair`
+/// lattice but of all the fields of the struct instead of just two.
+///
+/// Note that all fields must be lattice types. If any field cannot be a lattice type then the
+/// `where` clauses prevent the trait impl from compiling.
+///
+/// These derive macros will create a second set of generics to allow conversion and merging
+/// between varying types. For example, given this struct:
+/// ```rust,ignore
+/// #[derive(Lattice)]
+/// struct MyLattice<KeySet, Epoch>
+/// where
+///     KeySet: Collection,
+///     Epoch: Ord,
+/// {
+///     keys: SetUnion<KeySet>,
+///     epoch: Max<Epoch>,
+/// }
+/// ```
+/// Will create derive macros `impl`s in the form:
+/// ```rust,ignore
+/// impl<KeySet, Epoch, KeySetOther, EpochOther>
+///     Merge<MyLattice<KeySetOther, EpochOther>>
+///     for MyLattice<KeySet, Epoch>
+/// where
+///     KeySet: Collection,
+///     Epoch: Ord,
+///     KeySetOther: Collection,
+///     EpochOther: Ord,
+/// {
+///     // ...
+/// }
+/// ```
+#[proc_macro_derive(Lattice)]
+pub fn derive_lattice_macro(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    derive_lattice(&process_item_struct(parse_macro_input!(item))).into()
+}
+/// Derives lattice `Merge`.
+///
+/// See [`#[derive(Lattice)]`](`Lattice`) for more info.
+#[proc_macro_derive(Merge)]
+pub fn derive_merge_macro(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    derive_merge(&process_item_struct(parse_macro_input!(item))).into()
+}
+/// Derives [`PartialEq`], [`PartialOrd`], and `LatticeOrd` together.
+///
+/// See [`#[derive(Lattice)]`](`Lattice`) for more info.
+#[proc_macro_derive(LatticeOrd)]
+pub fn derive_lattice_ord_macro(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    derive_lattice_ord(&process_item_struct(parse_macro_input!(item))).into()
+}
+/// Derives lattice `IsBot`.
+///
+/// See [`#[derive(Lattice)]`](`Lattice`) for more info.
+#[proc_macro_derive(IsBot)]
+pub fn derive_is_bot_macro(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    derive_is_bot(&process_item_struct(parse_macro_input!(item))).into()
+}
+/// Derives lattice `IsTop`.
+///
+/// See [`#[derive(Lattice)]`](`Lattice`) for more info.
+#[proc_macro_derive(IsTop)]
+pub fn derive_is_top_macro(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    derive_is_top(&process_item_struct(parse_macro_input!(item))).into()
+}
+/// Derives `LatticeFrom`.
+///
+/// See [`#[derive(Lattice)]`](`Lattice`) for more info.
+#[proc_macro_derive(LatticeFrom)]
+pub fn derive_lattice_from_macro(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    derive_lattice_from(&process_item_struct(parse_macro_input!(item))).into()
+}
+
+/// [`process_item_struct`] return value helper struct.
+struct ProcessItemStruct {
+    root: TokenStream,
+    item_struct: ItemStruct,
+    item_struct_renamed: ItemStruct,
+    self_where_predicates: Punctuated<WherePredicate, Token![,]>,
+    both_where_predicates: Punctuated<WherePredicate, Token![,]>,
+    field_names: Vec<Member>,
+    combined_generics: Generics,
+}
+/// Helper for common pre-processing code shared between macros.
+fn process_item_struct(item_struct: ItemStruct) -> ProcessItemStruct {
+    let mut item_struct_renamed = item_struct.clone();
+    let extra_where_predicates = rename_generics(&mut item_struct_renamed, |ident| {
+        format_ident!("__{}Other", ident)
+    });
+
+    // Basic `where` predicates, no extras.
+    let mut self_where_predicates = item_struct
+        .generics
+        .where_clause
+        .clone()
+        .map(|WhereClause { predicates, .. }| predicates)
+        .unwrap_or_default();
+    ensure_trailing(&mut self_where_predicates);
+    // Basic `where` predicates for combined original and renamed parameters.
+    let mut both_where_predicates = self_where_predicates.clone();
+    both_where_predicates.extend(extra_where_predicates);
+    ensure_trailing(&mut both_where_predicates);
+
+    // Fields.
+    let field_names = match &item_struct.fields {
+        syn::Fields::Named(FieldsNamed { named, .. }) => named
+            .iter()
+            .map(|Field { ident, .. }| Member::Named(ident.clone().unwrap()))
+            .collect::<Vec<_>>(),
+        syn::Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => (0..(unnamed.len() as u32))
+            .map(|index| {
+                Member::Unnamed(Index {
+                    index,
+                    span: Span::call_site(),
+                })
+            })
+            .collect(),
+        syn::Fields::Unit => Vec::new(),
+    };
+
+    // Extend the original generics.
+    let mut combined_generics = item_struct.generics.clone();
+    combined_generics
+        .params
+        .extend(item_struct_renamed.generics.params.clone());
+
+    ProcessItemStruct {
+        root: root(),
+        item_struct,
+        item_struct_renamed,
+        self_where_predicates,
+        both_where_predicates,
+        field_names,
+        combined_generics,
+    }
+}
+
+/// See [`derive_lattice_macro`].
+fn derive_lattice(process_item_struct: &ProcessItemStruct) -> TokenStream {
+    let mut out = TokenStream::new();
+    out.extend(derive_merge(process_item_struct));
+    out.extend(derive_lattice_ord(process_item_struct));
+    out.extend(derive_is_bot(process_item_struct));
+    out.extend(derive_is_top(process_item_struct));
+    out.extend(derive_lattice_from(process_item_struct));
+    out
+}
+
+/// See [`derive_merge_macro`].
+fn derive_merge(
+    ProcessItemStruct {
+        root,
+        item_struct,
+        item_struct_renamed,
+        self_where_predicates: _,
+        both_where_predicates,
+        field_names,
+        combined_generics,
+    }: &ProcessItemStruct,
+) -> TokenStream {
+    let merge_where_predicates = item_struct
+        .fields
+        .iter()
+        .zip(item_struct_renamed.fields.iter())
+        .map(|(field_self, field_othr)| {
+            let ty_self = &field_self.ty;
+            let ty_othr = &field_othr.ty;
+            quote! {
+                #ty_self: #root::Merge<#ty_othr>
+            }
+        });
+
+    let ident = &item_struct.ident;
+    let (_, ty_generics_self, _) = item_struct.generics.split_for_impl();
+    let (_, ty_generics_othr, _) = item_struct_renamed.generics.split_for_impl();
+    let (impl_generics_both, _, _) = combined_generics.split_for_impl();
+    quote! {
+        impl #impl_generics_both #root::Merge<#ident #ty_generics_othr> for #ident #ty_generics_self
+        where
+            #both_where_predicates
+            #( #merge_where_predicates ),*
+        {
+            fn merge(&mut self, other: #ident #ty_generics_othr) -> bool {
+                let mut changed = false;
+                #(
+                    changed |= #root::Merge::merge(&mut self.#field_names, other.#field_names);
+                )*
+                changed
+            }
+        }
+    }
+}
+
+/// See [`derive_lattice_ord_macro`].
+fn derive_lattice_ord(
+    ProcessItemStruct {
+        root,
+        item_struct,
+        item_struct_renamed,
+        self_where_predicates: _,
+        both_where_predicates,
+        field_names,
+        combined_generics,
+    }: &ProcessItemStruct,
+) -> TokenStream {
+    // PartialEq.
+    let pareq_where_predicates = item_struct
+        .fields
+        .iter()
+        .zip(item_struct_renamed.fields.iter())
+        .map(|(field_self, field_othr)| {
+            let ty_self = &field_self.ty;
+            let ty_othr = &field_othr.ty;
+            quote! {
+                #ty_self: ::core::cmp::PartialEq<#ty_othr>
+            }
+        });
+    // PartialOrd and LatticeOrd.
+    let compare_where_predicates = item_struct
+        .fields
+        .iter()
+        .zip(item_struct_renamed.fields.iter())
+        .map(|(field_self, field_othr)| {
+            let ty_self = &field_self.ty;
+            let ty_othr = &field_othr.ty;
+            quote! {
+                #ty_self: ::core::cmp::PartialOrd<#ty_othr>
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let ident = &item_struct.ident;
+    let (_, ty_generics_self, _) = item_struct.generics.split_for_impl();
+    let (_, ty_generics_othr, _) = item_struct_renamed.generics.split_for_impl();
+    let (impl_generics_both, _, _) = combined_generics.split_for_impl();
+    quote! {
+        impl #impl_generics_both ::core::cmp::PartialEq<#ident #ty_generics_othr> for #ident #ty_generics_self
+        where
+            #both_where_predicates
+            #( #pareq_where_predicates ),*
+        {
+            fn eq(&self, other: &#ident #ty_generics_othr) -> bool {
+                #(
+                    if !::core::cmp::PartialEq::eq(&self.#field_names, &other.#field_names) {
+                        return false;
+                    }
+                )*
+                true
+            }
+        }
+
+        impl #impl_generics_both ::core::cmp::PartialOrd<#ident #ty_generics_othr> for #ident #ty_generics_self
+        where
+            #both_where_predicates
+            #( #compare_where_predicates ),*
+        {
+            fn partial_cmp(&self, other: &#ident #ty_generics_othr) -> ::core::option::Option<::core::cmp::Ordering> {
+                let mut self_any_greater = false;
+                let mut othr_any_greater = false;
+                #(
+                    // `?` short-circuits `None` (uncomparable).
+                    match ::core::cmp::PartialOrd::partial_cmp(&self.#field_names, &other.#field_names)? {
+                        ::core::cmp::Ordering::Less => {
+                            othr_any_greater = true;
+                        }
+                        ::core::cmp::Ordering::Greater => {
+                            self_any_greater = true;
+                        }
+                        ::core::cmp::Ordering::Equal => {}
+                    }
+                    if self_any_greater && othr_any_greater {
+                        return ::core::option::Option::None;
+                    }
+                )*
+                ::core::option::Option::Some(
+                    match (self_any_greater, othr_any_greater) {
+                        (false, false) => ::core::cmp::Ordering::Equal,
+                        (false, true) => ::core::cmp::Ordering::Less,
+                        (true, false) => ::core::cmp::Ordering::Greater,
+                        (true, true) => ::core::unreachable!(),
+                    }
+                )
+            }
+        }
+        impl #impl_generics_both #root::LatticeOrd<#ident #ty_generics_othr> for #ident #ty_generics_self
+        where
+            #both_where_predicates
+            #( #compare_where_predicates ),*
+        {}
+    }
+}
+
+/// See [`derive_is_bot_macro`].
+fn derive_is_bot(
+    ProcessItemStruct {
+        root,
+        item_struct,
+        item_struct_renamed: _,
+        self_where_predicates,
+        both_where_predicates: _,
+        field_names,
+        combined_generics: _,
+    }: &ProcessItemStruct,
+) -> TokenStream {
+    let isbot_where_predicates = item_struct.fields.iter().map(|Field { ty, .. }| {
+        quote! {
+            #ty: #root::IsBot
+        }
+    });
+
+    let ident = &item_struct.ident;
+    let (impl_generics_self, ty_generics_self, _) = item_struct.generics.split_for_impl();
+    quote! {
+        impl #impl_generics_self #root::IsBot for #ident #ty_generics_self
+        where
+            #self_where_predicates
+            #( #isbot_where_predicates ),*
+        {
+            fn is_bot(&self) -> bool {
+                #(
+                    if !#root::IsBot::is_bot(&self.#field_names) {
+                        return false;
+                    }
+                )*
+                true
+            }
+        }
+    }
+}
+
+/// See [`derive_is_top_macro`].
+fn derive_is_top(
+    ProcessItemStruct {
+        root,
+        item_struct,
+        item_struct_renamed: _,
+        self_where_predicates,
+        both_where_predicates: _,
+        field_names,
+        combined_generics: _,
+    }: &ProcessItemStruct,
+) -> TokenStream {
+    let istop_where_predicates = item_struct.fields.iter().map(|Field { ty, .. }| {
+        quote! {
+            #ty: #root::IsTop
+        }
+    });
+
+    let ident = &item_struct.ident;
+    let (impl_generics_self, ty_generics_self, _) = item_struct.generics.split_for_impl();
+    quote! {
+        impl #impl_generics_self #root::IsTop for #ident #ty_generics_self
+        where
+            #self_where_predicates
+            #( #istop_where_predicates ),*
+        {
+            fn is_top(&self) -> bool {
+                #(
+                    if !#root::IsTop::is_top(&self.#field_names) {
+                        return false;
+                    }
+                )*
+                true
+            }
+        }
+    }
+}
+
+/// See [`derive_lattice_from_macro`].
+fn derive_lattice_from(
+    ProcessItemStruct {
+        root,
+        item_struct,
+        item_struct_renamed,
+        self_where_predicates: _,
+        both_where_predicates,
+        field_names,
+        combined_generics,
+    }: &ProcessItemStruct,
+) -> TokenStream {
+    let latticefrom_where_predicates = item_struct
+        .fields
+        .iter()
+        .zip(item_struct_renamed.fields.iter())
+        .map(|(field_self, field_othr)| {
+            let ty_self = &field_self.ty;
+            let ty_othr = &field_othr.ty;
+            quote! {
+                #ty_self: #root::LatticeFrom<#ty_othr>
+            }
+        });
+
+    let ident = &item_struct.ident;
+    let (_, ty_generics_self, _) = item_struct.generics.split_for_impl();
+    let (_, ty_generics_othr, _) = item_struct_renamed.generics.split_for_impl();
+    let (impl_generics_both, _, _) = combined_generics.split_for_impl();
+    quote! {
+        impl #impl_generics_both #root::LatticeFrom<#ident #ty_generics_othr> for #ident #ty_generics_self
+        where
+            #both_where_predicates
+            #( #latticefrom_where_predicates ),*
+        {
+            fn lattice_from(other: #ident #ty_generics_othr) -> Self {
+                Self {
+                    #(
+                        #field_names: #root::LatticeFrom::lattice_from(other.#field_names),
+                    )*
+                }
+            }
+        }
+    }
+}
+
+/// Also see `lattices/tests/macro.rs`
+#[cfg(test)]
+mod test {
+    use syn::parse_quote;
+
+    use super::*;
+
+    /// Snapshots the macro output without actually testing if it compiles.
+    /// See `lattices/tests/macro.rs` for compiling tests.
+    macro_rules! assert_derive_snapshots {
+        ( $( $t:tt )* ) => {
+            {
+                let item = parse_quote! {
+                    $( $t )*
+                };
+                let process_item_struct = process_item_struct(item);
+                let derive_lattice = derive_lattice(&process_item_struct);
+                insta::assert_snapshot!(prettyplease::unparse(&parse_quote! { #derive_lattice }));
+            }
+        };
+    }
+
+    #[test]
+    fn derive_example() {
+        assert_derive_snapshots! {
+            struct MyLattice<KeySet, Epoch> {
+                keys: SetUnion<KeySet>,
+                epoch: Max<Epoch>,
+            }
+        };
+    }
+
+    #[test]
+    fn derive_pair() {
+        assert_derive_snapshots! {
+            pub struct Pair<LatA, LatB> {
+                pub a: LatA,
+                pub b: LatB,
+            }
+        };
+    }
+
+    #[test]
+    fn derive_similar_fields() {
+        // Will create duplicate where clauses, but that is OK.
+        assert_derive_snapshots! {
+            pub struct SimilarFields {
+                a: Max<usize>,
+                b: Max<usize>,
+                c: Max<usize>,
+            }
+        };
+    }
+}

--- a/lattices_macro/src/snapshots/lattices_macro__test__derive_example.snap
+++ b/lattices_macro/src/snapshots/lattices_macro__test__derive_example.snap
@@ -1,0 +1,153 @@
+---
+source: lattices_macro/src/lib.rs
+expression: "prettyplease::unparse(&parse_quote! { # derive_lattice })"
+---
+impl<
+    KeySet,
+    Epoch,
+    __KeySetOther,
+    __EpochOther,
+> lattices::Merge<MyLattice<__KeySetOther, __EpochOther>> for MyLattice<KeySet, Epoch>
+where
+    SetUnion<KeySet>: lattices::Merge<SetUnion<__KeySetOther>>,
+    Max<Epoch>: lattices::Merge<Max<__EpochOther>>,
+{
+    fn merge(&mut self, other: MyLattice<__KeySetOther, __EpochOther>) -> bool {
+        let mut changed = false;
+        changed |= lattices::Merge::merge(&mut self.keys, other.keys);
+        changed |= lattices::Merge::merge(&mut self.epoch, other.epoch);
+        changed
+    }
+}
+impl<
+    KeySet,
+    Epoch,
+    __KeySetOther,
+    __EpochOther,
+> ::core::cmp::PartialEq<MyLattice<__KeySetOther, __EpochOther>>
+for MyLattice<KeySet, Epoch>
+where
+    SetUnion<KeySet>: ::core::cmp::PartialEq<SetUnion<__KeySetOther>>,
+    Max<Epoch>: ::core::cmp::PartialEq<Max<__EpochOther>>,
+{
+    fn eq(&self, other: &MyLattice<__KeySetOther, __EpochOther>) -> bool {
+        if !::core::cmp::PartialEq::eq(&self.keys, &other.keys) {
+            return false;
+        }
+        if !::core::cmp::PartialEq::eq(&self.epoch, &other.epoch) {
+            return false;
+        }
+        true
+    }
+}
+impl<
+    KeySet,
+    Epoch,
+    __KeySetOther,
+    __EpochOther,
+> ::core::cmp::PartialOrd<MyLattice<__KeySetOther, __EpochOther>>
+for MyLattice<KeySet, Epoch>
+where
+    SetUnion<KeySet>: ::core::cmp::PartialOrd<SetUnion<__KeySetOther>>,
+    Max<Epoch>: ::core::cmp::PartialOrd<Max<__EpochOther>>,
+{
+    fn partial_cmp(
+        &self,
+        other: &MyLattice<__KeySetOther, __EpochOther>,
+    ) -> ::core::option::Option<::core::cmp::Ordering> {
+        let mut self_any_greater = false;
+        let mut othr_any_greater = false;
+        match ::core::cmp::PartialOrd::partial_cmp(&self.keys, &other.keys)? {
+            ::core::cmp::Ordering::Less => {
+                othr_any_greater = true;
+            }
+            ::core::cmp::Ordering::Greater => {
+                self_any_greater = true;
+            }
+            ::core::cmp::Ordering::Equal => {}
+        }
+        if self_any_greater && othr_any_greater {
+            return ::core::option::Option::None;
+        }
+        match ::core::cmp::PartialOrd::partial_cmp(&self.epoch, &other.epoch)? {
+            ::core::cmp::Ordering::Less => {
+                othr_any_greater = true;
+            }
+            ::core::cmp::Ordering::Greater => {
+                self_any_greater = true;
+            }
+            ::core::cmp::Ordering::Equal => {}
+        }
+        if self_any_greater && othr_any_greater {
+            return ::core::option::Option::None;
+        }
+        ::core::option::Option::Some(
+            match (self_any_greater, othr_any_greater) {
+                (false, false) => ::core::cmp::Ordering::Equal,
+                (false, true) => ::core::cmp::Ordering::Less,
+                (true, false) => ::core::cmp::Ordering::Greater,
+                (true, true) => ::core::unreachable!(),
+            },
+        )
+    }
+}
+impl<
+    KeySet,
+    Epoch,
+    __KeySetOther,
+    __EpochOther,
+> lattices::LatticeOrd<MyLattice<__KeySetOther, __EpochOther>>
+for MyLattice<KeySet, Epoch>
+where
+    SetUnion<KeySet>: ::core::cmp::PartialOrd<SetUnion<__KeySetOther>>,
+    Max<Epoch>: ::core::cmp::PartialOrd<Max<__EpochOther>>,
+{}
+impl<KeySet, Epoch> lattices::IsBot for MyLattice<KeySet, Epoch>
+where
+    SetUnion<KeySet>: lattices::IsBot,
+    Max<Epoch>: lattices::IsBot,
+{
+    fn is_bot(&self) -> bool {
+        if !lattices::IsBot::is_bot(&self.keys) {
+            return false;
+        }
+        if !lattices::IsBot::is_bot(&self.epoch) {
+            return false;
+        }
+        true
+    }
+}
+impl<KeySet, Epoch> lattices::IsTop for MyLattice<KeySet, Epoch>
+where
+    SetUnion<KeySet>: lattices::IsTop,
+    Max<Epoch>: lattices::IsTop,
+{
+    fn is_top(&self) -> bool {
+        if !lattices::IsTop::is_top(&self.keys) {
+            return false;
+        }
+        if !lattices::IsTop::is_top(&self.epoch) {
+            return false;
+        }
+        true
+    }
+}
+impl<
+    KeySet,
+    Epoch,
+    __KeySetOther,
+    __EpochOther,
+> lattices::LatticeFrom<MyLattice<__KeySetOther, __EpochOther>>
+for MyLattice<KeySet, Epoch>
+where
+    SetUnion<KeySet>: lattices::LatticeFrom<SetUnion<__KeySetOther>>,
+    Max<Epoch>: lattices::LatticeFrom<Max<__EpochOther>>,
+{
+    fn lattice_from(other: MyLattice<__KeySetOther, __EpochOther>) -> Self {
+        Self {
+            keys: lattices::LatticeFrom::lattice_from(other.keys),
+            epoch: lattices::LatticeFrom::lattice_from(other.epoch),
+        }
+    }
+}
+

--- a/lattices_macro/src/snapshots/lattices_macro__test__derive_pair.snap
+++ b/lattices_macro/src/snapshots/lattices_macro__test__derive_pair.snap
@@ -1,0 +1,149 @@
+---
+source: lattices_macro/src/lib.rs
+expression: "prettyplease::unparse(&parse_quote! { # derive_lattice })"
+---
+impl<
+    LatA,
+    LatB,
+    __LatAOther,
+    __LatBOther,
+> lattices::Merge<Pair<__LatAOther, __LatBOther>> for Pair<LatA, LatB>
+where
+    LatA: lattices::Merge<__LatAOther>,
+    LatB: lattices::Merge<__LatBOther>,
+{
+    fn merge(&mut self, other: Pair<__LatAOther, __LatBOther>) -> bool {
+        let mut changed = false;
+        changed |= lattices::Merge::merge(&mut self.a, other.a);
+        changed |= lattices::Merge::merge(&mut self.b, other.b);
+        changed
+    }
+}
+impl<
+    LatA,
+    LatB,
+    __LatAOther,
+    __LatBOther,
+> ::core::cmp::PartialEq<Pair<__LatAOther, __LatBOther>> for Pair<LatA, LatB>
+where
+    LatA: ::core::cmp::PartialEq<__LatAOther>,
+    LatB: ::core::cmp::PartialEq<__LatBOther>,
+{
+    fn eq(&self, other: &Pair<__LatAOther, __LatBOther>) -> bool {
+        if !::core::cmp::PartialEq::eq(&self.a, &other.a) {
+            return false;
+        }
+        if !::core::cmp::PartialEq::eq(&self.b, &other.b) {
+            return false;
+        }
+        true
+    }
+}
+impl<
+    LatA,
+    LatB,
+    __LatAOther,
+    __LatBOther,
+> ::core::cmp::PartialOrd<Pair<__LatAOther, __LatBOther>> for Pair<LatA, LatB>
+where
+    LatA: ::core::cmp::PartialOrd<__LatAOther>,
+    LatB: ::core::cmp::PartialOrd<__LatBOther>,
+{
+    fn partial_cmp(
+        &self,
+        other: &Pair<__LatAOther, __LatBOther>,
+    ) -> ::core::option::Option<::core::cmp::Ordering> {
+        let mut self_any_greater = false;
+        let mut othr_any_greater = false;
+        match ::core::cmp::PartialOrd::partial_cmp(&self.a, &other.a)? {
+            ::core::cmp::Ordering::Less => {
+                othr_any_greater = true;
+            }
+            ::core::cmp::Ordering::Greater => {
+                self_any_greater = true;
+            }
+            ::core::cmp::Ordering::Equal => {}
+        }
+        if self_any_greater && othr_any_greater {
+            return ::core::option::Option::None;
+        }
+        match ::core::cmp::PartialOrd::partial_cmp(&self.b, &other.b)? {
+            ::core::cmp::Ordering::Less => {
+                othr_any_greater = true;
+            }
+            ::core::cmp::Ordering::Greater => {
+                self_any_greater = true;
+            }
+            ::core::cmp::Ordering::Equal => {}
+        }
+        if self_any_greater && othr_any_greater {
+            return ::core::option::Option::None;
+        }
+        ::core::option::Option::Some(
+            match (self_any_greater, othr_any_greater) {
+                (false, false) => ::core::cmp::Ordering::Equal,
+                (false, true) => ::core::cmp::Ordering::Less,
+                (true, false) => ::core::cmp::Ordering::Greater,
+                (true, true) => ::core::unreachable!(),
+            },
+        )
+    }
+}
+impl<
+    LatA,
+    LatB,
+    __LatAOther,
+    __LatBOther,
+> lattices::LatticeOrd<Pair<__LatAOther, __LatBOther>> for Pair<LatA, LatB>
+where
+    LatA: ::core::cmp::PartialOrd<__LatAOther>,
+    LatB: ::core::cmp::PartialOrd<__LatBOther>,
+{}
+impl<LatA, LatB> lattices::IsBot for Pair<LatA, LatB>
+where
+    LatA: lattices::IsBot,
+    LatB: lattices::IsBot,
+{
+    fn is_bot(&self) -> bool {
+        if !lattices::IsBot::is_bot(&self.a) {
+            return false;
+        }
+        if !lattices::IsBot::is_bot(&self.b) {
+            return false;
+        }
+        true
+    }
+}
+impl<LatA, LatB> lattices::IsTop for Pair<LatA, LatB>
+where
+    LatA: lattices::IsTop,
+    LatB: lattices::IsTop,
+{
+    fn is_top(&self) -> bool {
+        if !lattices::IsTop::is_top(&self.a) {
+            return false;
+        }
+        if !lattices::IsTop::is_top(&self.b) {
+            return false;
+        }
+        true
+    }
+}
+impl<
+    LatA,
+    LatB,
+    __LatAOther,
+    __LatBOther,
+> lattices::LatticeFrom<Pair<__LatAOther, __LatBOther>> for Pair<LatA, LatB>
+where
+    LatA: lattices::LatticeFrom<__LatAOther>,
+    LatB: lattices::LatticeFrom<__LatBOther>,
+{
+    fn lattice_from(other: Pair<__LatAOther, __LatBOther>) -> Self {
+        Self {
+            a: lattices::LatticeFrom::lattice_from(other.a),
+            b: lattices::LatticeFrom::lattice_from(other.b),
+        }
+    }
+}
+

--- a/lattices_macro/src/snapshots/lattices_macro__test__derive_similar_fields.snap
+++ b/lattices_macro/src/snapshots/lattices_macro__test__derive_similar_fields.snap
@@ -1,0 +1,154 @@
+---
+source: lattices_macro/src/lib.rs
+expression: "prettyplease::unparse(&parse_quote! { # derive_lattice })"
+---
+impl lattices::Merge<SimilarFields> for SimilarFields
+where
+    Max<usize>: lattices::Merge<Max<usize>>,
+    Max<usize>: lattices::Merge<Max<usize>>,
+    Max<usize>: lattices::Merge<Max<usize>>,
+{
+    fn merge(&mut self, other: SimilarFields) -> bool {
+        let mut changed = false;
+        changed |= lattices::Merge::merge(&mut self.a, other.a);
+        changed |= lattices::Merge::merge(&mut self.b, other.b);
+        changed |= lattices::Merge::merge(&mut self.c, other.c);
+        changed
+    }
+}
+impl ::core::cmp::PartialEq<SimilarFields> for SimilarFields
+where
+    Max<usize>: ::core::cmp::PartialEq<Max<usize>>,
+    Max<usize>: ::core::cmp::PartialEq<Max<usize>>,
+    Max<usize>: ::core::cmp::PartialEq<Max<usize>>,
+{
+    fn eq(&self, other: &SimilarFields) -> bool {
+        if !::core::cmp::PartialEq::eq(&self.a, &other.a) {
+            return false;
+        }
+        if !::core::cmp::PartialEq::eq(&self.b, &other.b) {
+            return false;
+        }
+        if !::core::cmp::PartialEq::eq(&self.c, &other.c) {
+            return false;
+        }
+        true
+    }
+}
+impl ::core::cmp::PartialOrd<SimilarFields> for SimilarFields
+where
+    Max<usize>: ::core::cmp::PartialOrd<Max<usize>>,
+    Max<usize>: ::core::cmp::PartialOrd<Max<usize>>,
+    Max<usize>: ::core::cmp::PartialOrd<Max<usize>>,
+{
+    fn partial_cmp(
+        &self,
+        other: &SimilarFields,
+    ) -> ::core::option::Option<::core::cmp::Ordering> {
+        let mut self_any_greater = false;
+        let mut othr_any_greater = false;
+        match ::core::cmp::PartialOrd::partial_cmp(&self.a, &other.a)? {
+            ::core::cmp::Ordering::Less => {
+                othr_any_greater = true;
+            }
+            ::core::cmp::Ordering::Greater => {
+                self_any_greater = true;
+            }
+            ::core::cmp::Ordering::Equal => {}
+        }
+        if self_any_greater && othr_any_greater {
+            return ::core::option::Option::None;
+        }
+        match ::core::cmp::PartialOrd::partial_cmp(&self.b, &other.b)? {
+            ::core::cmp::Ordering::Less => {
+                othr_any_greater = true;
+            }
+            ::core::cmp::Ordering::Greater => {
+                self_any_greater = true;
+            }
+            ::core::cmp::Ordering::Equal => {}
+        }
+        if self_any_greater && othr_any_greater {
+            return ::core::option::Option::None;
+        }
+        match ::core::cmp::PartialOrd::partial_cmp(&self.c, &other.c)? {
+            ::core::cmp::Ordering::Less => {
+                othr_any_greater = true;
+            }
+            ::core::cmp::Ordering::Greater => {
+                self_any_greater = true;
+            }
+            ::core::cmp::Ordering::Equal => {}
+        }
+        if self_any_greater && othr_any_greater {
+            return ::core::option::Option::None;
+        }
+        ::core::option::Option::Some(
+            match (self_any_greater, othr_any_greater) {
+                (false, false) => ::core::cmp::Ordering::Equal,
+                (false, true) => ::core::cmp::Ordering::Less,
+                (true, false) => ::core::cmp::Ordering::Greater,
+                (true, true) => ::core::unreachable!(),
+            },
+        )
+    }
+}
+impl lattices::LatticeOrd<SimilarFields> for SimilarFields
+where
+    Max<usize>: ::core::cmp::PartialOrd<Max<usize>>,
+    Max<usize>: ::core::cmp::PartialOrd<Max<usize>>,
+    Max<usize>: ::core::cmp::PartialOrd<Max<usize>>,
+{}
+impl lattices::IsBot for SimilarFields
+where
+    Max<usize>: lattices::IsBot,
+    Max<usize>: lattices::IsBot,
+    Max<usize>: lattices::IsBot,
+{
+    fn is_bot(&self) -> bool {
+        if !lattices::IsBot::is_bot(&self.a) {
+            return false;
+        }
+        if !lattices::IsBot::is_bot(&self.b) {
+            return false;
+        }
+        if !lattices::IsBot::is_bot(&self.c) {
+            return false;
+        }
+        true
+    }
+}
+impl lattices::IsTop for SimilarFields
+where
+    Max<usize>: lattices::IsTop,
+    Max<usize>: lattices::IsTop,
+    Max<usize>: lattices::IsTop,
+{
+    fn is_top(&self) -> bool {
+        if !lattices::IsTop::is_top(&self.a) {
+            return false;
+        }
+        if !lattices::IsTop::is_top(&self.b) {
+            return false;
+        }
+        if !lattices::IsTop::is_top(&self.c) {
+            return false;
+        }
+        true
+    }
+}
+impl lattices::LatticeFrom<SimilarFields> for SimilarFields
+where
+    Max<usize>: lattices::LatticeFrom<Max<usize>>,
+    Max<usize>: lattices::LatticeFrom<Max<usize>>,
+    Max<usize>: lattices::LatticeFrom<Max<usize>>,
+{
+    fn lattice_from(other: SimilarFields) -> Self {
+        Self {
+            a: lattices::LatticeFrom::lattice_from(other.a),
+            b: lattices::LatticeFrom::lattice_from(other.b),
+            c: lattices::LatticeFrom::lattice_from(other.c),
+        }
+    }
+}
+

--- a/precheck.bash
+++ b/precheck.bash
@@ -17,6 +17,6 @@ cargo clippy --all-targets --features python -- -D warnings
 
 INSTA_FORCE_PASS=1 INSTA_UPDATE=always TRYBUILD=overwrite cargo test --all-targets --no-fail-fast --features python
 cargo test --doc
-[ "$FULL" = true ] && RUSTDOCFLAGS="-Dwarnings" -cargo doc --no-deps
+[ "$FULL" = true ] && RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps
 
 [ "$FULL" = true ] && CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner cargo test -p hydroflow --target wasm32-unknown-unknown --tests --no-fail-fast


### PR DESCRIPTION
This adds derive macros to allow user-created macros. Each field must be a lattice.

Example usage:
```rust
struct MyLattice<KeySet, Epoch>
where
    KeySet: Collection,
    Epoch: Ord,
{
    keys: SetUnion<KeySet>,
    epoch: Max<Epoch>,
}
```

Uses `#[derive(Lattice)]` for the `lattices` library `Pair` lattice.
Also contains some cleanup in the `lattices` crate.