### PR TITLE
feat(hydro_deploy): improve progress UX by collapsing nested groups

### DIFF
--- a/hydro_deploy/core/src/hydroflow_crate/build.rs
+++ b/hydro_deploy/core/src/hydroflow_crate/build.rs
@@ -87,7 +87,7 @@ pub async fn build_crate_memoized(params: BuildParams) -> Result<&'static BuildO
         .get_or_init(MemoMap::new)
         .get_or_insert(&params, Default::default)
         .get_or_try_init(move || {
-            ProgressTracker::rich_leaf("build".to_string(), move |_, set_msg| async move {
+            ProgressTracker::rich_leaf("build", move |set_msg| async move {
                 tokio::task::spawn_blocking(move || {
                     let mut command = Command::new("cargo");
                     command.args(["build"]);

--- a/hydro_deploy/core/src/hydroflow_crate/service.rs
+++ b/hydro_deploy/core/src/hydroflow_crate/service.rs
@@ -197,13 +197,12 @@ impl Service for HydroflowCrateService {
         }
 
         ProgressTracker::with_group(
-            &self
-                .display_id
+            self.display_id
                 .clone()
                 .unwrap_or_else(|| format!("service/{}", self.id)),
             None,
             || async {
-                let built = self.build().await?;
+                let built = ProgressTracker::leaf("build", self.build()).await?;
 
                 let host = &self.on;
                 let launched = host.provision(resource_result);
@@ -223,8 +222,7 @@ impl Service for HydroflowCrateService {
         }
 
         ProgressTracker::with_group(
-            &self
-                .display_id
+            self.display_id
                 .clone()
                 .unwrap_or_else(|| format!("service/{}", self.id)),
             None,
@@ -259,7 +257,7 @@ impl Service for HydroflowCrateService {
                 binary.stdin().send(format!("{formatted_bind_config}\n"))?;
 
                 let ready_line = ProgressTracker::leaf(
-                    "waiting for ready".to_string(),
+                    "waiting for ready",
                     tokio::time::timeout(Duration::from_secs(60), stdout_receiver),
                 )
                 .await??;
@@ -317,8 +315,7 @@ impl Service for HydroflowCrateService {
 
     async fn stop(&mut self) -> Result<()> {
         ProgressTracker::with_group(
-            &self
-                .display_id
+            self.display_id
                 .clone()
                 .unwrap_or_else(|| format!("service/{}", self.id)),
             None,
@@ -327,7 +324,7 @@ impl Service for HydroflowCrateService {
                 launched_binary.stdin().send("stop\n".to_string())?;
 
                 let timeout_result = ProgressTracker::leaf(
-                    "waiting for exit".to_owned(),
+                    "waiting for exit",
                     tokio::time::timeout(Duration::from_secs(60), launched_binary.wait()),
                 )
                 .await;

--- a/hydro_deploy/core/src/ssh.rs
+++ b/hydro_deploy/core/src/ssh.rs
@@ -96,7 +96,7 @@ impl LaunchedBinary for LaunchedSshBinary {
 
     async fn stop(&mut self) -> Result<()> {
         if !self.channel.eof() {
-            ProgressTracker::leaf("force stopping".to_owned(), async {
+            ProgressTracker::leaf("force stopping", async {
                 self.channel.write_all(b"\x03").await?; // `^C`
                 self.channel.send_eof().await?;
                 self.channel.wait_eof().await?;
@@ -112,7 +112,7 @@ impl LaunchedBinary for LaunchedSshBinary {
             let mut script_channel = self.session.as_ref().unwrap().channel_session().await?;
             let mut fold_er = Folder::from(perf.fold_options.clone().unwrap_or_default());
 
-            let fold_data = ProgressTracker::leaf("perf script & folding".to_owned(), async move {
+            let fold_data = ProgressTracker::leaf("perf script & folding", async move {
                 let mut stderr_lines = FuturesBufReader::new(script_channel.stderr()).lines();
                 let stdout = script_channel.stream(0);
 
@@ -358,7 +358,7 @@ impl<T: LaunchedSshHost> LaunchedHost for T {
             let temp_path = PathBuf::from(format!("/home/{user}/hydro-{random}"));
             let sftp = &sftp;
 
-            ProgressTracker::rich_leaf(
+            ProgressTracker::progress_leaf(
                 format!("uploading binary to {}", binary_path.display()),
                 |set_progress, _| {
                     let binary = &binary;

--- a/hydro_deploy/core/src/terraform.rs
+++ b/hydro_deploy/core/src/terraform.rs
@@ -119,7 +119,7 @@ impl TerraformBatch {
             });
         }
 
-        ProgressTracker::with_group("terraform", None, || async {
+        ProgressTracker::with_group("terraform", Some(1), || async {
             let dothydro_folder = std::env::current_dir().unwrap().join(".hydro");
             std::fs::create_dir_all(&dothydro_folder).unwrap();
             let deployment_folder = tempfile::tempdir_in(dothydro_folder).unwrap();


### PR DESCRIPTION

Now, when a group only has a single active task, we skip printing a line for the group itself and instead collapse its information into the line for the inner task (recursively as necessary). This allows us to show more fine grained progress without overflowing the console.
