### PR TITLE
refactor(hydro_deploy): build cache cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,12 +220,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-once-cell"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9338790e78aa95a416786ec8389546c4b6a1dfc3dc36071ed9518a9413a542eb"
-
-[[package]]
 name = "async-process"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,7 +1358,6 @@ dependencies = [
  "futures",
  "hydro_deploy",
  "hydroflow_cli_integration",
- "once_cell",
  "pyo3",
  "pyo3-asyncio",
  "pythonize",
@@ -1393,7 +1386,6 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",
- "async-once-cell",
  "async-process",
  "async-recursion",
  "async-ssh2-lite",
@@ -1408,7 +1400,6 @@ dependencies = [
  "indicatif",
  "nanoid",
  "nix 0.26.4",
- "once_cell",
  "serde",
  "serde_json",
  "shell-escape",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1398,6 +1398,7 @@ dependencies = [
  "futures-core",
  "hydroflow_cli_integration",
  "indicatif",
+ "memo-map",
  "nanoid",
  "nix 0.26.4",
  "serde",
@@ -1903,6 +1904,12 @@ name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "memo-map"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374c335b2df19e62d4cb323103473cbc6510980253119180de862d89184f6a83"
 
 [[package]]
 name = "memoffset"

--- a/hydro_deploy/core/Cargo.toml
+++ b/hydro_deploy/core/Cargo.toml
@@ -10,7 +10,6 @@ description = "Hydro Deploy"
 [dependencies]
 anyhow = { version = "1.0.69", features = [ "backtrace" ] }
 async-channel = "1.8.0"
-async-once-cell = "0.5.3"
 async-process = "1.6.0"
 async-recursion = "1.0"
 async-ssh2-lite = { version = "0.4.2", features = [ "tokio" ] }
@@ -25,7 +24,6 @@ hydroflow_cli_integration = { path = "../hydroflow_cli_integration", version = "
 indicatif = "0.17.6"
 nanoid = "0.4.0"
 nix = "0.26.2"
-once_cell = "1.17"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 shell-escape = "0.1.5"

--- a/hydro_deploy/core/Cargo.toml
+++ b/hydro_deploy/core/Cargo.toml
@@ -22,6 +22,7 @@ futures = "0.3.26"
 futures-core = "0.3.26"
 hydroflow_cli_integration = { path = "../hydroflow_cli_integration", version = "^0.5.2" }
 indicatif = "0.17.6"
+memo-map = "0.3.2"
 nanoid = "0.4.0"
 nix = "0.26.2"
 serde = { version = "1", features = [ "derive" ] }

--- a/hydro_deploy/core/src/hydroflow_crate/build.rs
+++ b/hydro_deploy/core/src/hydroflow_crate/build.rs
@@ -131,7 +131,7 @@ pub async fn build_crate(
                                     let path = path.into_string();
                                     let data = std::fs::read(path).unwrap();
                                     return Ok(Arc::new(BuiltCrate {
-                                        unique_name: nanoid!(8),
+                                        unique_id: nanoid!(8),
                                         bin_data: data,
                                         bin_path: path_buf,
                                     }));

--- a/hydro_deploy/core/src/hydroflow_crate/build.rs
+++ b/hydro_deploy/core/src/hydroflow_crate/build.rs
@@ -72,9 +72,7 @@ pub struct BuildOutput {
 /// Build memoization cache.
 static BUILDS: OnceLock<MemoMap<BuildParams, OnceCell<BuildOutput>>> = OnceLock::new();
 
-pub async fn build_crate_memoized(
-    params: BuildParams,
-) -> Result<&'static BuildOutput, BuildError> {
+pub async fn build_crate_memoized(params: BuildParams) -> Result<&'static BuildOutput, BuildError> {
     BUILDS
         .get_or_init(MemoMap::new)
         .get_or_insert(&params, Default::default)

--- a/hydro_deploy/core/src/hydroflow_crate/mod.rs
+++ b/hydro_deploy/core/src/hydroflow_crate/mod.rs
@@ -12,7 +12,8 @@ pub mod ports;
 pub mod service;
 pub use service::*;
 
-/// Information about a built crate. See [`build::build_crate`].
+/// Information about a built crate.
+// See [`build::build_crate`].
 pub struct BuiltCrate {
     /// A unique but meaningless id.
     pub unique_id: String,

--- a/hydro_deploy/core/src/hydroflow_crate/mod.rs
+++ b/hydro_deploy/core/src/hydroflow_crate/mod.rs
@@ -12,7 +12,7 @@ pub mod ports;
 pub mod service;
 pub use service::*;
 
-/// Information about a built crate.
+/// Information about a built crate. See [`build::build_crate`].
 pub struct BuiltCrate {
     /// A unique but meaningless id.
     pub unique_id: String,

--- a/hydro_deploy/core/src/hydroflow_crate/mod.rs
+++ b/hydro_deploy/core/src/hydroflow_crate/mod.rs
@@ -14,11 +14,11 @@ pub use service::*;
 
 /// Information about a built crate.
 pub struct BuiltCrate {
-    /// A unique but meaningless name.
-    pub unique_name: String,
+    /// A unique but meaningless id.
+    pub unique_id: String,
     /// The binary contents as a byte array.
     pub bin_data: Vec<u8>,
-    /// The path to the binary file.
+    /// The path to the binary file. [`Self::bin_data`] has a copy of the content.
     pub bin_path: PathBuf,
 }
 

--- a/hydro_deploy/core/src/hydroflow_crate/mod.rs
+++ b/hydro_deploy/core/src/hydroflow_crate/mod.rs
@@ -6,22 +6,11 @@ use tokio::sync::RwLock;
 use super::Host;
 use crate::ServiceBuilder;
 
-mod build;
+pub(crate) mod build;
 pub mod ports;
 
 pub mod service;
 pub use service::*;
-
-/// Information about a built crate.
-// See [`build::build_crate`].
-pub struct BuiltCrate {
-    /// A unique but meaningless id.
-    pub unique_id: String,
-    /// The binary contents as a byte array.
-    pub bin_data: Vec<u8>,
-    /// The path to the binary file. [`Self::bin_data`] has a copy of the content.
-    pub bin_path: PathBuf,
-}
 
 #[derive(PartialEq)]
 pub enum CrateTarget {

--- a/hydro_deploy/core/src/hydroflow_crate/mod.rs
+++ b/hydro_deploy/core/src/hydroflow_crate/mod.rs
@@ -12,6 +12,16 @@ pub mod ports;
 pub mod service;
 pub use service::*;
 
+/// Information about a built crate.
+pub struct BuiltCrate {
+    /// A unique but meaningless name.
+    pub unique_name: String,
+    /// The binary contents as a byte array.
+    pub bin_data: Vec<u8>,
+    /// The path to the binary file.
+    pub bin_path: PathBuf,
+}
+
 #[derive(PartialEq)]
 pub enum CrateTarget {
     Default,

--- a/hydro_deploy/core/src/hydroflow_crate/service.rs
+++ b/hydro_deploy/core/src/hydroflow_crate/service.rs
@@ -11,8 +11,9 @@ use hydroflow_cli_integration::{InitConfig, ServerPort};
 use serde::Serialize;
 use tokio::sync::RwLock;
 
-use super::build::{build_crate, BuildError, BuiltCrate};
+use super::build::{build_crate, BuildError};
 use super::ports::{self, HydroflowPortConfig, HydroflowSink, SourcePath};
+use super::BuiltCrate;
 use crate::progress::ProgressTracker;
 use crate::{
     Host, HostTargetType, LaunchedBinary, LaunchedHost, ResourceBatch, ResourceResult,
@@ -42,7 +43,7 @@ pub struct HydroflowCrateService {
     /// Configuration for the ports that this service will listen on a port for.
     pub(super) port_to_bind: HashMap<String, ServerStrategy>,
 
-    built_binary: Arc<async_once_cell::OnceCell<Result<BuiltCrate, BuildError>>>,
+    built_binary: Arc<async_once_cell::OnceCell<Result<Arc<BuiltCrate>, BuildError>>>,
     launched_host: Option<Arc<dyn LaunchedHost>>,
 
     /// A map of port names to config for how other services can connect to this one.
@@ -181,7 +182,7 @@ impl HydroflowCrateService {
             .await
     }
 
-    fn build(&self) -> impl Future<Output = Result<BuiltCrate, BuildError>> {
+    fn build(&self) -> impl Future<Output = Result<Arc<BuiltCrate>, BuildError>> {
         let src_cloned = self.src.clone();
         let bin_cloned = self.bin.clone();
         let example_cloned = self.example.clone();

--- a/hydro_deploy/core/src/hydroflow_crate/service.rs
+++ b/hydro_deploy/core/src/hydroflow_crate/service.rs
@@ -29,7 +29,6 @@ pub struct HydroflowCrateService {
 
     meta: Option<String>,
 
-    // target_type: HostTargetType,
     /// Configuration for the ports this service will connect to as a client.
     pub(super) port_to_server: HashMap<String, ports::ServerConfig>,
 

--- a/hydro_deploy/core/src/hydroflow_crate/service.rs
+++ b/hydro_deploy/core/src/hydroflow_crate/service.rs
@@ -11,9 +11,8 @@ use hydroflow_cli_integration::{InitConfig, ServerPort};
 use serde::Serialize;
 use tokio::sync::{OnceCell, RwLock};
 
-use super::build::{build_crate, BuildError};
+use super::build::{build_crate, BuildError, BuildOutput};
 use super::ports::{self, HydroflowPortConfig, HydroflowSink, SourcePath};
-use super::BuiltCrate;
 use crate::progress::ProgressTracker;
 use crate::{
     Host, HostTargetType, LaunchedBinary, LaunchedHost, ResourceBatch, ResourceResult,
@@ -43,7 +42,7 @@ pub struct HydroflowCrateService {
     /// Configuration for the ports that this service will listen on a port for.
     pub(super) port_to_bind: HashMap<String, ServerStrategy>,
 
-    built_binary: Arc<OnceCell<Result<&'static BuiltCrate, BuildError>>>,
+    built_binary: Arc<OnceCell<Result<&'static BuildOutput, BuildError>>>,
     launched_host: Option<Arc<dyn LaunchedHost>>,
 
     /// A map of port names to config for how other services can connect to this one.
@@ -182,7 +181,7 @@ impl HydroflowCrateService {
             .await
     }
 
-    fn build(&self) -> impl Future<Output = Result<&'static BuiltCrate, BuildError>> {
+    fn build(&self) -> impl Future<Output = Result<&'static BuildOutput, BuildError>> {
         let src_cloned = self.src.clone();
         let bin_cloned = self.bin.clone();
         let example_cloned = self.example.clone();

--- a/hydro_deploy/core/src/lib.rs
+++ b/hydro_deploy/core/src/lib.rs
@@ -31,7 +31,7 @@ pub use hydroflow_crate::HydroflowCrate;
 pub mod custom_service;
 pub use custom_service::CustomService;
 
-use crate::hydroflow_crate::BuiltCrate;
+use crate::hydroflow_crate::build::BuildOutput;
 
 pub mod terraform;
 
@@ -95,12 +95,12 @@ pub trait LaunchedHost: Send + Sync {
     /// to listen to network connections (such as the IP address to bind to).
     fn server_config(&self, strategy: &ServerStrategy) -> ServerBindConfig;
 
-    async fn copy_binary(&self, binary: &BuiltCrate) -> Result<()>;
+    async fn copy_binary(&self, binary: &BuildOutput) -> Result<()>;
 
     async fn launch_binary(
         &self,
         id: String,
-        binary: &BuiltCrate,
+        binary: &BuildOutput,
         args: &[String],
         perf: Option<PathBuf>,
     ) -> Result<Arc<RwLock<dyn LaunchedBinary>>>;

--- a/hydro_deploy/core/src/lib.rs
+++ b/hydro_deploy/core/src/lib.rs
@@ -95,12 +95,12 @@ pub trait LaunchedHost: Send + Sync {
     /// to listen to network connections (such as the IP address to bind to).
     fn server_config(&self, strategy: &ServerStrategy) -> ServerBindConfig;
 
-    async fn copy_binary(&self, binary: Arc<BuiltCrate>) -> Result<()>;
+    async fn copy_binary(&self, binary: &BuiltCrate) -> Result<()>;
 
     async fn launch_binary(
         &self,
         id: String,
-        binary: Arc<BuiltCrate>,
+        binary: &BuiltCrate,
         args: &[String],
         perf: Option<PathBuf>,
     ) -> Result<Arc<RwLock<dyn LaunchedBinary>>>;

--- a/hydro_deploy/core/src/lib.rs
+++ b/hydro_deploy/core/src/lib.rs
@@ -31,6 +31,8 @@ pub use hydroflow_crate::HydroflowCrate;
 pub mod custom_service;
 pub use custom_service::CustomService;
 
+use crate::hydroflow_crate::BuiltCrate;
+
 pub mod terraform;
 
 pub mod util;
@@ -93,12 +95,12 @@ pub trait LaunchedHost: Send + Sync {
     /// to listen to network connections (such as the IP address to bind to).
     fn server_config(&self, strategy: &ServerStrategy) -> ServerBindConfig;
 
-    async fn copy_binary(&self, binary: Arc<(String, Vec<u8>, PathBuf)>) -> Result<()>;
+    async fn copy_binary(&self, binary: Arc<BuiltCrate>) -> Result<()>;
 
     async fn launch_binary(
         &self,
         id: String,
-        binary: Arc<(String, Vec<u8>, PathBuf)>,
+        binary: Arc<BuiltCrate>,
         args: &[String],
         perf: Option<PathBuf>,
     ) -> Result<Arc<RwLock<dyn LaunchedBinary>>>;

--- a/hydro_deploy/core/src/localhost/mod.rs
+++ b/hydro_deploy/core/src/localhost/mod.rs
@@ -13,7 +13,7 @@ use super::{
     ClientStrategy, Host, HostTargetType, LaunchedBinary, LaunchedHost, ResourceBatch,
     ResourceResult, ServerStrategy,
 };
-use crate::hydroflow_crate::BuiltCrate;
+use crate::hydroflow_crate::build::BuildOutput;
 
 pub mod launched_binary;
 pub use launched_binary::*;
@@ -148,14 +148,14 @@ impl LaunchedHost for LaunchedLocalhost {
         }
     }
 
-    async fn copy_binary(&self, _binary: &BuiltCrate) -> Result<()> {
+    async fn copy_binary(&self, _binary: &BuildOutput) -> Result<()> {
         Ok(())
     }
 
     async fn launch_binary(
         &self,
         id: String,
-        binary: &BuiltCrate,
+        binary: &BuildOutput,
         args: &[String],
         perf: Option<PathBuf>,
     ) -> Result<Arc<RwLock<dyn LaunchedBinary>>> {

--- a/hydro_deploy/core/src/localhost/mod.rs
+++ b/hydro_deploy/core/src/localhost/mod.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use async_process::{Command, Stdio};
 use async_trait::async_trait;
 use hydroflow_cli_integration::ServerBindConfig;
@@ -13,6 +13,7 @@ use super::{
     ClientStrategy, Host, HostTargetType, LaunchedBinary, LaunchedHost, ResourceBatch,
     ResourceResult, ServerStrategy,
 };
+use crate::hydroflow_crate::BuiltCrate;
 
 pub mod launched_binary;
 pub use launched_binary::*;
@@ -147,14 +148,14 @@ impl LaunchedHost for LaunchedLocalhost {
         }
     }
 
-    async fn copy_binary(&self, _binary: Arc<(String, Vec<u8>, PathBuf)>) -> Result<()> {
+    async fn copy_binary(&self, _binary: Arc<BuiltCrate>) -> Result<()> {
         Ok(())
     }
 
     async fn launch_binary(
         &self,
         id: String,
-        binary: Arc<(String, Vec<u8>, PathBuf)>,
+        binary: Arc<BuiltCrate>,
         args: &[String],
         perf: Option<PathBuf>,
     ) -> Result<Arc<RwLock<dyn LaunchedBinary>>> {
@@ -163,11 +164,11 @@ impl LaunchedHost for LaunchedLocalhost {
             let mut tmp = Command::new("perf");
             tmp.args(["record", "-F", "5", "--call-graph", "dwarf,64000", "-o"])
                 .arg(&perf)
-                .arg(&binary.2)
+                .arg(&binary.bin_path)
                 .args(args);
             tmp
         } else {
-            let mut tmp = Command::new(&binary.2);
+            let mut tmp = Command::new(&binary.bin_path);
             tmp.args(args);
             tmp
         };
@@ -181,7 +182,9 @@ impl LaunchedHost for LaunchedLocalhost {
         #[cfg(not(unix))]
         command.kill_on_drop(true);
 
-        let child = command.spawn()?;
+        let child = command
+            .spawn()
+            .with_context(|| format!("Failed to execute command: {:?}", command))?;
 
         Ok(Arc::new(RwLock::new(LaunchedLocalhostBinary::new(
             child, id,

--- a/hydro_deploy/core/src/localhost/mod.rs
+++ b/hydro_deploy/core/src/localhost/mod.rs
@@ -148,14 +148,14 @@ impl LaunchedHost for LaunchedLocalhost {
         }
     }
 
-    async fn copy_binary(&self, _binary: Arc<BuiltCrate>) -> Result<()> {
+    async fn copy_binary(&self, _binary: &BuiltCrate) -> Result<()> {
         Ok(())
     }
 
     async fn launch_binary(
         &self,
         id: String,
-        binary: Arc<BuiltCrate>,
+        binary: &BuiltCrate,
         args: &[String],
         perf: Option<PathBuf>,
     ) -> Result<Arc<RwLock<dyn LaunchedBinary>>> {

--- a/hydro_deploy/core/src/ssh.rs
+++ b/hydro_deploy/core/src/ssh.rs
@@ -213,11 +213,11 @@ impl<T: LaunchedSSHHost> LaunchedHost for T {
         )
         .await?;
 
-        // We may be deploying multiple binaries, so give each a unique file name.
-        let unique_id = &binary.unique_id;
+        // we may be deploying multiple binaries, so give each a unique name
+        let unique_name = &binary.unique_id;
 
         let user = self.ssh_user();
-        let binary_path = PathBuf::from(format!("/home/{user}/hydro-{unique_id}"));
+        let binary_path = PathBuf::from(format!("/home/{user}/hydro-{unique_name}"));
 
         if sftp.stat(&binary_path).await.is_err() {
             let random = nanoid!(8);

--- a/hydro_deploy/core/src/ssh.rs
+++ b/hydro_deploy/core/src/ssh.rs
@@ -213,11 +213,11 @@ impl<T: LaunchedSSHHost> LaunchedHost for T {
         )
         .await?;
 
-        // we may be deploying multiple binaries, so give each a unique name
-        let unique_name = &binary.unique_name;
+        // We may be deploying multiple binaries, so give each a unique file name.
+        let unique_id = &binary.unique_id;
 
         let user = self.ssh_user();
-        let binary_path = PathBuf::from(format!("/home/{user}/hydro-{unique_name}"));
+        let binary_path = PathBuf::from(format!("/home/{user}/hydro-{unique_id}"));
 
         if sftp.stat(&binary_path).await.is_err() {
             let random = nanoid!(8);
@@ -225,7 +225,7 @@ impl<T: LaunchedSSHHost> LaunchedHost for T {
             let sftp = &sftp;
 
             ProgressTracker::rich_leaf(
-                format!("uploading binary to /home/{user}/hydro-{unique_name}"),
+                format!("uploading binary to {}", binary_path.display()),
                 |set_progress, _| {
                     let binary = &binary;
                     let binary_path = &binary_path;
@@ -280,13 +280,13 @@ impl<T: LaunchedSSHHost> LaunchedHost for T {
     ) -> Result<Arc<RwLock<dyn LaunchedBinary>>> {
         let session = self.open_ssh_session().await?;
 
-        let unique_name = &binary.unique_name;
+        let unique_name = &binary.unique_id;
 
         let user = self.ssh_user();
         let binary_path = PathBuf::from(format!("/home/{user}/hydro-{unique_name}"));
 
         let channel = ProgressTracker::leaf(
-            format!("launching binary /home/{user}/hydro-{unique_name}"),
+            format!("launching binary {}", binary_path.display()),
             async {
                 let mut channel =
                     async_retry(

--- a/hydro_deploy/core/src/ssh.rs
+++ b/hydro_deploy/core/src/ssh.rs
@@ -20,7 +20,7 @@ use tokio::sync::RwLock;
 use super::progress::ProgressTracker;
 use super::util::async_retry;
 use super::{LaunchedBinary, LaunchedHost, ResourceResult, ServerStrategy};
-use crate::hydroflow_crate::BuiltCrate;
+use crate::hydroflow_crate::build::BuildOutput;
 use crate::util::prioritized_broadcast;
 
 struct LaunchedSSHBinary {
@@ -203,7 +203,7 @@ impl<T: LaunchedSSHHost> LaunchedHost for T {
         LaunchedSSHHost::server_config(self, bind_type)
     }
 
-    async fn copy_binary(&self, binary: &BuiltCrate) -> Result<()> {
+    async fn copy_binary(&self, binary: &BuildOutput) -> Result<()> {
         let session = self.open_ssh_session().await?;
 
         let sftp = async_retry(
@@ -274,7 +274,7 @@ impl<T: LaunchedSSHHost> LaunchedHost for T {
     async fn launch_binary(
         &self,
         id: String,
-        binary: &BuiltCrate,
+        binary: &BuildOutput,
         args: &[String],
         perf: Option<PathBuf>,
     ) -> Result<Arc<RwLock<dyn LaunchedBinary>>> {

--- a/hydro_deploy/core/src/ssh.rs
+++ b/hydro_deploy/core/src/ssh.rs
@@ -203,7 +203,7 @@ impl<T: LaunchedSSHHost> LaunchedHost for T {
         LaunchedSSHHost::server_config(self, bind_type)
     }
 
-    async fn copy_binary(&self, binary: Arc<BuiltCrate>) -> Result<()> {
+    async fn copy_binary(&self, binary: &BuiltCrate) -> Result<()> {
         let session = self.open_ssh_session().await?;
 
         let sftp = async_retry(
@@ -274,7 +274,7 @@ impl<T: LaunchedSSHHost> LaunchedHost for T {
     async fn launch_binary(
         &self,
         id: String,
-        binary: Arc<BuiltCrate>,
+        binary: &BuiltCrate,
         args: &[String],
         perf: Option<PathBuf>,
     ) -> Result<Arc<RwLock<dyn LaunchedBinary>>> {

--- a/hydro_deploy/hydro_cli/Cargo.toml
+++ b/hydro_deploy/hydro_cli/Cargo.toml
@@ -15,7 +15,6 @@ crate-type = ["cdylib"]
 [dependencies]
 hydro_deploy = { path = "../core", version = "^0.7.0" }
 tokio = { version = "1.16", features = [ "full" ] }
-once_cell = "1.17"
 anyhow = { version = "1.0.69", features = [ "backtrace" ] }
 clap = { version = "4.1.8", features = ["derive"] }
 pyo3 = { version = "0.20", features = ["abi3-py37"] }


### PR DESCRIPTION
* Replace mystery tuple with new `struct BuildOutput`
* Replace `Mutex` and `Arc`-infested `HashMap` with `memo-map` crate, greatly simplifying build cache typing
* Remove redundant build caching in `HydroflowCrateService`, expose and use cache parameters as `BuildParams`
* Remove `once_cell` and `async-once-cell` dependencies, use `std`'s `OnceLock`
* Add `Failed to execute command: {}` context to `perf` error message
* Cleanup some repeated `format!` expressions