### PR TITLE
feat(anna): blind gossip

### DIFF
--- a/.idea/hydroflow.iml
+++ b/.idea/hydroflow.iml
@@ -36,6 +36,8 @@
       <sourceFolder url="file://$MODULE_DIR$/variadics/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/website_playground/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/website_playground/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/datastores/gossip_kv/examples" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/datastores/gossip_kv/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,12 +1385,15 @@ dependencies = [
  "config",
  "hostname",
  "hydroflow",
+ "lattices",
  "rand 0.8.5",
  "serde",
  "serde_json",
  "shlex",
+ "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -4171,6 +4174,15 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
+dependencies = [
+ "getrandom 0.2.11",
+]
 
 [[package]]
 name = "valuable"

--- a/datastores/gossip_kv/Cargo.toml
+++ b/datastores/gossip_kv/Cargo.toml
@@ -11,12 +11,15 @@ clap = { version = "4.5.4", features = ["derive"] }
 config = "0.14.0"
 hostname = "0.4.0"
 hydroflow = { path="../../hydroflow" }
+lattices = { path = '../../lattices'}
 rand = "0.8.5"
 serde = "1.0.203"
 serde_json = "1.0.117"
 shlex = "1.3.0"
 tracing = "0.1.40"
 tracing-subscriber = {version = "0.3.18", features = ["env-filter"]}
+uuid = { version = "1.9.1", features = ["v4"] }
+tokio = { version = "1.0.0", features = ["rt", "rt-multi-thread", "macros"] }
 
 [[bin]]
 name = "gossip_server"

--- a/datastores/gossip_kv/protocol/lib.rs
+++ b/datastores/gossip_kv/protocol/lib.rs
@@ -1,4 +1,5 @@
 pub mod membership;
+pub mod model;
 
 use std::collections::HashSet;
 use std::fmt::Display;
@@ -6,6 +7,7 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
+use crate::model::{Clock, Namespaces};
 use crate::KeyParseError::InvalidNamespace;
 
 /// The namespace of the key of an entry in the key-value store.
@@ -145,6 +147,21 @@ pub enum ClientResponse {
     Set { success: bool },
     /// A response for a delete request. The success field is true if delete was successful.
     Delete { success: bool },
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+pub enum GossipMessage {
+    /// An "infecting message" to share updates with a peer.
+    Gossip {
+        message_id: String,
+        writes: Namespaces<Clock>,
+    },
+    /// An acknowledgement message sent by a peer in response to a Gossip message, to indicate
+    /// that it hasn't seen some of the writes in the Gossip message before.
+    Ack { message_id: String },
+    /// A negative acknowledgement sent by a peer in response to a Gossip message, to indicate
+    /// that it has seen all of the writes in the Gossip message before.
+    Nack { message_id: String },
 }
 
 #[cfg(test)]

--- a/datastores/gossip_kv/server/lattices/mod.rs
+++ b/datastores/gossip_kv/server/lattices/mod.rs
@@ -2,13 +2,14 @@ use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::hash::Hash;
 
-use hydroflow::lattices::{IsBot, IsTop, LatticeOrd, Merge};
+use hydroflow::lattices::{IsBot, IsTop, LatticeFrom, LatticeOrd, Merge};
+use serde::{Deserialize, Serialize};
 
 /// A bounded set union lattice with a fixed size N.
 ///
 /// Once the set reaches size N, it becomes top. The items in the set are no longer tracked to
 /// reclaim associated memory.
-#[derive(Debug, Clone, Eq)]
+#[derive(Debug, Clone, Eq, Serialize, Deserialize)]
 
 pub struct BoundedSetLattice<T, const N: usize>
 where
@@ -18,6 +19,15 @@ where
     // is_top => items.is_empty() ... i.e. the items are dropped when the lattice reaches top.
     items: HashSet<T>,
     is_top: bool,
+}
+
+impl<T, const N: usize> LatticeFrom<BoundedSetLattice<T, N>> for BoundedSetLattice<T, N>
+where
+    T: Eq + Hash,
+{
+    fn lattice_from(other: BoundedSetLattice<T, N>) -> Self {
+        other
+    }
 }
 
 impl<T, const N: usize> Default for BoundedSetLattice<T, N>


### PR DESCRIPTION
This change implements a blind gossip protocol where the gossipers don't receive (or care to receive) responses from the systems they gossip with. 

It also adds a deterministic testing framework for testing gossip.

Once request-reply is added, it can stop being blind.