### PR TITLE
feat(anna): Added support for user tables

### DIFF
--- a/datastores/gossip_kv/server/main.rs
+++ b/datastores/gossip_kv/server/main.rs
@@ -9,7 +9,7 @@ use hydroflow::lattices::PairBimorphism;
 use hydroflow::util::{bind_udp_bytes, ipv4_resolve};
 use hydroflow::{hydroflow_syntax, tokio, DemuxEnum};
 
-use crate::model::{delete_row, upsert_row, Clock, RowKey, TableMap, TableName};
+use crate::model::{delete_row, upsert_row, Clock, Namespaces, RowKey, TableName};
 
 mod model;
 
@@ -45,10 +45,7 @@ async fn main() {
     let address = ipv4_resolve("localhost:3000").unwrap();
     let (outbound, inbound, _) = bind_udp_bytes(address).await;
 
-    // let foobar: MapUnion<TableName, MapUnion<RowKey, Pair<RowValue, SetUnion<SocketAddr>>>> = MapUnion::new_from(HashMap::new());;
-
     let mut server = hydroflow_syntax! {
-
         outbound_messages = dest_sink_serde(outbound);
 
         inbound_messages = source_stream_serde(inbound)
@@ -58,65 +55,74 @@ async fn main() {
 
         inbound_messages[Get]
             -> inspect(|req| println!("Received Get request: {:?}", req))
-            -> filter(|(key, _)| {
-                match key.namespace {
-                    Namespace::System => true,
-                    _ => {
-                        // TODO: Support user namespace https://github.com/hydro-project/hydroflow/issues/1255
-                        eprintln!("Unsupported namespace: {:?}", key.namespace);
-                        false
-                    },
-                }
+            -> map(|(key, addr) : (Key, SocketAddr)| {
+                let row = MapUnionHashMap::new_from([
+                        (
+                            key.row_key,
+                            SetUnionHashSet::new_from([addr /* to respond with the result later*/])
+                        ),
+                ]);
+                let table = MapUnionHashMap::new_from([(key.table, row)]);
+                MapUnionHashMap::new_from([(key.namespace, table)])
             })
-            -> map(|(key, addr) : (Key, SocketAddr)| MapUnionHashMap::new_from([(key.table, MapUnionHashMap::new_from([(key.row_key, SetUnionHashSet::new_from([addr]))]))]))
-            -> system_table_gets;
+            -> gets;
 
         inbound_messages[Set]
             -> inspect(|request| println!("Received Set request: {:?}", request))
-            -> map(|(key, value, _addr) : (Key, String, SocketAddr)| upsert_row(Clock::new(context.current_tick().0), key.table, key.row_key, value))
-            -> system_table;
+            -> map(|(key, value, _addr) : (Key, String, SocketAddr)| upsert_row(Clock::new(context.current_tick().0), key.namespace, key.table, key.row_key, value))
+            -> namespaces;
 
         inbound_messages[Delete]
             -> inspect(|req| println!("Received Delete request: {:?}", req))
-            -> map(|(key, _addr) : (Key, SocketAddr)| delete_row(Clock::new(context.current_tick().0), key.table, key.row_key))
-            -> system_table;
+            -> map(|(key, _addr) : (Key, SocketAddr)| delete_row(Clock::new(context.current_tick().0), key.namespace, key.table, key.row_key))
+            -> namespaces;
 
-        system_table = union()
-            -> state::<'static, TableMap::<Clock>>();
+        namespaces = union()
+            -> state::<'static, Namespaces::<Clock>>();
 
-        system_table_gets = union()
-            -> state::<'tick, MapUnionHashMap<TableName, MapUnionHashMap<RowKey, SetUnionHashSet<SocketAddr>>>>();
+        gets = state::<'tick, MapUnionHashMap<Namespace, MapUnionHashMap<TableName, MapUnionHashMap<RowKey, SetUnionHashSet<SocketAddr>>>>>();
 
-        system_table -> [0]process_system_table_gets;
-        system_table_gets -> [1]process_system_table_gets;
+        namespaces -> [0]process_system_table_gets;
+        gets -> [1]process_system_table_gets;
 
-        process_system_table_gets = lattice_bimorphism(KeyedBimorphism::<HashMap<_, _>, _>::new(KeyedBimorphism::<HashMap<_, _>, _>::new(PairBimorphism)), #system_table, #system_table_gets)
+        process_system_table_gets = lattice_bimorphism(KeyedBimorphism::<HashMap<_, _>, _>::new(KeyedBimorphism::<HashMap<_, _>, _>::new(KeyedBimorphism::<HashMap<_, _>, _>::new(PairBimorphism))), #namespaces, #gets)
             -> flat_map(|result| {
 
-                    let mut response: Vec<(ClientResponse, SocketAddr)> = vec![];
+                let mut response: Vec<(ClientResponse, SocketAddr)> = vec![];
 
-                    // TODO: Support multiple results. https://github.com/hydro-project/hydroflow/issues/1256
+                // TODO: Support multiple results. https://github.com/hydro-project/hydroflow/issues/1256
                     let result = result.as_reveal_ref();
-                    for (table_name, table) in result.iter() {
-                        for (row_key, row_val) in table.as_reveal_ref().iter() {
-                            let key = Key {
-                                namespace: Namespace::System,
-                                table: table_name.clone(),
-                                row_key: row_key.clone(),
-                            };
+                    for (namespace, tables) in result.iter() {
+                        for (table_name, table) in tables.as_reveal_ref().iter() {
+                            for (row_key, join_results) in table.as_reveal_ref().iter() {
+                                let key = Key {
+                                    namespace: *namespace,
+                                    table: table_name.clone(),
+                                    row_key: row_key.clone(),
+                                };
 
-                            let value = row_val.as_reveal_ref().0.as_reveal_ref().1.as_reveal_ref().iter().find_or_first(|_| true).unwrap();
-                            let socket_addr = row_val.as_reveal_ref().1.as_reveal_ref().iter().find_or_first(|_| true).unwrap();
-                            response.push((ClientResponse::Get { key, value: Some(value.clone()) }, *socket_addr));
+                                let timestamped_values = join_results.as_reveal_ref().0;
+                                let all_values = timestamped_values.as_reveal_ref().1.as_reveal_ref();
+                                let first_value = all_values.iter().find_or_first(|_| true).unwrap();
+
+                                let all_addresses = join_results.as_reveal_ref().1.as_reveal_ref();
+                                let socket_addr = all_addresses.iter().find_or_first(|_| true).unwrap();
+
+                                response.push((
+                                    ClientResponse::Get {key, value: Some(first_value.clone())},
+                                    *socket_addr,
+                            ));
                         }
                     }
+                }
 
-                    response
-               }) -> outbound_messages;
+                response
+
+            }) -> outbound_messages;
 
         // Uncomment to aid with debugging.
         // source_interval(Duration::from_secs(3))
-        //    -> for_each(|_| println!("State: {:?}", #system_table));
+        //    -> for_each(|_| println!("State: {:?}", #namespaces));
     };
 
     server.run_async().await;


### PR DESCRIPTION
There were three options I tried here.

1. We could add another `state()` for the user table and `demux` requests over the `user` and `system` state. I have tried this, and it has led to significant, ugly code duplication.
2. Use [Mingwei's lattice macro](https://github.com/hydro-project/hydroflow/commit/b3d01c20cae2335a3da2c02343debe677f17786b) - seems like an ideal use case for the lattice since the requirements essentially call for a glorified `Pair<>`. However, there's no way to "project" lattice members out and use them in joins. Mingwei has [created an issue for this](https://github.com/hydro-project/hydroflow/issues/1263).
3. Add another nesting level with `MapUnionHashMap<Namespace, ...>` - which is what this PR does.

