### PR TITLE
fix(hydro_deploy): only record usermode events in perf

### DIFF
--- a/hydro_deploy/core/src/localhost/mod.rs
+++ b/hydro_deploy/core/src/localhost/mod.rs
@@ -229,8 +229,10 @@ impl LaunchedHost for LaunchedLocalhost {
                         "record",
                         "-F",
                         &tracing.frequency.to_string(),
+                        "-e",
+                        "cycles:u",
                         "--call-graph",
-                        "dwarf,64000",
+                        "dwarf,65528",
                         "-o",
                     ])
                     .arg(perf_outfile)

--- a/hydro_deploy/core/src/ssh.rs
+++ b/hydro_deploy/core/src/ssh.rs
@@ -380,7 +380,7 @@ impl<T: LaunchedSshHost> LaunchedHost for T {
                 if let Some(TracingOptions { frequency, .. }) = tracing.clone() {
                     // Attach perf to the command
                     command = format!(
-                        "perf record -F {frequency} --call-graph dwarf,64000 -o {PERF_OUTFILE} {command}",
+                        "perf record -F {frequency} -e cycles:u --call-graph dwarf,65528 -o {PERF_OUTFILE} {command}",
                     );
                 }
                 channel.exec(&command).await?;

--- a/hydroflow_plus_test/examples/perf_compute_pi.rs
+++ b/hydroflow_plus_test/examples/perf_compute_pi.rs
@@ -62,7 +62,7 @@ async fn main() {
                         .dtrace_outfile("leader.stacks")
                         .fold_outfile("leader.data.folded")
                         .flamegraph_outfile("leader.svg")
-                        .frequency(5)
+                        .frequency(128)
                         .build(),
                 ),
         )
@@ -78,7 +78,7 @@ async fn main() {
                                 .dtrace_outfile(format!("cluster{}.leader.stacks", idx))
                                 .fold_outfile(format!("cluster{}.data.folded", idx))
                                 .flamegraph_outfile(format!("cluster{}.svg", idx))
-                                .frequency(5)
+                                .frequency(128)
                                 .build(),
                         )
                 })


### PR DESCRIPTION

When kernel stacks are included, the DWARF traces can become corrupted / overflown leading to flamegraphs with broken parents. We only are interested in usermode, anyways, and can measure I/O overhead through other methods.
