### PR TITLE
fix(hydro_deploy): avoid Terraform crashing on empty provider block

### DIFF
--- a/hydro_deploy/core/src/terraform.rs
+++ b/hydro_deploy/core/src/terraform.rs
@@ -79,6 +79,7 @@ impl Drop for TerraformPool {
 #[derive(Serialize, Deserialize)]
 pub struct TerraformBatch {
     pub terraform: TerraformConfig,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub provider: HashMap<String, serde_json::Value>,
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub data: HashMap<String, HashMap<String, serde_json::Value>>,


### PR DESCRIPTION
fix(hydro_deploy): avoid Terraform crashing on empty provider block
