### PR TITLE
fix: MacOS lld compilation failure

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,6 +11,9 @@ rustflags = [
     # "-Aclippy::uninlined-format-args",
 ]
 
+[target.x86_64-apple-darwin]
+linker = "rust-lld"
+
 [target.x86_64-unknown-linux-musl]
 linker = "rust-lld"
 


### PR DESCRIPTION
MacOS uses Rust lld, avoids this error: ld: Assertion failed: (name.size() <= maxLength), function makeSymbolStringInPlace