### PR TITLE
refactor(hydro_deploy)!: make `Service::collect_resources` take `&self` instead of `&mut self`

### DIFF
--- a/hydro_deploy/core/src/custom_service.rs
+++ b/hydro_deploy/core/src/custom_service.rs
@@ -41,7 +41,7 @@ impl CustomService {
 
 #[async_trait]
 impl Service for CustomService {
-    fn collect_resources(&mut self, _resource_batch: &mut ResourceBatch) {
+    fn collect_resources(&self, _resource_batch: &mut ResourceBatch) {
         if self.launched_host.is_some() {
             return;
         }

--- a/hydro_deploy/core/src/deployment.rs
+++ b/hydro_deploy/core/src/deployment.rs
@@ -66,16 +66,16 @@ impl Deployment {
                 .collect::<Vec<_>>();
             self.services = active_services;
 
-            for service in self.services.iter_mut() {
+            for service in self.services.iter() {
                 service
                     .upgrade()
                     .unwrap()
-                    .write()
+                    .read()
                     .await
                     .collect_resources(&mut resource_batch);
             }
 
-            for host in self.hosts.iter_mut() {
+            for host in self.hosts.iter() {
                 host.collect_resources(&mut resource_batch);
             }
 

--- a/hydro_deploy/core/src/hydroflow_crate/service.rs
+++ b/hydro_deploy/core/src/hydroflow_crate/service.rs
@@ -158,7 +158,7 @@ impl HydroflowCrateService {
 
 #[async_trait]
 impl Service for HydroflowCrateService {
-    fn collect_resources(&mut self, _resource_batch: &mut ResourceBatch) {
+    fn collect_resources(&self, _resource_batch: &mut ResourceBatch) {
         if self.launched_host.is_some() {
             return;
         }

--- a/hydro_deploy/core/src/lib.rs
+++ b/hydro_deploy/core/src/lib.rs
@@ -190,7 +190,7 @@ pub trait Service: Send + Sync {
     ///
     /// This should also perform any "free", non-blocking computations (compilations),
     /// because the `deploy` method will be called after these resources are allocated.
-    fn collect_resources(&mut self, resource_batch: &mut ResourceBatch);
+    fn collect_resources(&self, resource_batch: &mut ResourceBatch);
 
     /// Connects to the acquired resources and prepares the service to be launched.
     async fn deploy(&mut self, resource_result: &Arc<ResourceResult>) -> Result<()>;


### PR DESCRIPTION
#430 but still has `RwLock` wrapping

Depends on #1347