### PR TITLE
feat(anna): Server node adds itself to sys/members on start-up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,7 +1262,10 @@ dependencies = [
  "clap",
  "hostname",
  "hydroflow",
+ "once_cell",
+ "rand 0.8.5",
  "serde",
+ "serde_json",
  "shlex",
  "tracing",
  "tracing-subscriber",
@@ -2908,9 +2911,9 @@ checksum = "5a9f47faea3cad316faa914d013d24f471cd90bfca1a0c70f05a3f42c6441e99"
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
@@ -2928,9 +2931,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2939,9 +2942,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "indexmap",
  "itoa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,7 +1262,6 @@ dependencies = [
  "clap",
  "hostname",
  "hydroflow",
- "once_cell",
  "rand 0.8.5",
  "serde",
  "serde_json",

--- a/datastores/gossip_kv/Cargo.toml
+++ b/datastores/gossip_kv/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 clap = { version = "4.5.4", features = ["derive"] }
 hostname = "0.4.0"
 hydroflow = { path="../../hydroflow" }
-once_cell = "1.19.0"
 rand = "0.8.5"
 serde = "1.0.203"
 serde_json = "1.0.117"

--- a/datastores/gossip_kv/Cargo.toml
+++ b/datastores/gossip_kv/Cargo.toml
@@ -8,9 +8,12 @@ publish = false
 
 [dependencies]
 clap = { version = "4.5.4", features = ["derive"] }
-serde = { version = "1.0.198", features = ["derive"] }
-hydroflow = { path="../../hydroflow" }
 hostname = "0.4.0"
+hydroflow = { path="../../hydroflow" }
+once_cell = "1.19.0"
+rand = "0.8.5"
+serde = "1.0.203"
+serde_json = "1.0.117"
 shlex = "1.3.0"
 tracing = "0.1.40"
 tracing-subscriber = {version = "0.3.18", features = ["env-filter"]}

--- a/datastores/gossip_kv/protocol/lib.rs
+++ b/datastores/gossip_kv/protocol/lib.rs
@@ -1,3 +1,5 @@
+pub mod membership;
+
 use std::collections::HashSet;
 use std::fmt::Display;
 use std::str::FromStr;

--- a/datastores/gossip_kv/protocol/membership.rs
+++ b/datastores/gossip_kv/protocol/membership.rs
@@ -1,0 +1,83 @@
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use serde::{Deserialize, Serialize};
+
+/// Information about a member in the cluster.
+///
+/// A member is a transducer that is part of the cluster. Leaving or failing is a terminal
+/// state for a member. When a transducer restarts and rejoins the cluster, it is considered a
+/// new member.
+///
+/// # Generic Parameters
+/// -- `A`: The transport of the endpoint on which the protocol is running. In production, this will
+/// likely be a `SocketAddr`.
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+pub struct MemberData<A>
+where
+    A: Debug + Clone + Eq + Hash + Serialize,
+{
+    /// The name of the member. Usually, this is a randomly generated identifier, based on the
+    /// hostname on which the member is running.
+    pub name: String,
+
+    /// The protocols that the member supports.
+    pub protocols: Vec<Protocol<A>>,
+}
+
+/// A builder for `MemberData`.
+pub struct MemberDataBuilder<A>
+where
+    A: Debug + Clone + Eq + Hash + Serialize,
+{
+    name: String,
+    protocols: Vec<Protocol<A>>,
+}
+
+impl<A> MemberDataBuilder<A>
+where
+    A: Debug + Clone + Eq + Hash + Serialize,
+{
+    /// Creates a new `MemberDataBuilder`.
+    pub fn new(name: String) -> Self {
+        MemberDataBuilder {
+            name,
+            protocols: Vec::new(),
+        }
+    }
+
+    /// Adds a protocol to the member.
+    pub fn add_protocol(mut self, protocol: Protocol<A>) -> Self {
+        self.protocols.push(protocol);
+        self
+    }
+
+    /// Builds the `MemberData`.
+    pub fn build(self) -> MemberData<A> {
+        MemberData {
+            name: self.name,
+            protocols: self.protocols,
+        }
+    }
+}
+
+/// A protocol supported by a member.
+///
+/// # Generic Parameters
+/// -- `A`: The transport of the endpoint on which the protocol is running. In production, this will
+/// likely be a `SocketAddr`.
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+pub struct Protocol<A> {
+    /// The name of the protocol.
+    pub name: String,
+
+    /// The endpoint on which the protocol is running.
+    pub endpoint: A,
+}
+
+impl<A> Protocol<A> {
+    /// Creates a new `Protocol`.
+    pub fn new(name: String, endpoint: A) -> Self {
+        Protocol { name, endpoint }
+    }
+}

--- a/datastores/gossip_kv/server/main.rs
+++ b/datastores/gossip_kv/server/main.rs
@@ -40,7 +40,7 @@ async fn main() {
     // Setup protocol information in the member metadata.
     let client_protocol_address =
         SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), opts.client_port);
-    let member_data = MemberDataBuilder::new(member_name())
+    let member_data = MemberDataBuilder::new(member_name().clone())
         .add_protocol(Protocol::new("client".into(), client_protocol_address))
         .build();
 

--- a/datastores/gossip_kv/server/main.rs
+++ b/datastores/gossip_kv/server/main.rs
@@ -1,136 +1,57 @@
-use std::collections::HashMap;
 use std::fmt::Debug;
 use std::future::ready;
 use std::hash::Hash;
 use std::io::Error;
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-use gossip_protocol::{ClientRequest, ClientResponse, Key, Namespace};
-use hydroflow::futures::{Sink, SinkExt, Stream, StreamExt};
-use hydroflow::itertools::Itertools;
-use hydroflow::lattices::map_union::{KeyedBimorphism, MapUnionHashMap};
-use hydroflow::lattices::set_union::SetUnionHashSet;
-use hydroflow::lattices::PairBimorphism;
-use hydroflow::scheduled::graph::Hydroflow;
-use hydroflow::util::{bind_udp_bytes, ipv4_resolve};
-use hydroflow::{bincode, hydroflow_syntax, tokio, DemuxEnum};
-use tracing::{error, trace};
+use clap::Parser;
+use gossip_protocol::membership::{MemberDataBuilder, Protocol};
+use gossip_protocol::ClientRequest;
+use hydroflow::futures::{SinkExt, StreamExt};
+use hydroflow::util::bind_udp_bytes;
+use hydroflow::{bincode, tokio};
+use tracing::{error, info};
 
-use crate::model::{delete_row, upsert_row, Clock, Namespaces, RowKey, TableName};
+use crate::membership::member_name;
+use crate::server::server;
 
+mod membership;
 mod model;
+mod server;
+mod util;
 
-#[derive(Debug, DemuxEnum)]
-enum ClientRequestWithAddress<A> {
-    Get { key: Key, addr: A },
-    Set { key: Key, value: String, addr: A },
-    Delete { key: Key, addr: A },
-}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Parser)]
+struct Opts {
+    /// Port to listen for gossip messages.
+    #[clap(short, long, default_value = "3000")]
+    gossip_port: u16,
 
-impl<A> ClientRequestWithAddress<A> {
-    fn from_request_and_address(request: ClientRequest, addr: A) -> Self {
-        match request {
-            ClientRequest::Get { key } => Self::Get { key, addr },
-            ClientRequest::Set { key, value } => Self::Set { key, value, addr },
-            ClientRequest::Delete { key } => Self::Delete { key, addr },
-        }
-    }
-}
-
-fn server<I, O, A, E>(ib: I, ob: O) -> Hydroflow<'static>
-where
-    I: Stream<Item = (ClientRequest, A)> + Unpin + 'static,
-    O: Sink<(ClientResponse, A), Error = E> + Unpin + 'static,
-    A: Hash + Debug + Clone + Eq + 'static, // "Address"
-    E: Debug + 'static,
-{
-    hydroflow_syntax! {
-        outbound_messages =
-            inspect(|(resp, addr)| trace!("Sending response: {:?} to {:?}", resp, addr))
-            -> dest_sink(ob);
-
-        inbound_messages = source_stream(ib)
-            -> map(|(msg, addr)| ClientRequestWithAddress::from_request_and_address(msg, addr))
-            -> demux_enum::<ClientRequestWithAddress<A>>();
-
-        inbound_messages[Get]
-            -> inspect(|req| trace!("Received Get request: {:?} at {:?}", req, context.current_tick()))
-            -> map(|(key, addr) : (Key, A)| {
-                let row = MapUnionHashMap::new_from([
-                        (
-                            key.row_key,
-                            SetUnionHashSet::new_from([addr /* to respond with the result later*/])
-                        ),
-                ]);
-                let table = MapUnionHashMap::new_from([(key.table, row)]);
-                MapUnionHashMap::new_from([(key.namespace, table)])
-            })
-            -> gets;
-
-        inbound_messages[Set]
-            -> inspect(|request| trace!("Received Set request: {:?} at {:?}", request, context.current_tick()))
-            -> map(|(key, value, _addr) : (Key, String, A)| upsert_row(Clock::new(context.current_tick().0), key.namespace, key.table, key.row_key, value))
-            -> namespaces;
-
-        inbound_messages[Delete]
-            -> inspect(|req| trace!("Received Delete request: {:?} at {:?}", req, context.current_tick()))
-            -> map(|(key, _addr) : (Key, A)| delete_row(Clock::new(context.current_tick().0), key.namespace, key.table, key.row_key))
-            -> namespaces;
-
-        namespaces = union()
-            -> state::<'static, Namespaces::<Clock>>();
-
-        gets = state::<'tick, MapUnionHashMap<Namespace, MapUnionHashMap<TableName, MapUnionHashMap<RowKey, SetUnionHashSet<A>>>>>();
-
-        namespaces -> [0]process_system_table_gets;
-        gets -> [1]process_system_table_gets;
-
-        process_system_table_gets = lattice_bimorphism(KeyedBimorphism::<HashMap<_, _>, _>::new(KeyedBimorphism::<HashMap<_, _>, _>::new(KeyedBimorphism::<HashMap<_, _>, _>::new(PairBimorphism))), #namespaces, #gets)
-            -> flat_map(|result| {
-
-                let mut response: Vec<(ClientResponse, A)> = vec![];
-
-                    let result = result.as_reveal_ref();
-                    for (namespace, tables) in result.iter() {
-                        for (table_name, table) in tables.as_reveal_ref().iter() {
-                            for (row_key, join_results) in table.as_reveal_ref().iter() {
-                                let key = Key {
-                                    namespace: *namespace,
-                                    table: table_name.clone(),
-                                    row_key: row_key.clone(),
-                                };
-
-                                let timestamped_values = join_results.as_reveal_ref().0;
-                                let all_values = timestamped_values.as_reveal_ref().1.as_reveal_ref();
-
-                                let all_addresses = join_results.as_reveal_ref().1.as_reveal_ref();
-                                let socket_addr = all_addresses.iter().find_or_first(|_| true).unwrap();
-
-                                response.push((
-                                    ClientResponse::Get {key, value: all_values.clone()},
-                                    socket_addr.clone(),
-                            ));
-                        }
-                    }
-                }
-
-                response
-
-            }) -> outbound_messages;
-
-        // Uncomment to aid with debugging.
-        // source_interval(Duration::from_secs(3))
-        //    -> for_each(|_| println!("State: {:?}", #namespaces));
-    }
+    /// Port to listen for client requests.
+    #[clap(short, long, default_value = "3001")]
+    client_port: u16,
 }
 
 #[hydroflow::main]
 async fn main() {
     tracing_subscriber::fmt::init();
 
-    let address = ipv4_resolve("localhost:3000").unwrap();
-    let (outbound, inbound, _) = bind_udp_bytes(address).await;
+    let opts: Opts = Opts::parse();
 
+    // Setup protocol information in the member metadata.
+    let client_protocol_address =
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), opts.client_port);
+    let member_data = MemberDataBuilder::new(member_name())
+        .add_protocol(Protocol::new("client".into(), client_protocol_address))
+        .build();
+
+    let (outbound, inbound, _) = bind_udp_bytes(client_protocol_address).await;
+
+    info!(
+        "Server {:?} listening for client requests on: {:?}",
+        member_data.name, client_protocol_address
+    );
+
+    // Setup message serialization for outbound client responses.
     let ob = outbound.with(|(msg, addr)| {
         ready(Ok::<(hydroflow::bytes::Bytes, SocketAddr), Error>((
             hydroflow::util::serialize_to_bytes(msg),
@@ -138,6 +59,7 @@ async fn main() {
         )))
     });
 
+    // Setup message deserialization for inbound client requests.
     let ib = inbound.filter_map(|input| {
         let mapped = match input {
             Ok((bytes, addr)) => {
@@ -159,76 +81,7 @@ async fn main() {
         ready(mapped)
     });
 
-    let mut server = server(ib, ob);
-
+    // Create and run the server
+    let mut server = server(ib, ob, member_data);
     server.run_async().await;
-}
-
-#[cfg(test)]
-mod tests {
-    use std::collections::HashSet;
-    use std::convert::Infallible;
-
-    use hydroflow::futures::sink;
-
-    use super::*;
-    fn sink_from_fn<T>(mut f: impl FnMut(T)) -> impl Sink<T, Error = Infallible> {
-        sink::drain().with(move |item| {
-            (f)(item);
-            ready(Result::<(), Infallible>::Ok(()))
-        })
-    }
-
-    #[hydroflow::test]
-    async fn test_multiple_values_same_tick() {
-        let (server_input_tx, server_input_rx) =
-            hydroflow::util::unbounded_channel::<(ClientRequest, ())>();
-        let (server_output_tx, mut server_output_rx) =
-            hydroflow::util::unbounded_channel::<(ClientResponse, ())>();
-
-        let mut server = server(
-            server_input_rx,
-            sink_from_fn(move |(resp, _)| server_output_tx.send((resp, ())).unwrap()),
-        );
-
-        let key = Key {
-            namespace: Namespace::System,
-            table: "table".to_string(),
-            row_key: "row".to_string(),
-        };
-        let val_a = "A".to_string();
-        let val_b = "B".to_string();
-
-        // Send multiple writes to the same key in the same tick.
-        let set_a = ClientRequest::Set {
-            key: key.clone(),
-            value: val_a.clone(),
-        };
-        let set_b = ClientRequest::Set {
-            key: key.clone(),
-            value: val_b.clone(),
-        };
-
-        server_input_tx.send((set_a, ())).unwrap();
-        server_input_tx.send((set_b, ())).unwrap();
-
-        server.run_tick();
-
-        // Read the value back.
-        let get = ClientRequest::Get { key: key.clone() };
-        server_input_tx.send((get, ())).unwrap();
-        server.run_tick();
-
-        let output = hydroflow::util::collect_ready_async::<Vec<_>, _>(&mut server_output_rx).await;
-        assert_eq!(
-            output,
-            &[(
-                ClientResponse::Get {
-                    key,
-                    value: HashSet::from([val_a, val_b])
-                },
-                ()
-            )]
-        );
-    }
 }

--- a/datastores/gossip_kv/server/membership.rs
+++ b/datastores/gossip_kv/server/membership.rs
@@ -1,6 +1,5 @@
-use std::sync::Mutex;
+use std::sync::OnceLock;
 
-use once_cell::sync::Lazy;
 use rand::distributions::Distribution;
 use rand::{thread_rng, Rng};
 
@@ -14,22 +13,20 @@ impl Distribution<char> for LowercaseAlphanumeric {
     }
 }
 
-/// Holds a name for the current process.
-static MEMBER_NAME: Lazy<Mutex<String>> = Lazy::new(|| {
-    // Generate a lower-case alphanumeric suffix of length 4
-    let suffix: String = thread_rng()
-        .sample_iter(&LowercaseAlphanumeric)
-        .take(4)
-        .map(char::from)
-        .collect();
-
-    // Retrieve hostname
-    let hostname = hostname::get().unwrap().to_str().unwrap().to_string();
-
-    Mutex::new(format!("{}-{}", hostname, suffix))
-});
-
 /// Gets a name for the current process.
-pub fn member_name() -> String {
-    MEMBER_NAME.lock().unwrap().clone()
+pub fn member_name() -> &'static String {
+    static MEMBER_NAME: OnceLock<String> = OnceLock::new();
+    MEMBER_NAME.get_or_init(|| {
+        // Generate a lower-case alphanumeric suffix of length 4
+        let suffix: String = thread_rng()
+            .sample_iter(&LowercaseAlphanumeric)
+            .take(4)
+            .map(char::from)
+            .collect();
+
+        // Retrieve hostname
+        let hostname = hostname::get().unwrap().to_str().unwrap().to_string();
+
+        format!("{}-{}", hostname, suffix)
+    })
 }

--- a/datastores/gossip_kv/server/membership.rs
+++ b/datastores/gossip_kv/server/membership.rs
@@ -1,0 +1,35 @@
+use std::sync::Mutex;
+
+use once_cell::sync::Lazy;
+use rand::distributions::Distribution;
+use rand::{thread_rng, Rng};
+
+/// This is a simple distribution that generates a random lower-case alphanumeric
+struct LowercaseAlphanumeric;
+
+impl Distribution<char> for LowercaseAlphanumeric {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> char {
+        let choices = b"abcdefghijklmnopqrstuvwxyz0123456789";
+        choices[rng.gen_range(0..choices.len())] as char
+    }
+}
+
+/// Holds a name for the current process.
+static MEMBER_NAME: Lazy<Mutex<String>> = Lazy::new(|| {
+    // Generate a lower-case alphanumeric suffix of length 4
+    let suffix: String = thread_rng()
+        .sample_iter(&LowercaseAlphanumeric)
+        .take(4)
+        .map(char::from)
+        .collect();
+
+    // Retrieve hostname
+    let hostname = hostname::get().unwrap().to_str().unwrap().to_string();
+
+    Mutex::new(format!("{}-{}", hostname, suffix))
+});
+
+/// Gets a name for the current process.
+pub fn member_name() -> String {
+    MEMBER_NAME.lock().unwrap().clone()
+}

--- a/datastores/gossip_kv/server/server.rs
+++ b/datastores/gossip_kv/server/server.rs
@@ -1,0 +1,298 @@
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use gossip_protocol::membership::MemberData;
+use gossip_protocol::{ClientRequest, ClientResponse, Key, Namespace};
+use hydroflow::futures::{Sink, Stream};
+use hydroflow::hydroflow_syntax;
+use hydroflow::itertools::Itertools;
+use hydroflow::lattices::map_union::{KeyedBimorphism, MapUnionHashMap};
+use hydroflow::lattices::set_union::SetUnionHashSet;
+use hydroflow::lattices::PairBimorphism;
+use hydroflow::scheduled::graph::Hydroflow;
+use serde::Serialize;
+use tracing::{info, trace};
+
+use crate::model::{delete_row, upsert_row, Clock, Namespaces, RowKey, TableName};
+use crate::util::ClientRequestWithAddress;
+
+/// Creates a L0 key-value store server using Hydroflow.
+///
+/// # Arguments
+/// -- `ib`: The input stream of client requests for the client protocol.
+/// -- `ob`: The output sink of client responses for the client protocol.
+/// -- `member_info`: The membership information of the server.
+///
+/// # Generic Arguments
+/// -- `I`: The input stream type for the client protocol.
+/// -- `O`: The output sink type for the client protocol.
+/// -- `A`: The transport (address type) for the client protocol.
+pub fn server<I, O, A, E>(ib: I, ob: O, member_info: MemberData<A>) -> Hydroflow<'static>
+where
+    I: Stream<Item = (ClientRequest, A)> + Unpin + 'static,
+    O: Sink<(ClientResponse, A), Error = E> + Unpin + 'static,
+    A: Hash + Debug + Clone + Eq + Serialize + 'static, // "Address"
+    E: Debug + 'static,
+{
+    hydroflow_syntax! {
+
+        on_start = initialize() -> tee();
+
+        on_start -> for_each(|_| info!("Transducer started."));
+
+        // Setup member metadata for this process.
+        on_start -> map(|_| upsert_row(Clock::new(0), Namespace::System, "members".to_string(), member_info.name.clone(), serde_json::to_string(&member_info).unwrap()))
+            -> namespaces;
+
+        outbound_messages =
+            inspect(|(resp, addr)| trace!("Sending response: {:?} to {:?}", resp, addr))
+            -> dest_sink(ob);
+
+        inbound_messages = source_stream(ib)
+            -> map(|(msg, addr)| ClientRequestWithAddress::from_request_and_address(msg, addr))
+            -> demux_enum::<ClientRequestWithAddress<A>>();
+
+        inbound_messages[Get]
+            -> inspect(|req| trace!("Received Get request: {:?} at {:?}", req, context.current_tick()))
+            -> map(|(key, addr) : (Key, A)| {
+                let row = MapUnionHashMap::new_from([
+                        (
+                            key.row_key,
+                            SetUnionHashSet::new_from([addr /* to respond with the result later*/])
+                        ),
+                ]);
+                let table = MapUnionHashMap::new_from([(key.table, row)]);
+                MapUnionHashMap::new_from([(key.namespace, table)])
+            })
+            -> gets;
+
+        inbound_messages[Set]
+            -> inspect(|request| trace!("Received Set request: {:?} at {:?}", request, context.current_tick()))
+            -> map(|(key, value, _addr) : (Key, String, A)| upsert_row(Clock::new(context.current_tick().0), key.namespace, key.table, key.row_key, value))
+            -> namespaces;
+
+        inbound_messages[Delete]
+            -> inspect(|req| trace!("Received Delete request: {:?} at {:?}", req, context.current_tick()))
+            -> map(|(key, _addr) : (Key, A)| delete_row(Clock::new(context.current_tick().0), key.namespace, key.table, key.row_key))
+            -> namespaces;
+
+        namespaces = union()
+            -> state::<'static, Namespaces::<Clock>>();
+
+        gets = state::<'tick, MapUnionHashMap<Namespace, MapUnionHashMap<TableName, MapUnionHashMap<RowKey, SetUnionHashSet<A>>>>>();
+
+        namespaces -> [0]process_system_table_gets;
+        gets -> [1]process_system_table_gets;
+
+        process_system_table_gets = lattice_bimorphism(KeyedBimorphism::<HashMap<_, _>, _>::new(KeyedBimorphism::<HashMap<_, _>, _>::new(KeyedBimorphism::<HashMap<_, _>, _>::new(PairBimorphism))), #namespaces, #gets)
+            -> flat_map(|result| {
+
+                let mut response: Vec<(ClientResponse, A)> = vec![];
+
+                    let result = result.as_reveal_ref();
+                    for (namespace, tables) in result.iter() {
+                        for (table_name, table) in tables.as_reveal_ref().iter() {
+                            for (row_key, join_results) in table.as_reveal_ref().iter() {
+                                let key = Key {
+                                    namespace: *namespace,
+                                    table: table_name.clone(),
+                                    row_key: row_key.clone(),
+                                };
+
+                                let timestamped_values = join_results.as_reveal_ref().0;
+                                let all_values = timestamped_values.as_reveal_ref().1.as_reveal_ref();
+
+                                let all_addresses = join_results.as_reveal_ref().1.as_reveal_ref();
+                                let socket_addr = all_addresses.iter().find_or_first(|_| true).unwrap();
+
+                                response.push((
+                                    ClientResponse::Get {key, value: all_values.clone()},
+                                    socket_addr.clone(),
+                            ));
+                        }
+                    }
+                }
+                response
+            }) -> outbound_messages;
+
+        // Uncomment to aid with debugging.
+        // source_interval(Duration::from_secs(3))
+        //    -> for_each(|_| println!("State: {:?}", #namespaces));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::convert::Infallible;
+    use std::future::ready;
+
+    use futures::SinkExt;
+    use gossip_protocol::membership::{MemberDataBuilder, Protocol};
+    use hydroflow::futures::sink;
+    use hydroflow::tokio::sync::mpsc::UnboundedSender;
+    use hydroflow::tokio_stream::wrappers::UnboundedReceiverStream;
+    use hydroflow::{futures, tokio};
+
+    use super::*;
+
+    /// A mapping sink that applies a function to each item sent to the sink.
+    fn sink_from_fn<T>(mut f: impl FnMut(T)) -> impl Sink<T, Error = Infallible> {
+        sink::drain().with(move |item| {
+            (f)(item);
+            ready(Result::<(), Infallible>::Ok(()))
+        })
+    }
+
+    /// Endpoints for the test transport are just strings.
+    type TestAddr = String;
+
+    /// A test instance of the L0 key-value store server.
+    ///
+    /// Encapsulates everything needed to interact with the server.
+    pub struct TestServer {
+        /// The Hydroflow server instance.
+        pub server: Hydroflow<'static>,
+
+        /// Send client requests to the server using this channel.
+        pub client_requests: UnboundedSender<(ClientRequest, TestAddr)>,
+
+        /// Receive client responses from the server using this stream.
+        pub client_responses: UnboundedReceiverStream<(ClientResponse, TestAddr)>,
+    }
+
+    /// Create a test instance of the L0 key-value store server.
+    ///
+    /// Arguments:
+    /// -- `member_name`: The name of the member.
+    /// -- `client_endpoint`: The endpoint for the client protocol.
+    fn test_server<M, E>(member_name: M, client_endpoint: E) -> TestServer
+    where
+        M: Into<String>,
+        E: Into<TestAddr>,
+    {
+        let (client_request_tx, client_request_rx) =
+            hydroflow::util::unbounded_channel::<(ClientRequest, TestAddr)>();
+        let (client_response_tx, client_response_rx) =
+            hydroflow::util::unbounded_channel::<(ClientResponse, TestAddr)>();
+
+        let builder = MemberDataBuilder::new(member_name.into()).add_protocol(Protocol::new(
+            client_endpoint.into(),
+            "client_endpoint".to_string(),
+        ));
+
+        let member_data = builder.build();
+
+        let server = server(
+            client_request_rx,
+            sink_from_fn(move |(resp, addr)| client_response_tx.send((resp, addr)).unwrap()),
+            member_data,
+        );
+
+        TestServer {
+            server,
+            client_requests: client_request_tx,
+            client_responses: client_response_rx,
+        }
+    }
+
+    const TEST_SERVER_NAME: &str = "test_server";
+    const TEST_CLIENT_ENDPOINT: &str = "client_endpoint";
+
+    #[hydroflow::test]
+    async fn test_member_initialization() {
+        let mut test_server = test_server(TEST_SERVER_NAME, "client_endpoint");
+        let key = "/sys/members/test_server".parse::<Key>().unwrap();
+        // TODO: The test fails if we don't run a tick before sending the get request. Why?
+        test_server.server.run_tick(); // Finish initialization.
+
+        // Check membership information.
+        test_server
+            .client_requests
+            .send((
+                ClientRequest::Get { key: key.clone() },
+                "unit_test".to_string(),
+            ))
+            .unwrap();
+        test_server.server.run_tick();
+
+        let output =
+            hydroflow::util::collect_ready_async::<Vec<_>, _>(&mut test_server.client_responses)
+                .await;
+
+        let expected_member_data = MemberDataBuilder::new(TEST_SERVER_NAME.to_string())
+            .add_protocol(Protocol::new(
+                TEST_CLIENT_ENDPOINT.to_string(),
+                "client_endpoint".to_string(),
+            ))
+            .build();
+
+        assert_eq!(
+            output,
+            &[(
+                ClientResponse::Get {
+                    key,
+                    value: HashSet::from([serde_json::to_string(&expected_member_data).unwrap()])
+                },
+                "unit_test".to_string()
+            )]
+        );
+    }
+
+    #[hydroflow::test]
+    async fn test_multiple_values_same_tick() {
+        let mut test_server = test_server("test_server", "gossip_endpoint");
+
+        let key = Key {
+            namespace: Namespace::System,
+            table: "table".to_string(),
+            row_key: "row".to_string(),
+        };
+        let val_a = "A".to_string();
+        let val_b = "B".to_string();
+
+        // Send multiple writes to the same key in the same tick.
+        let set_a = ClientRequest::Set {
+            key: key.clone(),
+            value: val_a.clone(),
+        };
+        let set_b = ClientRequest::Set {
+            key: key.clone(),
+            value: val_b.clone(),
+        };
+
+        test_server
+            .client_requests
+            .send((set_a, "foo".to_string()))
+            .unwrap();
+        test_server
+            .client_requests
+            .send((set_b, "bar".to_string()))
+            .unwrap();
+
+        test_server.server.run_tick();
+
+        // Read the value back.
+        let get = ClientRequest::Get { key: key.clone() };
+        test_server
+            .client_requests
+            .send((get, "TODO".to_string()))
+            .unwrap();
+        test_server.server.run_tick();
+
+        let output =
+            hydroflow::util::collect_ready_async::<Vec<_>, _>(&mut test_server.client_responses)
+                .await;
+        assert_eq!(
+            output,
+            &[(
+                ClientResponse::Get {
+                    key,
+                    value: HashSet::from([val_a, val_b])
+                },
+                "TODO".to_string()
+            )]
+        );
+    }
+}

--- a/datastores/gossip_kv/server/util.rs
+++ b/datastores/gossip_kv/server/util.rs
@@ -1,0 +1,25 @@
+use gossip_protocol::{ClientRequest, Key};
+use hydroflow::DemuxEnum;
+
+/// Convenience enum to represent a client request with the address of the client. Makes it
+/// possible to use `demux_enum` in the surface syntax.
+#[derive(Debug, DemuxEnum)]
+pub enum ClientRequestWithAddress<A> {
+    /// A get request with the key and the address of the client.
+    Get { key: Key, addr: A },
+    /// A set request with the key, value and the address of the client.
+    Set { key: Key, value: String, addr: A },
+    /// A delete request with the key and the address of the client.
+    Delete { key: Key, addr: A },
+}
+
+impl<A> ClientRequestWithAddress<A> {
+    /// Create a `ClientRequestWithAddress` from a `ClientRequest` and an address.
+    pub fn from_request_and_address(request: ClientRequest, addr: A) -> Self {
+        match request {
+            ClientRequest::Get { key } => Self::Get { key, addr },
+            ClientRequest::Set { key, value } => Self::Set { key, value, addr },
+            ClientRequest::Delete { key } => Self::Delete { key, addr },
+        }
+    }
+}


### PR DESCRIPTION
* Added a member metadata type to the protocol.
* Uses JSON serialization for now to keep things human-readable.
* Some clean-up - server main.rs doesn't contain the server or the server unit tests. It is a slim layer that limits responsibility to parsing command-line arguments and wiring network I/O. Business logic and tests moved to `server.rs.`