### PR TITLE
fix(hydroflow_plus): rewrite IR in place to avoid stack overflow and disable cloning

### DIFF
--- a/hydroflow_plus/src/builder/built.rs
+++ b/hydroflow_plus/src/builder/built.rs
@@ -46,7 +46,7 @@ impl<'a> BuiltFlow<'a> {
     }
 }
 
-pub(crate) fn build_inner(ir: Vec<HfPlusLeaf>) -> BTreeMap<usize, HydroflowGraph> {
+pub(crate) fn build_inner(ir: &mut Vec<HfPlusLeaf>) -> BTreeMap<usize, HydroflowGraph> {
     let mut builders = BTreeMap::new();
     let mut built_tees = HashMap::new();
     let mut next_stmt_id = 0;
@@ -69,7 +69,7 @@ impl<'a> BuiltFlow<'a> {
         self.used = true;
 
         HfCompiled {
-            hydroflow_ir: build_inner(std::mem::take(&mut self.ir)),
+            hydroflow_ir: build_inner(&mut self.ir),
             extra_stmts: BTreeMap::new(),
             _phantom: PhantomData,
         }

--- a/hydroflow_plus/src/builder/deploy.rs
+++ b/hydroflow_plus/src/builder/deploy.rs
@@ -44,7 +44,7 @@ impl<'a, D: Deploy<'a>> DeployFlow<'a, D> {
         self.used = true;
 
         let mut seen_tees: HashMap<_, _> = HashMap::new();
-        let ir_leaves_networked: Vec<HfPlusLeaf> = std::mem::take(&mut self.ir)
+        let mut ir_leaves_networked: Vec<HfPlusLeaf> = std::mem::take(&mut self.ir)
             .into_iter()
             .map(|leaf| leaf.compile_network::<D>(env, &mut seen_tees, &self.nodes, &self.clusters))
             .collect();
@@ -81,7 +81,7 @@ impl<'a, D: Deploy<'a>> DeployFlow<'a, D> {
         }
 
         HfCompiled {
-            hydroflow_ir: build_inner(ir_leaves_networked),
+            hydroflow_ir: build_inner(&mut ir_leaves_networked),
             extra_stmts,
             _phantom: PhantomData,
         }
@@ -94,7 +94,7 @@ impl<'a, D: Deploy<'a, CompileEnv = ()>> DeployFlow<'a, D> {
         self.used = true;
 
         let mut seen_tees_instantiate: HashMap<_, _> = HashMap::new();
-        let ir_leaves_networked: Vec<HfPlusLeaf> = std::mem::take(&mut self.ir)
+        let mut ir_leaves_networked: Vec<HfPlusLeaf> = std::mem::take(&mut self.ir)
             .into_iter()
             .map(|leaf| {
                 leaf.compile_network::<D>(
@@ -106,7 +106,7 @@ impl<'a, D: Deploy<'a, CompileEnv = ()>> DeployFlow<'a, D> {
             })
             .collect();
 
-        let mut compiled = build_inner(ir_leaves_networked.clone());
+        let mut compiled = build_inner(&mut ir_leaves_networked);
         let mut meta = D::Meta::default();
 
         let (mut processes, mut clusters) = (

--- a/hydroflow_plus/src/ir.rs
+++ b/hydroflow_plus/src/ir.rs
@@ -44,20 +44,7 @@ impl std::fmt::Debug for DebugExpr {
 
 pub enum DebugInstantiate<'a> {
     Building(),
-    Finalized(syn::Expr, syn::Expr, Rc<dyn Fn() + 'a>),
-}
-
-impl<'a> Clone for DebugInstantiate<'a> {
-    fn clone(&self) -> Self {
-        match self {
-            DebugInstantiate::Building() => {
-                panic!("cannot clone building function")
-            }
-            DebugInstantiate::Finalized(sink, source, connect_fn) => {
-                DebugInstantiate::Finalized(sink.clone(), source.clone(), connect_fn.clone())
-            }
-        }
-    }
+    Finalized(syn::Expr, syn::Expr, Box<dyn Fn() + 'a>),
 }
 
 impl<'a> std::fmt::Debug for DebugInstantiate<'a> {
@@ -76,7 +63,7 @@ impl std::fmt::Debug for DebugPipelineFn {
 }
 
 /// A source in a Hydroflow+ graph, where data enters the graph.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum HfPlusSource {
     Stream(DebugExpr),
     Iter(DebugExpr),
@@ -87,7 +74,7 @@ pub enum HfPlusSource {
 /// An leaf in a Hydroflow+ graph, which is an pipeline that doesn't emit
 /// any downstream values. Traversals over the dataflow graph and
 /// generating Hydroflow IR start from leaves.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum HfPlusLeaf<'a> {
     ForEach {
         f: DebugExpr,
@@ -113,43 +100,53 @@ impl<'a> HfPlusLeaf<'a> {
         clusters: &HashMap<usize, D::Cluster>,
     ) -> HfPlusLeaf<'a> {
         self.transform_children(
-            |n, s| n.compile_network::<D>(compile_env, s, nodes, clusters),
+            |n, s| {
+                n.compile_network::<D>(compile_env, s, nodes, clusters);
+            },
             seen_tees,
         )
     }
 
     pub fn connect_network(self, seen_tees: &mut SeenTees<'a>) -> HfPlusLeaf<'a> {
-        self.transform_children(|n, s| n.connect_network(s), seen_tees)
+        self.transform_children(
+            |n, s| {
+                n.connect_network(s);
+            },
+            seen_tees,
+        )
     }
 
     pub fn transform_children(
         self,
-        mut transform: impl FnMut(HfPlusNode<'a>, &mut SeenTees<'a>) -> HfPlusNode<'a>,
+        mut transform: impl FnMut(&mut HfPlusNode<'a>, &mut SeenTees<'a>),
         seen_tees: &mut SeenTees<'a>,
     ) -> HfPlusLeaf<'a> {
         match self {
-            HfPlusLeaf::ForEach { f, input } => HfPlusLeaf::ForEach {
-                f,
-                input: Box::new(transform(*input, seen_tees)),
-            },
-            HfPlusLeaf::DestSink { sink, input } => HfPlusLeaf::DestSink {
-                sink,
-                input: Box::new(transform(*input, seen_tees)),
-            },
+            HfPlusLeaf::ForEach { f, mut input } => {
+                transform(&mut input, seen_tees);
+                HfPlusLeaf::ForEach { f, input }
+            }
+            HfPlusLeaf::DestSink { sink, mut input } => {
+                transform(&mut input, seen_tees);
+                HfPlusLeaf::DestSink { sink, input }
+            }
             HfPlusLeaf::CycleSink {
                 ident,
                 location_kind,
-                input,
-            } => HfPlusLeaf::CycleSink {
-                ident,
-                location_kind,
-                input: Box::new(transform(*input, seen_tees)),
-            },
+                mut input,
+            } => {
+                transform(&mut input, seen_tees);
+                HfPlusLeaf::CycleSink {
+                    ident,
+                    location_kind,
+                    input,
+                }
+            }
         }
     }
 
     pub fn emit(
-        self,
+        &self,
         graph_builders: &mut BTreeMap<usize, FlatGraphBuilder>,
         built_tees: &mut HashMap<*const RefCell<HfPlusNode<'a>>, (syn::Ident, usize)>,
         next_stmt_id: &mut usize,
@@ -193,12 +190,12 @@ impl<'a> HfPlusLeaf<'a> {
                 };
 
                 assert_eq!(
-                    input_location_id, location_id,
+                    input_location_id, *location_id,
                     "cycle_sink location mismatch"
                 );
 
                 graph_builders
-                    .entry(location_id)
+                    .entry(*location_id)
                     .or_default()
                     .add_statement(parse_quote! {
                         #ident = #input_ident;
@@ -210,7 +207,7 @@ impl<'a> HfPlusLeaf<'a> {
 
 /// An intermediate node in a Hydroflow+ graph, which consumes data
 /// from upstream nodes and emits data to downstream nodes.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum HfPlusNode<'a> {
     Placeholder,
 
@@ -299,390 +296,307 @@ pub type SeenTees<'a> = HashMap<*const RefCell<HfPlusNode<'a>>, Rc<RefCell<HfPlu
 
 impl<'a> HfPlusNode<'a> {
     pub fn compile_network<D: Deploy<'a> + 'a>(
-        self,
+        &mut self,
         compile_env: &D::CompileEnv,
         seen_tees: &mut SeenTees<'a>,
         nodes: &HashMap<usize, D::Process>,
         clusters: &HashMap<usize, D::Cluster>,
-    ) -> HfPlusNode<'a> {
-        match self.transform_children(
+    ) {
+        self.transform_children(
             |n, s| n.compile_network::<D>(compile_env, s, nodes, clusters),
             seen_tees,
-        ) {
-            HfPlusNode::Network {
-                from_location,
-                to_location,
-                serialize_pipeline,
-                instantiate_fn,
-                deserialize_pipeline,
-                input,
-            } => {
-                let (sink_expr, source_expr, connect_fn) = match instantiate_fn {
-                    DebugInstantiate::Building() => {
-                        let ((sink, source), connect_fn) = match (from_location, to_location) {
-                            (LocationId::Process(from), LocationId::Process(to)) => {
-                                let from_node = nodes
-                                    .get(&from)
-                                    .unwrap_or_else(|| {
-                                        panic!(
-                                            "A location used in the graph was not instantiated: {}",
-                                            from
-                                        )
-                                    })
-                                    .clone();
-                                let to_node = nodes
-                                    .get(&to)
-                                    .unwrap_or_else(|| {
-                                        panic!(
-                                            "A location used in the graph was not instantiated: {}",
-                                            to
-                                        )
-                                    })
-                                    .clone();
+        );
 
-                                let sink_port = D::allocate_process_port(&from_node);
-                                let source_port = D::allocate_process_port(&to_node);
+        if let HfPlusNode::Network {
+            from_location,
+            to_location,
+            instantiate_fn,
+            ..
+        } = self
+        {
+            let (sink_expr, source_expr, connect_fn) = match instantiate_fn {
+                DebugInstantiate::Building() => {
+                    let ((sink, source), connect_fn) = match (from_location, to_location) {
+                        (LocationId::Process(from), LocationId::Process(to)) => {
+                            let from_node = nodes
+                                .get(from)
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "A location used in the graph was not instantiated: {}",
+                                        from
+                                    )
+                                })
+                                .clone();
+                            let to_node = nodes
+                                .get(to)
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "A location used in the graph was not instantiated: {}",
+                                        to
+                                    )
+                                })
+                                .clone();
 
-                                (
-                                    D::o2o_sink_source(
-                                        compile_env,
-                                        &from_node,
-                                        &sink_port,
-                                        &to_node,
-                                        &source_port,
-                                    ),
-                                    Rc::new(move || {
-                                        D::o2o_connect(
-                                            &from_node,
-                                            &sink_port,
-                                            &to_node,
-                                            &source_port,
-                                        )
-                                    }) as Rc<dyn Fn() + 'a>,
-                                )
-                            }
-                            (LocationId::Process(from), LocationId::Cluster(to)) => {
-                                let from_node = nodes
-                                    .get(&from)
-                                    .unwrap_or_else(|| {
-                                        panic!(
-                                            "A location used in the graph was not instantiated: {}",
-                                            from
-                                        )
-                                    })
-                                    .clone();
-                                let to_node = clusters
-                                    .get(&to)
-                                    .unwrap_or_else(|| {
-                                        panic!(
-                                            "A location used in the graph was not instantiated: {}",
-                                            to
-                                        )
-                                    })
-                                    .clone();
+                            let sink_port = D::allocate_process_port(&from_node);
+                            let source_port = D::allocate_process_port(&to_node);
 
-                                let sink_port = D::allocate_process_port(&from_node);
-                                let source_port = D::allocate_cluster_port(&to_node);
+                            (
+                                D::o2o_sink_source(
+                                    compile_env,
+                                    &from_node,
+                                    &sink_port,
+                                    &to_node,
+                                    &source_port,
+                                ),
+                                Box::new(move || {
+                                    D::o2o_connect(&from_node, &sink_port, &to_node, &source_port)
+                                }) as Box<dyn Fn() + 'a>,
+                            )
+                        }
+                        (LocationId::Process(from), LocationId::Cluster(to)) => {
+                            let from_node = nodes
+                                .get(from)
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "A location used in the graph was not instantiated: {}",
+                                        from
+                                    )
+                                })
+                                .clone();
+                            let to_node = clusters
+                                .get(to)
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "A location used in the graph was not instantiated: {}",
+                                        to
+                                    )
+                                })
+                                .clone();
 
-                                (
-                                    D::o2m_sink_source(
-                                        compile_env,
-                                        &from_node,
-                                        &sink_port,
-                                        &to_node,
-                                        &source_port,
-                                    ),
-                                    Rc::new(move || {
-                                        D::o2m_connect(
-                                            &from_node,
-                                            &sink_port,
-                                            &to_node,
-                                            &source_port,
-                                        )
-                                    }) as Rc<dyn Fn() + 'a>,
-                                )
-                            }
-                            (LocationId::Cluster(from), LocationId::Process(to)) => {
-                                let from_node = clusters
-                                    .get(&from)
-                                    .unwrap_or_else(|| {
-                                        panic!(
-                                            "A location used in the graph was not instantiated: {}",
-                                            from
-                                        )
-                                    })
-                                    .clone();
-                                let to_node = nodes
-                                    .get(&to)
-                                    .unwrap_or_else(|| {
-                                        panic!(
-                                            "A location used in the graph was not instantiated: {}",
-                                            to
-                                        )
-                                    })
-                                    .clone();
+                            let sink_port = D::allocate_process_port(&from_node);
+                            let source_port = D::allocate_cluster_port(&to_node);
 
-                                let sink_port = D::allocate_cluster_port(&from_node);
-                                let source_port = D::allocate_process_port(&to_node);
+                            (
+                                D::o2m_sink_source(
+                                    compile_env,
+                                    &from_node,
+                                    &sink_port,
+                                    &to_node,
+                                    &source_port,
+                                ),
+                                Box::new(move || {
+                                    D::o2m_connect(&from_node, &sink_port, &to_node, &source_port)
+                                }) as Box<dyn Fn() + 'a>,
+                            )
+                        }
+                        (LocationId::Cluster(from), LocationId::Process(to)) => {
+                            let from_node = clusters
+                                .get(from)
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "A location used in the graph was not instantiated: {}",
+                                        from
+                                    )
+                                })
+                                .clone();
+                            let to_node = nodes
+                                .get(to)
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "A location used in the graph was not instantiated: {}",
+                                        to
+                                    )
+                                })
+                                .clone();
 
-                                (
-                                    D::m2o_sink_source(
-                                        compile_env,
-                                        &from_node,
-                                        &sink_port,
-                                        &to_node,
-                                        &source_port,
-                                    ),
-                                    Rc::new(move || {
-                                        D::m2o_connect(
-                                            &from_node,
-                                            &sink_port,
-                                            &to_node,
-                                            &source_port,
-                                        )
-                                    }) as Rc<dyn Fn() + 'a>,
-                                )
-                            }
-                            (LocationId::Cluster(from), LocationId::Cluster(to)) => {
-                                let from_node = clusters
-                                    .get(&from)
-                                    .unwrap_or_else(|| {
-                                        panic!(
-                                            "A location used in the graph was not instantiated: {}",
-                                            from
-                                        )
-                                    })
-                                    .clone();
-                                let to_node = clusters
-                                    .get(&to)
-                                    .unwrap_or_else(|| {
-                                        panic!(
-                                            "A location used in the graph was not instantiated: {}",
-                                            to
-                                        )
-                                    })
-                                    .clone();
+                            let sink_port = D::allocate_cluster_port(&from_node);
+                            let source_port = D::allocate_process_port(&to_node);
 
-                                let sink_port = D::allocate_cluster_port(&from_node);
-                                let source_port = D::allocate_cluster_port(&to_node);
+                            (
+                                D::m2o_sink_source(
+                                    compile_env,
+                                    &from_node,
+                                    &sink_port,
+                                    &to_node,
+                                    &source_port,
+                                ),
+                                Box::new(move || {
+                                    D::m2o_connect(&from_node, &sink_port, &to_node, &source_port)
+                                }) as Box<dyn Fn() + 'a>,
+                            )
+                        }
+                        (LocationId::Cluster(from), LocationId::Cluster(to)) => {
+                            let from_node = clusters
+                                .get(from)
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "A location used in the graph was not instantiated: {}",
+                                        from
+                                    )
+                                })
+                                .clone();
+                            let to_node = clusters
+                                .get(to)
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "A location used in the graph was not instantiated: {}",
+                                        to
+                                    )
+                                })
+                                .clone();
 
-                                (
-                                    D::m2m_sink_source(
-                                        compile_env,
-                                        &from_node,
-                                        &sink_port,
-                                        &to_node,
-                                        &source_port,
-                                    ),
-                                    Rc::new(move || {
-                                        D::m2m_connect(
-                                            &from_node,
-                                            &sink_port,
-                                            &to_node,
-                                            &source_port,
-                                        )
-                                    }) as Rc<dyn Fn() + 'a>,
-                                )
-                            }
-                        };
+                            let sink_port = D::allocate_cluster_port(&from_node);
+                            let source_port = D::allocate_cluster_port(&to_node);
 
-                        (sink, source, connect_fn)
-                    }
+                            (
+                                D::m2m_sink_source(
+                                    compile_env,
+                                    &from_node,
+                                    &sink_port,
+                                    &to_node,
+                                    &source_port,
+                                ),
+                                Box::new(move || {
+                                    D::m2m_connect(&from_node, &sink_port, &to_node, &source_port)
+                                }) as Box<dyn Fn() + 'a>,
+                            )
+                        }
+                    };
 
-                    DebugInstantiate::Finalized(_, _, _) => panic!("network already finalized"),
-                };
-
-                HfPlusNode::Network {
-                    from_location,
-                    to_location,
-                    serialize_pipeline,
-                    instantiate_fn: DebugInstantiate::Finalized(sink_expr, source_expr, connect_fn),
-                    deserialize_pipeline,
-                    input,
+                    (sink, source, connect_fn)
                 }
-            }
 
-            o => o,
+                DebugInstantiate::Finalized(_, _, _) => panic!("network already finalized"),
+            };
+
+            *instantiate_fn = DebugInstantiate::Finalized(sink_expr, source_expr, connect_fn);
         }
     }
 
-    pub fn connect_network(self, seen_tees: &mut SeenTees<'a>) -> HfPlusNode<'a> {
-        match self.transform_children(|n, s| n.connect_network(s), seen_tees) {
-            HfPlusNode::Network {
-                from_location,
-                to_location,
-                serialize_pipeline,
-                instantiate_fn,
-                deserialize_pipeline,
-                input,
-            } => {
-                match instantiate_fn {
-                    DebugInstantiate::Building() => panic!("network not built"),
+    pub fn connect_network(&mut self, seen_tees: &mut SeenTees<'a>) {
+        self.transform_children(|n, s| n.connect_network(s), seen_tees);
+        if let HfPlusNode::Network { instantiate_fn, .. } = self {
+            match instantiate_fn {
+                DebugInstantiate::Building() => panic!("network not built"),
 
-                    DebugInstantiate::Finalized(_, _, ref connect_fn) => {
-                        connect_fn();
-                    }
-                };
-
-                HfPlusNode::Network {
-                    from_location,
-                    to_location,
-                    serialize_pipeline,
-                    instantiate_fn,
-                    deserialize_pipeline,
-                    input,
+                DebugInstantiate::Finalized(_, _, ref connect_fn) => {
+                    connect_fn();
                 }
             }
-
-            o => o,
         }
     }
 
     pub fn transform_children(
-        self,
-        mut transform: impl FnMut(HfPlusNode<'a>, &mut SeenTees<'a>) -> HfPlusNode<'a>,
+        &mut self,
+        mut transform: impl FnMut(&mut HfPlusNode<'a>, &mut SeenTees<'a>),
         seen_tees: &mut SeenTees<'a>,
-    ) -> HfPlusNode<'a> {
+    ) {
         match self {
-            HfPlusNode::Placeholder => HfPlusNode::Placeholder,
+            HfPlusNode::Placeholder => {
+                panic!();
+            }
 
-            HfPlusNode::Source {
-                source,
-                location_kind,
-            } => HfPlusNode::Source {
-                source,
-                location_kind,
-            },
+            HfPlusNode::Source { .. } => {}
 
-            HfPlusNode::CycleSource {
-                ident,
-                location_kind,
-            } => HfPlusNode::CycleSource {
-                ident,
-                location_kind,
-            },
+            HfPlusNode::CycleSource { .. } => {}
 
             HfPlusNode::Tee { inner } => {
                 if let Some(transformed) =
                     seen_tees.get(&(inner.as_ref() as *const RefCell<HfPlusNode>))
                 {
-                    HfPlusNode::Tee {
-                        inner: transformed.clone(),
-                    }
+                    *inner = transformed.clone();
                 } else {
                     let transformed_cell = Rc::new(RefCell::new(HfPlusNode::Placeholder));
                     seen_tees.insert(
                         inner.as_ref() as *const RefCell<HfPlusNode>,
                         transformed_cell.clone(),
                     );
-                    let orig = inner.replace(HfPlusNode::Placeholder);
-                    *transformed_cell.borrow_mut() = transform(orig, seen_tees);
-                    HfPlusNode::Tee {
-                        inner: transformed_cell,
-                    }
+                    let mut orig = inner.replace(HfPlusNode::Placeholder);
+                    transform(&mut orig, seen_tees);
+                    *transformed_cell.borrow_mut() = orig;
+                    *inner = transformed_cell;
                 }
             }
 
-            HfPlusNode::Persist(inner) => {
-                HfPlusNode::Persist(Box::new(transform(*inner, seen_tees)))
+            HfPlusNode::Persist(inner) => transform(inner.as_mut(), seen_tees),
+            HfPlusNode::Delta(inner) => transform(inner.as_mut(), seen_tees),
+
+            HfPlusNode::Union(left, right) => {
+                transform(left.as_mut(), seen_tees);
+                transform(right.as_mut(), seen_tees);
             }
-            HfPlusNode::Delta(inner) => HfPlusNode::Delta(Box::new(transform(*inner, seen_tees))),
+            HfPlusNode::CrossProduct(left, right) => {
+                transform(left.as_mut(), seen_tees);
+                transform(right.as_mut(), seen_tees);
+            }
+            HfPlusNode::CrossSingleton(left, right) => {
+                transform(left.as_mut(), seen_tees);
+                transform(right.as_mut(), seen_tees);
+            }
+            HfPlusNode::Join(left, right) => {
+                transform(left.as_mut(), seen_tees);
+                transform(right.as_mut(), seen_tees);
+            }
+            HfPlusNode::Difference(left, right) => {
+                transform(left.as_mut(), seen_tees);
+                transform(right.as_mut(), seen_tees);
+            }
+            HfPlusNode::AntiJoin(left, right) => {
+                transform(left.as_mut(), seen_tees);
+                transform(right.as_mut(), seen_tees);
+            }
 
-            HfPlusNode::Union(left, right) => HfPlusNode::Union(
-                Box::new(transform(*left, seen_tees)),
-                Box::new(transform(*right, seen_tees)),
-            ),
-            HfPlusNode::CrossProduct(left, right) => HfPlusNode::CrossProduct(
-                Box::new(transform(*left, seen_tees)),
-                Box::new(transform(*right, seen_tees)),
-            ),
-            HfPlusNode::CrossSingleton(left, right) => HfPlusNode::CrossSingleton(
-                Box::new(transform(*left, seen_tees)),
-                Box::new(transform(*right, seen_tees)),
-            ),
-            HfPlusNode::Join(left, right) => HfPlusNode::Join(
-                Box::new(transform(*left, seen_tees)),
-                Box::new(transform(*right, seen_tees)),
-            ),
-            HfPlusNode::Difference(left, right) => HfPlusNode::Difference(
-                Box::new(transform(*left, seen_tees)),
-                Box::new(transform(*right, seen_tees)),
-            ),
-            HfPlusNode::AntiJoin(left, right) => HfPlusNode::AntiJoin(
-                Box::new(transform(*left, seen_tees)),
-                Box::new(transform(*right, seen_tees)),
-            ),
-
-            HfPlusNode::Map { f, input } => HfPlusNode::Map {
-                f,
-                input: Box::new(transform(*input, seen_tees)),
-            },
-            HfPlusNode::FlatMap { f, input } => HfPlusNode::FlatMap {
-                f,
-                input: Box::new(transform(*input, seen_tees)),
-            },
-            HfPlusNode::Filter { f, input } => HfPlusNode::Filter {
-                f,
-                input: Box::new(transform(*input, seen_tees)),
-            },
-            HfPlusNode::FilterMap { f, input } => HfPlusNode::FilterMap {
-                f,
-                input: Box::new(transform(*input, seen_tees)),
-            },
-            HfPlusNode::Sort(input) => HfPlusNode::Sort(Box::new(transform(*input, seen_tees))),
+            HfPlusNode::Map { input, .. } => {
+                transform(input.as_mut(), seen_tees);
+            }
+            HfPlusNode::FlatMap { input, .. } => {
+                transform(input.as_mut(), seen_tees);
+            }
+            HfPlusNode::Filter { input, .. } => {
+                transform(input.as_mut(), seen_tees);
+            }
+            HfPlusNode::FilterMap { input, .. } => {
+                transform(input.as_mut(), seen_tees);
+            }
+            HfPlusNode::Sort(input) => {
+                transform(input.as_mut(), seen_tees);
+            }
             HfPlusNode::DeferTick(input) => {
-                HfPlusNode::DeferTick(Box::new(transform(*input, seen_tees)))
+                transform(input.as_mut(), seen_tees);
             }
             HfPlusNode::Enumerate(input) => {
-                HfPlusNode::Enumerate(Box::new(transform(*input, seen_tees)))
+                transform(input.as_mut(), seen_tees);
             }
-            HfPlusNode::Inspect { f, input } => HfPlusNode::Inspect {
-                f,
-                input: Box::new(transform(*input, seen_tees)),
-            },
+            HfPlusNode::Inspect { input, .. } => {
+                transform(input.as_mut(), seen_tees);
+            }
 
-            HfPlusNode::Unique(input) => HfPlusNode::Unique(Box::new(transform(*input, seen_tees))),
+            HfPlusNode::Unique(input) => {
+                transform(input.as_mut(), seen_tees);
+            }
 
-            HfPlusNode::Fold { init, acc, input } => HfPlusNode::Fold {
-                init,
-                acc,
-                input: Box::new(transform(*input, seen_tees)),
-            },
-            HfPlusNode::FoldKeyed { init, acc, input } => HfPlusNode::FoldKeyed {
-                init,
-                acc,
-                input: Box::new(transform(*input, seen_tees)),
-            },
+            HfPlusNode::Fold { input, .. } => {
+                transform(input.as_mut(), seen_tees);
+            }
+            HfPlusNode::FoldKeyed { input, .. } => {
+                transform(input.as_mut(), seen_tees);
+            }
 
-            HfPlusNode::Reduce { f, input } => HfPlusNode::Reduce {
-                f,
-                input: Box::new(transform(*input, seen_tees)),
-            },
-            HfPlusNode::ReduceKeyed { f, input } => HfPlusNode::ReduceKeyed {
-                f,
-                input: Box::new(transform(*input, seen_tees)),
-            },
+            HfPlusNode::Reduce { input, .. } => {
+                transform(input.as_mut(), seen_tees);
+            }
+            HfPlusNode::ReduceKeyed { input, .. } => {
+                transform(input.as_mut(), seen_tees);
+            }
 
-            HfPlusNode::Network {
-                from_location,
-                to_location,
-                serialize_pipeline,
-                instantiate_fn,
-                deserialize_pipeline,
-                input,
-            } => HfPlusNode::Network {
-                from_location,
-                to_location,
-                serialize_pipeline,
-                instantiate_fn,
-                deserialize_pipeline,
-                input: Box::new(transform(*input, seen_tees)),
-            },
+            HfPlusNode::Network { input, .. } => {
+                transform(input.as_mut(), seen_tees);
+            }
         }
     }
 
     pub fn emit(
-        self,
+        &self,
         graph_builders: &mut BTreeMap<usize, FlatGraphBuilder>,
         built_tees: &mut HashMap<*const RefCell<HfPlusNode<'a>>, (syn::Ident, usize)>,
         next_stmt_id: &mut usize,
@@ -768,11 +682,11 @@ impl<'a> HfPlusNode<'a> {
                 };
 
                 graph_builders
-                    .entry(location_id)
+                    .entry(*location_id)
                     .or_default()
                     .add_statement(source_stmt);
 
-                (source_ident, location_id)
+                (source_ident, *location_id)
             }
 
             HfPlusNode::CycleSource {
@@ -784,16 +698,17 @@ impl<'a> HfPlusNode<'a> {
                     LocationId::Cluster(id) => id,
                 };
 
-                (ident.clone(), location_id)
+                (ident.clone(), *location_id)
             }
 
             HfPlusNode::Tee { inner } => {
                 if let Some(ret) = built_tees.get(&(inner.as_ref() as *const RefCell<HfPlusNode>)) {
                     ret.clone()
                 } else {
-                    let (inner_ident, inner_location_id) = inner
-                        .replace(HfPlusNode::Placeholder)
-                        .emit(graph_builders, built_tees, next_stmt_id);
+                    let (inner_ident, inner_location_id) =
+                        inner
+                            .borrow()
+                            .emit(graph_builders, built_tees, next_stmt_id);
 
                     let tee_id = *next_stmt_id;
                     *next_stmt_id += 1;
@@ -893,17 +808,19 @@ impl<'a> HfPlusNode<'a> {
                     unreachable!()
                 };
 
-                let (left_inner, left_was_persist) = if let HfPlusNode::Persist(left) = *left {
-                    (left, true)
-                } else {
-                    (left, false)
-                };
+                let (left_inner, left_was_persist) =
+                    if let HfPlusNode::Persist(left) = left.as_ref() {
+                        (left, true)
+                    } else {
+                        (left, false)
+                    };
 
-                let (right_inner, right_was_persist) = if let HfPlusNode::Persist(right) = *right {
-                    (right, true)
-                } else {
-                    (right, false)
-                };
+                let (right_inner, right_was_persist) =
+                    if let HfPlusNode::Persist(right) = right.as_ref() {
+                        (right, true)
+                    } else {
+                        (right, false)
+                    };
 
                 let (left_ident, left_location_id) =
                     left_inner.emit(graph_builders, built_tees, next_stmt_id);
@@ -970,7 +887,8 @@ impl<'a> HfPlusNode<'a> {
                     unreachable!()
                 };
 
-                let (right, right_was_persist) = if let HfPlusNode::Persist(right) = *right {
+                let (right, right_was_persist) = if let HfPlusNode::Persist(right) = right.as_ref()
+                {
                     (right, true)
                 } else {
                     (right, false)
@@ -1188,7 +1106,8 @@ impl<'a> HfPlusNode<'a> {
                     unreachable!()
                 };
 
-                let (input, input_was_persist) = if let HfPlusNode::Persist(input) = *input {
+                let (input, input_was_persist) = if let HfPlusNode::Persist(input) = input.as_ref()
+                {
                     (input, true)
                 } else {
                     (input, false)
@@ -1229,7 +1148,8 @@ impl<'a> HfPlusNode<'a> {
                     unreachable!()
                 };
 
-                let (input, input_was_persist) = if let HfPlusNode::Persist(input) = *input {
+                let (input, input_was_persist) = if let HfPlusNode::Persist(input) = input.as_ref()
+                {
                     (input, true)
                 } else {
                     (input, false)
@@ -1296,7 +1216,7 @@ impl<'a> HfPlusNode<'a> {
                     LocationId::Cluster(id) => id,
                 };
 
-                let receiver_builder = graph_builders.entry(to_id).or_default();
+                let receiver_builder = graph_builders.entry(*to_id).or_default();
                 let receiver_stream_id = *next_stmt_id;
                 *next_stmt_id += 1;
 
@@ -1313,7 +1233,7 @@ impl<'a> HfPlusNode<'a> {
                     });
                 }
 
-                (receiver_stream_ident, to_id)
+                (receiver_stream_ident, *to_id)
             }
         }
     }

--- a/hydroflow_plus/src/profiler.rs
+++ b/hydroflow_plus/src/profiler.rs
@@ -17,23 +17,24 @@ fn quoted_any_fn<'a, F: Fn(&usize) + 'a, Q: IntoQuotedMut<'a, F>>(q: Q) -> Q {
 
 /// Add a profiling node before each node to count the cardinality of its input
 fn add_profiling_node<'a>(
-    node: HfPlusNode<'a>,
+    node: &mut HfPlusNode<'a>,
     _context: RuntimeContext<'a>,
     counters: RuntimeData<&'a RefCell<Vec<u64>>>,
     counter_queue: RuntimeData<&'a RefCell<UnboundedSender<(usize, u64)>>>,
     id: &mut u32,
     seen_tees: &mut SeenTees<'a>,
-) -> HfPlusNode<'a> {
+) {
     let my_id = *id;
     *id += 1;
 
-    let child = node.transform_children(
+    node.transform_children(
         |node, seen_tees| {
             add_profiling_node(node, _context, counters, counter_queue, id, seen_tees)
         },
         seen_tees,
     );
-    HfPlusNode::Inspect {
+    let orig_node = std::mem::replace(node, HfPlusNode::Placeholder);
+    *node = HfPlusNode::Inspect {
         f: quoted_any_fn(q!({
             // Put counters on queue
             counter_queue
@@ -49,7 +50,7 @@ fn add_profiling_node<'a>(
         }))
         .splice()
         .into(),
-        input: Box::new(child),
+        input: Box::new(orig_node),
     }
 }
 

--- a/hydroflow_plus/src/properties.rs
+++ b/hydroflow_plus/src/properties.rs
@@ -42,19 +42,19 @@ impl PropertyDatabase {
 // TODO add a test that verifies the space of possible graphs after rewrites is correct for each property
 
 fn properties_optimize_node<'a>(
-    node: HfPlusNode<'a>,
+    node: &mut HfPlusNode<'a>,
     db: &PropertyDatabase,
     seen_tees: &mut SeenTees<'a>,
-) -> HfPlusNode<'a> {
-    match node.transform_children(
+) {
+    node.transform_children(
         |node, seen_tees| properties_optimize_node(node, db, seen_tees),
         seen_tees,
-    ) {
-        HfPlusNode::ReduceKeyed { f, input } if db.is_tagged_commutative(&f.0) => {
+    );
+    match node {
+        HfPlusNode::ReduceKeyed { f, .. } if db.is_tagged_commutative(&f.0) => {
             dbg!("IDENTIFIED COMMUTATIVE OPTIMIZATION for {:?}", &f);
-            HfPlusNode::ReduceKeyed { f, input }
         }
-        o => o,
+        _ => {}
     }
 }
 

--- a/hydroflow_plus/src/stream.rs
+++ b/hydroflow_plus/src/stream.rs
@@ -74,11 +74,19 @@ impl<'a, T: Clone, W, N: Location> Clone for Stream<'a, T, W, N> {
             };
         }
 
-        Stream::new(
-            self.location_kind,
-            self.ir_leaves.clone(),
-            self.ir_node.borrow().clone(),
-        )
+        if let HfPlusNode::Tee { inner } = self.ir_node.borrow().deref() {
+            Stream {
+                location_kind: self.location_kind,
+                ir_leaves: self.ir_leaves.clone(),
+                ir_node: HfPlusNode::Tee {
+                    inner: inner.clone(),
+                }
+                .into(),
+                _phantom: PhantomData,
+            }
+        } else {
+            unreachable!()
+        }
     }
 }
 


### PR DESCRIPTION

Cloning was unsafe because values behind a `Rc<RefCell<...>>` in the case of tee would be entangled with the old IR.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydroflow/pull/1404).
* #1405
* #1398
* __->__ #1404