### PR TITLE
style!: rename some `CLI`->`Deploy`, decapitalize acronym names

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
 upper-case-acronyms-aggressive = true
+avoid-breaking-exported-api = false

--- a/hydro_deploy/hydroflow_plus_deploy/src/runtime.rs
+++ b/hydro_deploy/hydroflow_plus_deploy/src/runtime.rs
@@ -10,13 +10,13 @@ use stageleft::{q, Quoted, RuntimeData};
 
 use super::HydroflowPlusMeta;
 
-pub struct CliRuntime {}
+pub struct DeployRuntime {}
 
-impl<'a> Deploy<'a> for CliRuntime {
+impl<'a> Deploy<'a> for DeployRuntime {
     type InstantiateEnv = ();
     type CompileEnv = RuntimeData<&'a DeployPorts<HydroflowPlusMeta>>;
-    type Process = CliRuntimeNode;
-    type Cluster = CliRuntimeCluster;
+    type Process = DeployRuntimeNode;
+    type Cluster = DeployRuntimeCluster;
     type Meta = ();
     type GraphId = usize;
     type ProcessPort = String;
@@ -27,13 +27,13 @@ impl<'a> Deploy<'a> for CliRuntime {
     }
 
     fn trivial_process(_id: usize) -> Self::Process {
-        CliRuntimeNode {
+        DeployRuntimeNode {
             next_port: Rc::new(RefCell::new(0)),
         }
     }
 
     fn trivail_cluster(_id: usize) -> Self::Cluster {
-        CliRuntimeCluster {
+        DeployRuntimeCluster {
             next_port: Rc::new(RefCell::new(0)),
         }
     }
@@ -228,11 +228,11 @@ impl<'a> Deploy<'a> for CliRuntime {
 }
 
 #[derive(Clone)]
-pub struct CliRuntimeNode {
+pub struct DeployRuntimeNode {
     next_port: Rc<RefCell<usize>>,
 }
 
-impl Node for CliRuntimeNode {
+impl Node for DeployRuntimeNode {
     type Port = String;
     type Meta = ();
     type InstantiateEnv = ();
@@ -252,16 +252,16 @@ impl Node for CliRuntimeNode {
         _graph: HydroflowGraph,
         _extra_stmts: Vec<syn::Stmt>,
     ) {
-        panic!(".deploy() cannot be called on a CLIRuntimeNode");
+        panic!(".deploy() cannot be called on a DeployRuntimeNode");
     }
 }
 
 #[derive(Clone)]
-pub struct CliRuntimeCluster {
+pub struct DeployRuntimeCluster {
     next_port: Rc<RefCell<usize>>,
 }
 
-impl Node for CliRuntimeCluster {
+impl Node for DeployRuntimeCluster {
     type Port = String;
     type Meta = ();
     type InstantiateEnv = ();
@@ -281,21 +281,21 @@ impl Node for CliRuntimeCluster {
         _graph: HydroflowGraph,
         _extra_stmts: Vec<syn::Stmt>,
     ) {
-        panic!(".deploy() cannot be called on a CLIRuntimeCluster");
+        panic!(".deploy() cannot be called on a DeployRuntimeCluster");
     }
 }
 
-impl<'a> ProcessSpec<'a, CliRuntime> for () {
-    fn build(self, _id: usize, _name_hint: &str) -> CliRuntimeNode {
-        CliRuntimeNode {
+impl<'a> ProcessSpec<'a, DeployRuntime> for () {
+    fn build(self, _id: usize, _name_hint: &str) -> DeployRuntimeNode {
+        DeployRuntimeNode {
             next_port: Rc::new(RefCell::new(0)),
         }
     }
 }
 
-impl<'cli> ClusterSpec<'cli, CliRuntime> for () {
-    fn build(self, _id: usize, _name_hint: &str) -> CliRuntimeCluster {
-        CliRuntimeCluster {
+impl<'cli> ClusterSpec<'cli, DeployRuntime> for () {
+    fn build(self, _id: usize, _name_hint: &str) -> DeployRuntimeCluster {
+        DeployRuntimeCluster {
             next_port: Rc::new(RefCell::new(0)),
         }
     }

--- a/hydro_deploy/hydroflow_plus_deploy/src/runtime.rs
+++ b/hydro_deploy/hydroflow_plus_deploy/src/runtime.rs
@@ -10,13 +10,13 @@ use stageleft::{q, Quoted, RuntimeData};
 
 use super::HydroflowPlusMeta;
 
-pub struct CLIRuntime {}
+pub struct CliRuntime {}
 
-impl<'a> Deploy<'a> for CLIRuntime {
+impl<'a> Deploy<'a> for CliRuntime {
     type InstantiateEnv = ();
     type CompileEnv = RuntimeData<&'a DeployPorts<HydroflowPlusMeta>>;
-    type Process = CLIRuntimeNode;
-    type Cluster = CLIRuntimeCluster;
+    type Process = CliRuntimeNode;
+    type Cluster = CliRuntimeCluster;
     type Meta = ();
     type GraphId = usize;
     type ProcessPort = String;
@@ -27,13 +27,13 @@ impl<'a> Deploy<'a> for CLIRuntime {
     }
 
     fn trivial_process(_id: usize) -> Self::Process {
-        CLIRuntimeNode {
+        CliRuntimeNode {
             next_port: Rc::new(RefCell::new(0)),
         }
     }
 
     fn trivail_cluster(_id: usize) -> Self::Cluster {
-        CLIRuntimeCluster {
+        CliRuntimeCluster {
             next_port: Rc::new(RefCell::new(0)),
         }
     }
@@ -228,11 +228,11 @@ impl<'a> Deploy<'a> for CLIRuntime {
 }
 
 #[derive(Clone)]
-pub struct CLIRuntimeNode {
+pub struct CliRuntimeNode {
     next_port: Rc<RefCell<usize>>,
 }
 
-impl Node for CLIRuntimeNode {
+impl Node for CliRuntimeNode {
     type Port = String;
     type Meta = ();
     type InstantiateEnv = ();
@@ -257,11 +257,11 @@ impl Node for CLIRuntimeNode {
 }
 
 #[derive(Clone)]
-pub struct CLIRuntimeCluster {
+pub struct CliRuntimeCluster {
     next_port: Rc<RefCell<usize>>,
 }
 
-impl Node for CLIRuntimeCluster {
+impl Node for CliRuntimeCluster {
     type Port = String;
     type Meta = ();
     type InstantiateEnv = ();
@@ -285,17 +285,17 @@ impl Node for CLIRuntimeCluster {
     }
 }
 
-impl<'a> ProcessSpec<'a, CLIRuntime> for () {
-    fn build(self, _id: usize, _name_hint: &str) -> CLIRuntimeNode {
-        CLIRuntimeNode {
+impl<'a> ProcessSpec<'a, CliRuntime> for () {
+    fn build(self, _id: usize, _name_hint: &str) -> CliRuntimeNode {
+        CliRuntimeNode {
             next_port: Rc::new(RefCell::new(0)),
         }
     }
 }
 
-impl<'cli> ClusterSpec<'cli, CLIRuntime> for () {
-    fn build(self, _id: usize, _name_hint: &str) -> CLIRuntimeCluster {
-        CLIRuntimeCluster {
+impl<'cli> ClusterSpec<'cli, CliRuntime> for () {
+    fn build(self, _id: usize, _name_hint: &str) -> CliRuntimeCluster {
+        CliRuntimeCluster {
             next_port: Rc::new(RefCell::new(0)),
         }
     }

--- a/hydroflow/src/scheduled/port.rs
+++ b/hydroflow/src/scheduled/port.rs
@@ -20,10 +20,12 @@ pub trait Polarity: 'static {}
 /// An uninstantiable type used to tag port [`Polarity`] as **send**.
 ///
 /// See also: [`RECV`].
+#[allow(clippy::upper_case_acronyms)]
 pub enum SEND {}
 /// An uninstantiable type used to tag port [`Polarity`] as **receive**.
 ///
 /// See also: [`SEND`].
+#[allow(clippy::upper_case_acronyms)]
 pub enum RECV {}
 #[sealed]
 impl Polarity for SEND {}

--- a/hydroflow_plus/src/lib.rs
+++ b/hydroflow_plus/src/lib.rs
@@ -66,7 +66,7 @@ impl<'a, ID> HfCompiled<'a, ID> {
 }
 
 impl<'a> HfCompiled<'a, usize> {
-    pub fn with_dynamic_id(self, id: impl Quoted<'a, usize>) -> HfBuiltWithID<'a> {
+    pub fn with_dynamic_id(self, id: impl Quoted<'a, usize>) -> HfBuiltWithId<'a> {
         let hydroflow_crate = proc_macro_crate::crate_name("hydroflow_plus")
             .expect("hydroflow_plus should be present in `Cargo.toml`");
         let root = match hydroflow_crate {
@@ -116,7 +116,7 @@ impl<'a> HfCompiled<'a, usize> {
 
         let conditioned_tokens: TokenStream = conditioned_tokens.unwrap();
         let id = id.splice();
-        HfBuiltWithID {
+        HfBuiltWithId {
             tokens: syn::parse_quote!({
                 let __given_id = #id;
                 #conditioned_tokens else {
@@ -162,14 +162,14 @@ impl<'a> FreeVariable<Hydroflow<'a>> for HfCompiled<'a, ()> {
     }
 }
 
-pub struct HfBuiltWithID<'a> {
+pub struct HfBuiltWithId<'a> {
     tokens: TokenStream,
     _phantom: PhantomData<&'a mut &'a ()>,
 }
 
-impl<'a> Quoted<'a, Hydroflow<'a>> for HfBuiltWithID<'a> {}
+impl<'a> Quoted<'a, Hydroflow<'a>> for HfBuiltWithId<'a> {}
 
-impl<'a> FreeVariable<Hydroflow<'a>> for HfBuiltWithID<'a> {
+impl<'a> FreeVariable<Hydroflow<'a>> for HfBuiltWithId<'a> {
     fn to_tokens(self) -> (Option<TokenStream>, Option<TokenStream>) {
         (None, Some(self.tokens))
     }

--- a/hydroflow_plus/src/stream.rs
+++ b/hydroflow_plus/src/stream.rs
@@ -568,7 +568,7 @@ impl<'a, T, W, N: Location> Stream<'a, T, W, N> {
         self.send_bincode::<N2, CoreType>(other).map(q!(|(_, b)| b))
     }
 
-    pub fn send_bytes_interleaved<N2: Location, Tag, V>(
+    pub fn send_bytes_interleaved<N2: Location, Tag>(
         self,
         other: &N2,
     ) -> Stream<'a, Bytes, Async, N2>

--- a/hydroflow_plus_test/src/cluster/compute_pi.rs
+++ b/hydroflow_plus_test/src/cluster/compute_pi.rs
@@ -46,7 +46,7 @@ pub fn compute_pi(flow: &FlowBuilder, batch_size: usize) -> (Cluster<Worker>, Pr
 
 #[cfg(test)]
 mod tests {
-    use hydroflow_plus_deploy::CliRuntime;
+    use hydroflow_plus_deploy::DeployRuntime;
     use stageleft::RuntimeData;
 
     #[test]
@@ -58,7 +58,7 @@ mod tests {
         insta::assert_debug_snapshot!(built.ir());
 
         for (id, ir) in built
-            .compile::<CliRuntime>(&RuntimeData::new("FAKE"))
+            .compile::<DeployRuntime>(&RuntimeData::new("FAKE"))
             .hydroflow_ir()
         {
             insta::with_settings!({snapshot_suffix => format!("surface_graph_{id}")}, {

--- a/hydroflow_plus_test/src/cluster/compute_pi.rs
+++ b/hydroflow_plus_test/src/cluster/compute_pi.rs
@@ -46,7 +46,7 @@ pub fn compute_pi(flow: &FlowBuilder, batch_size: usize) -> (Cluster<Worker>, Pr
 
 #[cfg(test)]
 mod tests {
-    use hydroflow_plus_deploy::CLIRuntime;
+    use hydroflow_plus_deploy::CliRuntime;
     use stageleft::RuntimeData;
 
     #[test]
@@ -58,7 +58,7 @@ mod tests {
         insta::assert_debug_snapshot!(built.ir());
 
         for (id, ir) in built
-            .compile::<CLIRuntime>(&RuntimeData::new("FAKE"))
+            .compile::<CliRuntime>(&RuntimeData::new("FAKE"))
             .hydroflow_ir()
         {
             insta::with_settings!({snapshot_suffix => format!("surface_graph_{id}")}, {

--- a/hydroflow_plus_test/src/cluster/map_reduce.rs
+++ b/hydroflow_plus_test/src/cluster/map_reduce.rs
@@ -36,7 +36,7 @@ pub fn map_reduce(flow: &FlowBuilder) -> (Process<Leader>, Cluster<Worker>) {
 
 #[cfg(test)]
 mod tests {
-    use hydroflow_plus_deploy::CliRuntime;
+    use hydroflow_plus_deploy::DeployRuntime;
     use stageleft::RuntimeData;
 
     #[test]
@@ -48,7 +48,7 @@ mod tests {
         insta::assert_debug_snapshot!(built.ir());
 
         for (id, ir) in built
-            .compile::<CliRuntime>(&RuntimeData::new("FAKE"))
+            .compile::<DeployRuntime>(&RuntimeData::new("FAKE"))
             .hydroflow_ir()
         {
             insta::with_settings!({snapshot_suffix => format!("surface_graph_{id}")}, {

--- a/hydroflow_plus_test/src/cluster/map_reduce.rs
+++ b/hydroflow_plus_test/src/cluster/map_reduce.rs
@@ -36,7 +36,7 @@ pub fn map_reduce(flow: &FlowBuilder) -> (Process<Leader>, Cluster<Worker>) {
 
 #[cfg(test)]
 mod tests {
-    use hydroflow_plus_deploy::CLIRuntime;
+    use hydroflow_plus_deploy::CliRuntime;
     use stageleft::RuntimeData;
 
     #[test]
@@ -48,7 +48,7 @@ mod tests {
         insta::assert_debug_snapshot!(built.ir());
 
         for (id, ir) in built
-            .compile::<CLIRuntime>(&RuntimeData::new("FAKE"))
+            .compile::<CliRuntime>(&RuntimeData::new("FAKE"))
             .hydroflow_ir()
         {
             insta::with_settings!({snapshot_suffix => format!("surface_graph_{id}")}, {

--- a/relalg/src/lib.rs
+++ b/relalg/src/lib.rs
@@ -24,7 +24,7 @@ impl Datum {
         }
     }
 
-    pub fn is_true(self) -> bool {
+    pub fn is_true(&self) -> bool {
         matches!(self, Datum::Bool(true))
     }
 }

--- a/website_playground/src/lib.rs
+++ b/website_playground/src/lib.rs
@@ -34,14 +34,14 @@ pub fn init() {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct JSLineColumn {
+pub struct JsLineColumn {
     pub line: usize,
     pub column: usize,
 }
 
-impl From<LineColumn> for JSLineColumn {
+impl From<LineColumn> for JsLineColumn {
     fn from(lc: LineColumn) -> Self {
-        JSLineColumn {
+        JsLineColumn {
             line: lc.line,
             column: lc.column,
         }
@@ -49,12 +49,12 @@ impl From<LineColumn> for JSLineColumn {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct JSSpan {
-    pub start: JSLineColumn,
-    pub end: Option<JSLineColumn>,
+pub struct JsSpan {
+    pub start: JsLineColumn,
+    pub end: Option<JsLineColumn>,
 }
 
-impl From<Span> for JSSpan {
+impl From<Span> for JsSpan {
     fn from(span: Span) -> Self {
         #[cfg(procmacro2_semver_exempt)]
         let is_call_site = span.eq(&Span::call_site());
@@ -63,12 +63,12 @@ impl From<Span> for JSSpan {
         let is_call_site = true;
 
         if is_call_site {
-            JSSpan {
-                start: JSLineColumn { line: 0, column: 0 },
+            JsSpan {
+                start: JsLineColumn { line: 0, column: 0 },
                 end: None,
             }
         } else {
-            JSSpan {
+            JsSpan {
                 start: span.start().into(),
                 end: Some(span.end().into()),
             }
@@ -77,15 +77,15 @@ impl From<Span> for JSSpan {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct JSDiagnostic {
-    pub span: JSSpan,
+pub struct JsDiagnostic {
+    pub span: JsSpan,
     pub message: String,
     pub is_error: bool,
 }
 
-impl From<Diagnostic> for JSDiagnostic {
+impl From<Diagnostic> for JsDiagnostic {
     fn from(diag: Diagnostic) -> Self {
-        JSDiagnostic {
+        JsDiagnostic {
             span: diag.span.into(),
             message: diag.message,
             is_error: diag.level == Level::Error,
@@ -96,7 +96,7 @@ impl From<Diagnostic> for JSDiagnostic {
 #[derive(Serialize, Deserialize)]
 pub struct HydroflowResult {
     pub output: Option<HydroflowOutput>,
-    pub diagnostics: Vec<JSDiagnostic>,
+    pub diagnostics: Vec<JsDiagnostic>,
 }
 #[derive(Serialize, Deserialize)]
 pub struct HydroflowOutput {
@@ -148,7 +148,7 @@ pub fn compile_hydroflow(
             output: None,
             diagnostics: errors
                 .into_iter()
-                .map(|e| JSDiagnostic {
+                .map(|e| JsDiagnostic {
                     span: e.span().into(),
                     message: e.to_string(),
                     is_error: true,


### PR DESCRIPTION
BREAKING CHANGE: changes some pub-facing names. Behaviors are the same.