### PR TITLE
fix(hydroflow_plus): overly restrictive input types for `send_bincode_interleaved`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,6 +1559,7 @@ version = "0.0.0"
 dependencies = [
  "futures",
  "hydro_deploy",
+ "hydroflow",
  "hydroflow_plus",
  "hydroflow_plus_cli_integration",
  "hydroflow_plus_test_macro",

--- a/hydroflow_plus/src/stream.rs
+++ b/hydroflow_plus/src/stream.rs
@@ -507,9 +507,9 @@ impl<'a, T, W, N: Location + Clone> Stream<'a, T, W, N> {
     pub fn send_bincode_interleaved<N2: Location + Clone, Tag, CoreType, V>(
         self,
         other: &N2,
-    ) -> Stream<'a, T, Async, N2>
+    ) -> Stream<'a, CoreType, Async, N2>
     where
-        N: HfSend<N2, V, In<CoreType> = T, Out<CoreType> = (Tag, T)>,
+        N: HfSend<N2, V, In<CoreType> = T, Out<CoreType> = (Tag, CoreType)>,
         CoreType: Serialize + DeserializeOwned,
     {
         self.send_bincode::<N2, V, CoreType>(other)

--- a/hydroflow_plus_test/Cargo.toml
+++ b/hydroflow_plus_test/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+hydroflow = { path = "../hydroflow", version = "^0.8.0", features = ["debugging"] }
 hydroflow_plus = { path = "../hydroflow_plus", version = "^0.8.0" }
 tokio = { version = "1.16", features = [ "full" ] }
 stageleft = { path = "../stageleft", version = "^0.3.0" }


### PR DESCRIPTION

The original types prevented usage in cluster-to-cluster communication.
