### PR TITLE
refactor(hydro_deploy)!: replace some uses of `tokio::sync::RwLock` with `std::sync::Mutex` #430 (3/3)

### DIFF
--- a/hydro_deploy/core/src/hydroflow_crate/mod.rs
+++ b/hydro_deploy/core/src/hydroflow_crate/mod.rs
@@ -150,7 +150,7 @@ mod tests {
 
         deployment.deploy().await.unwrap();
 
-        let stdout = service.try_read().unwrap().stdout().await;
+        let stdout = service.try_read().unwrap().stdout();
 
         deployment.start().await.unwrap();
 

--- a/hydro_deploy/core/src/lib.rs
+++ b/hydro_deploy/core/src/lib.rs
@@ -72,18 +72,18 @@ pub struct ResourceResult {
 
 #[async_trait]
 pub trait LaunchedBinary: Send + Sync {
-    async fn stdin(&self) -> Sender<String>;
+    fn stdin(&self) -> Sender<String>;
 
     /// Provides a oneshot channel for the CLI to handshake with the binary,
     /// with the guarantee that as long as the CLI is holding on
     /// to a handle, none of the messages will also be broadcast
     /// to the user-facing [`LaunchedBinary::stdout`] channel.
-    async fn cli_stdout(&self) -> tokio::sync::oneshot::Receiver<String>;
+    fn cli_stdout(&self) -> tokio::sync::oneshot::Receiver<String>;
 
-    async fn stdout(&self) -> Receiver<String>;
-    async fn stderr(&self) -> Receiver<String>;
+    fn stdout(&self) -> Receiver<String>;
+    fn stderr(&self) -> Receiver<String>;
 
-    async fn exit_code(&self) -> Option<i32>;
+    fn exit_code(&self) -> Option<i32>;
 
     async fn wait(&mut self) -> Option<i32>;
 }

--- a/hydro_deploy/hydro_cli/src/lib.rs
+++ b/hydro_deploy/hydro_cli/src/lib.rs
@@ -569,7 +569,7 @@ impl HydroflowCrate {
         interruptible_future_to_py(py, async move {
             let underlying = underlying.read().await;
             Ok(PyReceiver {
-                receiver: Arc::new(underlying.stdout().await),
+                receiver: Arc::new(underlying.stdout()),
             })
         })
     }
@@ -579,7 +579,7 @@ impl HydroflowCrate {
         interruptible_future_to_py(py, async move {
             let underlying = underlying.read().await;
             Ok(PyReceiver {
-                receiver: Arc::new(underlying.stderr().await),
+                receiver: Arc::new(underlying.stderr()),
             })
         })
     }
@@ -588,7 +588,7 @@ impl HydroflowCrate {
         let underlying = self.underlying.clone();
         interruptible_future_to_py(py, async move {
             let underlying = underlying.read().await;
-            Ok(underlying.exit_code().await)
+            Ok(underlying.exit_code())
         })
     }
 

--- a/hydro_deploy/hydroflow_plus_cli_integration/src/deploy.rs
+++ b/hydro_deploy/hydroflow_plus_cli_integration/src/deploy.rs
@@ -56,12 +56,12 @@ pub trait DeployCrateWrapper {
 
     #[allow(async_fn_in_trait)]
     async fn stdout(&self) -> Receiver<String> {
-        self.underlying().read().await.stdout().await
+        self.underlying().read().await.stdout()
     }
 
     #[allow(async_fn_in_trait)]
     async fn stderr(&self) -> Receiver<String> {
-        self.underlying().read().await.stderr().await
+        self.underlying().read().await.stderr()
     }
 }
 


### PR DESCRIPTION
`std::sync::Mutex` should be used as long as the lock is not held across any `.await` yield points.

STACK: #1338 ~~#1341~~