### PR TITLE
refactor(hydro_deploy)!: use `buildstructor` to handle excessive `Deployment` method arguments, fix #1364

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ perf.data.old
 flamegraph.svg
 
 /rustc-ice-*.txt
-/*.perf.data*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "buildstructor"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3907aac66c65520545ae3cb3c195306e20d5ed5c90bfbb992e061cf12a104d0"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "str_inflector",
+ "syn 2.0.60",
+ "thiserror",
+ "try_match",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,6 +1391,7 @@ dependencies = [
  "async-recursion",
  "async-ssh2-lite",
  "async-trait",
+ "buildstructor",
  "bytes",
  "cargo_metadata",
  "dunce",
@@ -3097,6 +3113,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str_inflector"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0b848d5a7695b33ad1be00f84a3c079fe85c9278a325ff9159e6c99cef4ef7"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3615,6 +3641,26 @@ dependencies = [
  "regex",
  "thiserror",
  "tree-sitter",
+]
+
+[[package]]
+name = "try_match"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b065c869a3f832418e279aa4c1d7088f9d5d323bde15a60a08e20c2cd4549082"
+dependencies = [
+ "try_match_inner",
+]
+
+[[package]]
+name = "try_match_inner"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9c81686f7ab4065ccac3df7a910c4249f8c0f3fb70421d6ddec19b9311f63f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
 ]
 
 [[package]]

--- a/hydro_deploy/core/Cargo.toml
+++ b/hydro_deploy/core/Cargo.toml
@@ -13,6 +13,7 @@ async-process = "1.6.0"
 async-recursion = "1.0"
 async-ssh2-lite = { version = "0.4.2", features = [ "tokio" ] }
 async-trait = "0.1.64"
+buildstructor = "0.5.4"
 bytes = "1.1.0"
 cargo_metadata = "0.15.4"
 dunce = "1.0.4"

--- a/hydro_deploy/core/src/azure.rs
+++ b/hydro_deploy/core/src/azure.rs
@@ -44,14 +44,16 @@ impl LaunchedSshHost for LaunchedVirtualMachine {
 }
 
 pub struct AzureHost {
-    pub id: usize,
-    pub project: String,
-    pub os_type: String, // linux or windows
-    pub machine_size: String,
-    pub image: Option<HashMap<String, String>>,
-    pub region: String,
-    pub user: Option<String>,
-    pub launched: OnceLock<Arc<LaunchedVirtualMachine>>,
+    /// ID from [`crate::Deployment::add_host`].
+    id: usize,
+
+    project: String,
+    os_type: String, // linux or windows
+    machine_size: String,
+    image: Option<HashMap<String, String>>,
+    region: String,
+    user: Option<String>,
+    pub launched: OnceLock<Arc<LaunchedVirtualMachine>>, // TODO(mingwei): fix pub
     external_ports: Mutex<Vec<u16>>,
 }
 

--- a/hydro_deploy/core/src/gcp.rs
+++ b/hydro_deploy/core/src/gcp.rs
@@ -169,15 +169,17 @@ impl GcpNetwork {
 }
 
 pub struct GcpComputeEngineHost {
-    pub id: usize,
-    pub project: String,
-    pub machine_type: String,
-    pub image: String,
-    pub region: String,
-    pub network: Arc<RwLock<GcpNetwork>>,
-    pub user: Option<String>,
-    pub startup_script: Option<String>,
-    pub launched: OnceLock<Arc<LaunchedComputeEngine>>,
+    /// ID from [`crate::Deployment::add_host`].
+    id: usize,
+
+    project: String,
+    machine_type: String,
+    image: String,
+    region: String,
+    network: Arc<RwLock<GcpNetwork>>,
+    user: Option<String>,
+    startup_script: Option<String>,
+    pub launched: OnceLock<Arc<LaunchedComputeEngine>>, // TODO(mingwei): fix pub
     external_ports: Mutex<Vec<u16>>,
 }
 

--- a/hydro_deploy/hydro_cli/src/lib.rs
+++ b/hydro_deploy/hydro_cli/src/lib.rs
@@ -23,8 +23,8 @@ use tokio::sync::oneshot::Sender;
 use tokio::sync::{Mutex, RwLock};
 
 mod cli;
-use hydro_deploy as core;
 use hydro_deploy::ssh::LaunchedSshHost;
+use hydro_deploy::{self as core};
 
 static TOKIO_RUNTIME: std::sync::RwLock<Option<tokio::runtime::Runtime>> =
     std::sync::RwLock::new(None);

--- a/hydroflow_plus_test/examples/compute_pi.rs
+++ b/hydroflow_plus_test/examples/compute_pi.rs
@@ -21,15 +21,14 @@ async fn main() {
 
         (
             Box::new(move |deployment| -> Arc<dyn Host> {
-                deployment.GcpComputeEngineHost(
-                    &project,
-                    "e2-micro",
-                    "debian-cloud/debian-11",
-                    "us-west1-a",
-                    network.clone(),
-                    None,
-                    None,
-                )
+                deployment
+                    .GcpComputeEngineHost()
+                    .project(&project)
+                    .machine_type("e2-micro")
+                    .image("debian-cloud/debian-11")
+                    .region("us-west1-a")
+                    .network(network.clone())
+                    .add()
             }),
             "release",
         )

--- a/hydroflow_plus_test/examples/first_ten_distributed.rs
+++ b/hydroflow_plus_test/examples/first_ten_distributed.rs
@@ -19,15 +19,14 @@ async fn main() {
 
         (
             Box::new(move |deployment| -> Arc<dyn Host> {
-                deployment.GcpComputeEngineHost(
-                    &project,
-                    "e2-micro",
-                    "debian-cloud/debian-11",
-                    "us-west1-a",
-                    network.clone(),
-                    None,
-                    None,
-                )
+                deployment
+                    .GcpComputeEngineHost()
+                    .project(&project)
+                    .machine_type("e2-micro")
+                    .image("debian-cloud/debian-11")
+                    .region("us-west1-a")
+                    .network(network.clone())
+                    .add()
             }),
             "release",
         )

--- a/hydroflow_plus_test/examples/map_reduce.rs
+++ b/hydroflow_plus_test/examples/map_reduce.rs
@@ -20,15 +20,14 @@ async fn main() {
 
         (
             Box::new(move |deployment| -> Arc<dyn Host> {
-                deployment.GcpComputeEngineHost(
-                    &project,
-                    "e2-micro",
-                    "debian-cloud/debian-11",
-                    "us-west1-a",
-                    network.clone(),
-                    None,
-                    None,
-                )
+                deployment
+                    .GcpComputeEngineHost()
+                    .project(&project)
+                    .machine_type("e2-micro")
+                    .image("debian-cloud/debian-11")
+                    .region("us-west1-a")
+                    .network(network.clone())
+                    .add()
             }),
             "release",
         )

--- a/hydroflow_plus_test/examples/perf_compute_pi.rs
+++ b/hydroflow_plus_test/examples/perf_compute_pi.rs
@@ -23,15 +23,16 @@ async fn main() {
 
         (
             Box::new(move |deployment| -> Arc<dyn Host> {
-                deployment.GcpComputeEngineHost(
-                    &project,
-                    "e2-micro",
-                    "debian-cloud/debian-11",
-                    "us-west1-a",
-                    network.clone(),
-                    None,
-                    Some("sudo sh -c 'apt update && apt install -y linux-perf binutils && echo -1 > /proc/sys/kernel/perf_event_paranoid && echo 0 > /proc/sys/kernel/kptr_restrict'".to_owned())
-                )
+                let startup_script = "sudo sh -c 'apt update && apt install -y linux-perf binutils && echo -1 > /proc/sys/kernel/perf_event_paranoid && echo 0 > /proc/sys/kernel/kptr_restrict'";
+                deployment
+                    .GcpComputeEngineHost()
+                    .project(&project)
+                    .machine_type("e2-micro")
+                    .image("debian-cloud/debian-11")
+                    .region("us-west1-a")
+                    .network(network.clone())
+                    .startup_script(startup_script)
+                    .add()
             }),
             "profile",
         )

--- a/hydroflow_plus_test/examples/simple_cluster.rs
+++ b/hydroflow_plus_test/examples/simple_cluster.rs
@@ -20,15 +20,14 @@ async fn main() {
 
         (
             Box::new(move |deployment| -> Arc<dyn Host> {
-                deployment.GcpComputeEngineHost(
-                    &project,
-                    "e2-micro",
-                    "debian-cloud/debian-11",
-                    "us-west1-a",
-                    network.clone(),
-                    None,
-                    None,
-                )
+                deployment
+                    .GcpComputeEngineHost()
+                    .project(&project)
+                    .machine_type("e2-micro")
+                    .image("debian-cloud/debian-11")
+                    .region("us-west1-a")
+                    .network(network.clone())
+                    .add()
             }),
             "release",
         )

--- a/template/hydroflow_plus/flow/examples/first_ten_distributed_gcp.rs
+++ b/template/hydroflow_plus/flow/examples/first_ten_distributed_gcp.rs
@@ -17,15 +17,14 @@ async fn main() {
     flow::first_ten_distributed::first_ten_distributed(
         &flow,
         &DeployProcessSpec::new(|| {
-            let host = deployment.GcpComputeEngineHost(
-                gcp_project.clone(),
-                "e2-micro",
-                "debian-cloud/debian-11",
-                "us-west1-a",
-                vpc.clone(),
-                None,
-                None,
-            );
+            let host = deployment
+                .GcpComputeEngineHost()
+                .project(gcp_project.clone())
+                .machine_type("e2-micro")
+                .image("debian-cloud/debian-11")
+                .region("us-west1-a")
+                .network(vpc.clone())
+                .add();
 
             deployment.add_service(HydroflowCrate::new(".", host).bin("first_ten_distributed"))
         }),


### PR DESCRIPTION
Adds new method `Deployment::AzureHost`

BREAKING CHANGE: Changes syntax for `Deployment::GcpComputeEngineHost`