### PR TITLE
fix(stageleft): typing hole when splicing `RuntimeData`

### DIFF
--- a/stageleft/src/lib.rs
+++ b/stageleft/src/lib.rs
@@ -226,7 +226,7 @@ pub struct RuntimeData<T> {
     _phantom: PhantomData<T>,
 }
 
-impl<'a, T> Quoted<'a, T> for RuntimeData<T> {}
+impl<'a, T: 'a> Quoted<'a, T> for RuntimeData<T> {}
 
 impl<T: Copy> Copy for RuntimeData<T> {}
 


### PR DESCRIPTION

Previously, a `RuntimeData` could be spliced in any context even if its data type may not be valid under the required `'a` lifetime constraint. This fixed that typing bug.

Soon, we should have regression testing for this via trybuild.
