### PR TITLE
feat(hydroflow_plus): add API for external network inputs

### DIFF
--- a/hydro_deploy/core/src/deployment.rs
+++ b/hydro_deploy/core/src/deployment.rs
@@ -69,9 +69,27 @@ impl Deployment {
         Ok(())
     }
 
+    /// Runs `start()`, waits for the trigger future, then runs `stop()`.
+    /// This is useful if you need to initiate external network connections between
+    /// `deploy()` and `start()`.
+    pub async fn start_until(&mut self, trigger: impl Future<Output = ()>) -> Result<()> {
+        // TODO(mingwei): should `trigger` interrupt `deploy()` and `start()`? If so make sure shutdown works as expected.
+        self.start().await?;
+        trigger.await;
+        self.stop().await?;
+        Ok(())
+    }
+
     /// Runs `deploy()`, and `start()`, waits for CTRL+C, then runs `stop()`.
     pub async fn run_ctrl_c(&mut self) -> Result<()> {
         self.run_until(tokio::signal::ctrl_c().map(|_| ())).await
+    }
+
+    /// Runs `start()`, waits for CTRL+C, then runs `stop()`.
+    /// This is useful if you need to initiate external network connections between
+    /// `deploy()` and `start()`.
+    pub async fn start_ctrl_c(&mut self) -> Result<()> {
+        self.start_until(tokio::signal::ctrl_c().map(|_| ())).await
     }
 
     pub async fn deploy(&mut self) -> Result<()> {

--- a/hydro_deploy/hydroflow_plus_deploy/src/deploy_runtime.rs
+++ b/hydro_deploy/hydroflow_plus_deploy/src/deploy_runtime.rs
@@ -120,3 +120,16 @@ pub fn deploy_m2m(
         },
     )
 }
+
+pub fn deploy_e2o(
+    env: RuntimeData<&DeployPorts<HydroflowPlusMeta>>,
+    c1_port: &str,
+    p2_port: &str,
+) -> syn::Expr {
+    q!({
+        env.port(p2_port)
+            .connect_local_blocking::<ConnectedDirect>()
+            .into_source()
+    })
+    .splice_untyped()
+}

--- a/hydro_deploy/hydroflow_plus_deploy/src/trybuild.rs
+++ b/hydro_deploy/hydroflow_plus_deploy/src/trybuild.rs
@@ -17,6 +17,7 @@ pub fn compile_graph_trybuild(graph: HydroflowGraph, extra_stmts: Vec<syn::Stmt>
 
     let source_ast: syn::File = syn::parse_quote! {
         #![allow(unused_crate_dependencies, missing_docs)]
+        use hydroflow_plus::*;
 
         #[allow(unused)]
         fn __hfplus_runtime<'a>(__hydroflow_plus_trybuild_cli: &'a hydroflow_plus::util::deploy::DeployPorts<hydroflow_plus_deploy::HydroflowPlusMeta>) -> hydroflow_plus::Hydroflow<'a> {

--- a/hydroflow_plus/src/builder/built.rs
+++ b/hydroflow_plus/src/builder/built.rs
@@ -4,9 +4,9 @@ use std::marker::PhantomData;
 use hydroflow_lang::graph::{eliminate_extra_unions_tees, HydroflowGraph};
 
 use super::deploy::{DeployFlow, DeployResult};
-use crate::deploy::{ClusterSpec, Deploy, LocalDeploy, ProcessSpec};
+use crate::deploy::{ClusterSpec, Deploy, ExternalSpec, LocalDeploy, ProcessSpec};
 use crate::ir::HfPlusLeaf;
-use crate::location::{Cluster, Process};
+use crate::location::{Cluster, ExternalProcess, Process};
 use crate::HfCompiled;
 
 pub struct BuiltFlow<'a> {
@@ -103,6 +103,7 @@ impl<'a> BuiltFlow<'a> {
             ir: std::mem::take(&mut self.ir),
             nodes: processes,
             clusters,
+            externals: HashMap::new(),
             used: false,
             _phantom: PhantomData,
         }
@@ -114,6 +115,14 @@ impl<'a> BuiltFlow<'a> {
         spec: impl ProcessSpec<'a, D>,
     ) -> DeployFlow<'a, D> {
         self.into_deploy().with_process(process, spec)
+    }
+
+    pub fn with_external<P, D: LocalDeploy<'a>>(
+        self,
+        process: &ExternalProcess<P>,
+        spec: impl ExternalSpec<'a, D>,
+    ) -> DeployFlow<'a, D> {
+        self.into_deploy().with_external(process, spec)
     }
 
     pub fn with_cluster<C, D: LocalDeploy<'a>>(

--- a/hydroflow_plus/src/builder/deploy.rs
+++ b/hydroflow_plus/src/builder/deploy.rs
@@ -1,18 +1,27 @@
 use std::collections::{BTreeMap, HashMap};
+use std::io::Error;
 use std::marker::PhantomData;
+use std::pin::Pin;
 
+use hydroflow::bytes::Bytes;
+use hydroflow::futures::Sink;
 use proc_macro2::Span;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use stageleft::Quoted;
 
 use super::built::build_inner;
-use crate::deploy::{LocalDeploy, Node};
+use crate::deploy::{ExternalSpec, LocalDeploy, Node, RegisterPort};
 use crate::ir::HfPlusLeaf;
-use crate::location::{Location, LocationId};
+use crate::location::{
+    ExternalBincodePort, ExternalBytesPort, ExternalProcess, Location, LocationId,
+};
 use crate::{Cluster, ClusterSpec, Deploy, HfCompiled, Process, ProcessSpec};
 
 pub struct DeployFlow<'a, D: LocalDeploy<'a>> {
     pub(super) ir: Vec<HfPlusLeaf<'a>>,
     pub(super) nodes: HashMap<usize, D::Process>,
+    pub(super) externals: HashMap<usize, D::ExternalProcess>,
     pub(super) clusters: HashMap<usize, D::Cluster>,
     pub(super) used: bool,
 
@@ -35,6 +44,17 @@ impl<'a, D: LocalDeploy<'a>> DeployFlow<'a, D> {
         self
     }
 
+    pub fn with_external<P>(
+        mut self,
+        process: &ExternalProcess<P>,
+        spec: impl ExternalSpec<'a, D>,
+    ) -> Self {
+        let tag_name = std::any::type_name::<P>().to_string();
+        self.externals
+            .insert(process.id, spec.build(process.id, &tag_name));
+        self
+    }
+
     pub fn with_cluster<C>(mut self, cluster: &Cluster<C>, spec: impl ClusterSpec<'a, D>) -> Self {
         let tag_name = std::any::type_name::<C>().to_string();
         self.clusters
@@ -50,7 +70,15 @@ impl<'a, D: Deploy<'a>> DeployFlow<'a, D> {
         let mut seen_tees: HashMap<_, _> = HashMap::new();
         let mut ir_leaves_networked: Vec<HfPlusLeaf> = std::mem::take(&mut self.ir)
             .into_iter()
-            .map(|leaf| leaf.compile_network::<D>(env, &mut seen_tees, &self.nodes, &self.clusters))
+            .map(|leaf| {
+                leaf.compile_network::<D>(
+                    env,
+                    &mut seen_tees,
+                    &self.nodes,
+                    &self.clusters,
+                    &self.externals,
+                )
+            })
             .collect();
 
         let extra_stmts = self.extra_stmts(env);
@@ -111,6 +139,7 @@ impl<'a, D: Deploy<'a, CompileEnv = ()>> DeployFlow<'a, D> {
                     &mut seen_tees_instantiate,
                     &self.nodes,
                     &self.clusters,
+                    &self.externals,
                 )
             })
             .collect();
@@ -119,7 +148,7 @@ impl<'a, D: Deploy<'a, CompileEnv = ()>> DeployFlow<'a, D> {
         let mut extra_stmts = self.extra_stmts(&());
         let mut meta = D::Meta::default();
 
-        let (mut processes, mut clusters) = (
+        let (mut processes, mut clusters, mut externals) = (
             std::mem::take(&mut self.nodes)
                 .into_iter()
                 .map(|(node_id, node)| {
@@ -144,6 +173,18 @@ impl<'a, D: Deploy<'a, CompileEnv = ()>> DeployFlow<'a, D> {
                     (cluster_id, cluster)
                 })
                 .collect::<HashMap<_, _>>(),
+            std::mem::take(&mut self.externals)
+                .into_iter()
+                .map(|(external_id, external)| {
+                    external.instantiate(
+                        env,
+                        &mut meta,
+                        compiled.remove(&external_id).unwrap(),
+                        extra_stmts.remove(&external_id).unwrap_or_default(),
+                    );
+                    (external_id, external)
+                })
+                .collect::<HashMap<_, _>>(),
         );
 
         for node in processes.values_mut() {
@@ -154,6 +195,10 @@ impl<'a, D: Deploy<'a, CompileEnv = ()>> DeployFlow<'a, D> {
             cluster.update_meta(&meta);
         }
 
+        for external in externals.values_mut() {
+            external.update_meta(&meta);
+        }
+
         let mut seen_tees_connect = HashMap::new();
         for leaf in ir_leaves_networked {
             leaf.connect_network(&mut seen_tees_connect);
@@ -162,6 +207,7 @@ impl<'a, D: Deploy<'a, CompileEnv = ()>> DeployFlow<'a, D> {
         DeployResult {
             processes,
             clusters,
+            externals,
         }
     }
 }
@@ -169,13 +215,14 @@ impl<'a, D: Deploy<'a, CompileEnv = ()>> DeployFlow<'a, D> {
 pub struct DeployResult<'a, D: Deploy<'a>> {
     processes: HashMap<usize, D::Process>,
     clusters: HashMap<usize, D::Cluster>,
+    externals: HashMap<usize, D::ExternalProcess>,
 }
 
 impl<'a, D: Deploy<'a>> DeployResult<'a, D> {
     pub fn get_process<P>(&self, p: &Process<P>) -> &D::Process {
         let id = match p.id() {
             LocationId::Process(id) => id,
-            LocationId::Cluster(id) => id,
+            _ => panic!("Process ID expected"),
         };
 
         self.processes.get(&id).unwrap()
@@ -183,10 +230,43 @@ impl<'a, D: Deploy<'a>> DeployResult<'a, D> {
 
     pub fn get_cluster<C>(&self, c: &Cluster<C>) -> &D::Cluster {
         let id = match c.id() {
-            LocationId::Process(id) => id,
             LocationId::Cluster(id) => id,
+            _ => panic!("Cluster ID expected"),
         };
 
         self.clusters.get(&id).unwrap()
+    }
+
+    pub fn get_external<P>(&self, p: &ExternalProcess<P>) -> &D::ExternalProcess {
+        self.externals.get(&p.id).unwrap()
+    }
+
+    pub fn raw_port(&self, port: ExternalBytesPort) -> D::ExternalRawPort {
+        self.externals
+            .get(&port.process_id)
+            .unwrap()
+            .raw_port(port.port_id)
+    }
+
+    pub async fn connect_sink_bytes(
+        &self,
+        port: ExternalBytesPort,
+    ) -> Pin<Box<dyn Sink<Bytes, Error = Error>>> {
+        self.externals
+            .get(&port.process_id)
+            .unwrap()
+            .as_bytes_sink(port.port_id)
+            .await
+    }
+
+    pub async fn connect_sink_bincode<T: Serialize + DeserializeOwned + 'static>(
+        &self,
+        port: ExternalBincodePort<T>,
+    ) -> Pin<Box<dyn Sink<T, Error = Error>>> {
+        self.externals
+            .get(&port.process_id)
+            .unwrap()
+            .as_bincode_sink(port.port_id)
+            .await
     }
 }

--- a/hydroflow_plus/src/deploy/graphs.rs
+++ b/hydroflow_plus/src/deploy/graphs.rs
@@ -7,6 +7,7 @@ pub struct SingleProcessGraph {}
 impl<'a> LocalDeploy<'a> for SingleProcessGraph {
     type Process = SingleNode;
     type Cluster = SingleNode;
+    type ExternalProcess = SingleNode;
     type Meta = ();
     type GraphId = ();
 
@@ -58,6 +59,7 @@ pub struct MultiGraph {}
 impl<'a> LocalDeploy<'a> for MultiGraph {
     type Process = MultiNode;
     type Cluster = MultiNode;
+    type ExternalProcess = MultiNode;
     type Meta = ();
     type GraphId = usize;
 

--- a/hydroflow_plus/src/ir.rs
+++ b/hydroflow_plus/src/ir.rs
@@ -10,7 +10,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
 use syn::parse_quote;
 
-use crate::deploy::Deploy;
+use crate::deploy::{Deploy, RegisterPort};
 use crate::location::LocationId;
 
 #[derive(Clone)]
@@ -66,6 +66,7 @@ impl std::fmt::Debug for DebugPipelineFn {
 #[derive(Debug)]
 pub enum HfPlusSource {
     Stream(DebugExpr),
+    ExternalNetwork(),
     Iter(DebugExpr),
     Interval(DebugExpr),
     Spin(),
@@ -98,10 +99,11 @@ impl<'a> HfPlusLeaf<'a> {
         seen_tees: &mut SeenTees<'a>,
         nodes: &HashMap<usize, D::Process>,
         clusters: &HashMap<usize, D::Cluster>,
+        externals: &HashMap<usize, D::ExternalProcess>,
     ) -> HfPlusLeaf<'a> {
         self.transform_children(
             |n, s| {
-                n.compile_network::<D>(compile_env, s, nodes, clusters);
+                n.compile_network::<D>(compile_env, s, nodes, clusters, externals);
             },
             seen_tees,
         )
@@ -187,6 +189,7 @@ impl<'a> HfPlusLeaf<'a> {
                 let location_id = match location_kind {
                     LocationId::Process(id) => id,
                     LocationId::Cluster(id) => id,
+                    LocationId::ExternalProcess(_) => panic!(),
                 };
 
                 assert_eq!(
@@ -285,7 +288,9 @@ pub enum HfPlusNode<'a> {
 
     Network {
         from_location: LocationId,
+        from_key: Option<usize>,
         to_location: LocationId,
+        to_key: Option<usize>,
         serialize_pipeline: Option<Pipeline>,
         instantiate_fn: DebugInstantiate<'a>,
         deserialize_pipeline: Option<Pipeline>,
@@ -302,170 +307,33 @@ impl<'a> HfPlusNode<'a> {
         seen_tees: &mut SeenTees<'a>,
         nodes: &HashMap<usize, D::Process>,
         clusters: &HashMap<usize, D::Cluster>,
+        externals: &HashMap<usize, D::ExternalProcess>,
     ) {
         self.transform_children(
-            |n, s| n.compile_network::<D>(compile_env, s, nodes, clusters),
+            |n, s| n.compile_network::<D>(compile_env, s, nodes, clusters, externals),
             seen_tees,
         );
 
         if let HfPlusNode::Network {
             from_location,
+            from_key,
             to_location,
+            to_key,
             instantiate_fn,
             ..
         } = self
         {
             let (sink_expr, source_expr, connect_fn) = match instantiate_fn {
-                DebugInstantiate::Building() => {
-                    let ((sink, source), connect_fn) = match (from_location, to_location) {
-                        (LocationId::Process(from), LocationId::Process(to)) => {
-                            let from_node = nodes
-                                .get(from)
-                                .unwrap_or_else(|| {
-                                    panic!(
-                                        "A location used in the graph was not instantiated: {}",
-                                        from
-                                    )
-                                })
-                                .clone();
-                            let to_node = nodes
-                                .get(to)
-                                .unwrap_or_else(|| {
-                                    panic!(
-                                        "A location used in the graph was not instantiated: {}",
-                                        to
-                                    )
-                                })
-                                .clone();
-
-                            let sink_port = D::allocate_process_port(&from_node);
-                            let source_port = D::allocate_process_port(&to_node);
-
-                            (
-                                D::o2o_sink_source(
-                                    compile_env,
-                                    &from_node,
-                                    &sink_port,
-                                    &to_node,
-                                    &source_port,
-                                ),
-                                Box::new(move || {
-                                    D::o2o_connect(&from_node, &sink_port, &to_node, &source_port)
-                                }) as Box<dyn Fn() + 'a>,
-                            )
-                        }
-                        (LocationId::Process(from), LocationId::Cluster(to)) => {
-                            let from_node = nodes
-                                .get(from)
-                                .unwrap_or_else(|| {
-                                    panic!(
-                                        "A location used in the graph was not instantiated: {}",
-                                        from
-                                    )
-                                })
-                                .clone();
-                            let to_node = clusters
-                                .get(to)
-                                .unwrap_or_else(|| {
-                                    panic!(
-                                        "A location used in the graph was not instantiated: {}",
-                                        to
-                                    )
-                                })
-                                .clone();
-
-                            let sink_port = D::allocate_process_port(&from_node);
-                            let source_port = D::allocate_cluster_port(&to_node);
-
-                            (
-                                D::o2m_sink_source(
-                                    compile_env,
-                                    &from_node,
-                                    &sink_port,
-                                    &to_node,
-                                    &source_port,
-                                ),
-                                Box::new(move || {
-                                    D::o2m_connect(&from_node, &sink_port, &to_node, &source_port)
-                                }) as Box<dyn Fn() + 'a>,
-                            )
-                        }
-                        (LocationId::Cluster(from), LocationId::Process(to)) => {
-                            let from_node = clusters
-                                .get(from)
-                                .unwrap_or_else(|| {
-                                    panic!(
-                                        "A location used in the graph was not instantiated: {}",
-                                        from
-                                    )
-                                })
-                                .clone();
-                            let to_node = nodes
-                                .get(to)
-                                .unwrap_or_else(|| {
-                                    panic!(
-                                        "A location used in the graph was not instantiated: {}",
-                                        to
-                                    )
-                                })
-                                .clone();
-
-                            let sink_port = D::allocate_cluster_port(&from_node);
-                            let source_port = D::allocate_process_port(&to_node);
-
-                            (
-                                D::m2o_sink_source(
-                                    compile_env,
-                                    &from_node,
-                                    &sink_port,
-                                    &to_node,
-                                    &source_port,
-                                ),
-                                Box::new(move || {
-                                    D::m2o_connect(&from_node, &sink_port, &to_node, &source_port)
-                                }) as Box<dyn Fn() + 'a>,
-                            )
-                        }
-                        (LocationId::Cluster(from), LocationId::Cluster(to)) => {
-                            let from_node = clusters
-                                .get(from)
-                                .unwrap_or_else(|| {
-                                    panic!(
-                                        "A location used in the graph was not instantiated: {}",
-                                        from
-                                    )
-                                })
-                                .clone();
-                            let to_node = clusters
-                                .get(to)
-                                .unwrap_or_else(|| {
-                                    panic!(
-                                        "A location used in the graph was not instantiated: {}",
-                                        to
-                                    )
-                                })
-                                .clone();
-
-                            let sink_port = D::allocate_cluster_port(&from_node);
-                            let source_port = D::allocate_cluster_port(&to_node);
-
-                            (
-                                D::m2m_sink_source(
-                                    compile_env,
-                                    &from_node,
-                                    &sink_port,
-                                    &to_node,
-                                    &source_port,
-                                ),
-                                Box::new(move || {
-                                    D::m2m_connect(&from_node, &sink_port, &to_node, &source_port)
-                                }) as Box<dyn Fn() + 'a>,
-                            )
-                        }
-                    };
-
-                    (sink, source, connect_fn)
-                }
+                DebugInstantiate::Building() => instantiate_network::<D>(
+                    from_location,
+                    *from_key,
+                    to_location,
+                    *to_key,
+                    nodes,
+                    clusters,
+                    externals,
+                    compile_env,
+                ),
 
                 DebugInstantiate::Finalized(_, _, _) => panic!("network already finalized"),
             };
@@ -662,49 +530,58 @@ impl<'a> HfPlusNode<'a> {
                 source,
                 location_kind,
             } => {
-                let source_id = *next_stmt_id;
-                *next_stmt_id += 1;
-
-                let source_ident =
-                    syn::Ident::new(&format!("stream_{}", source_id), Span::call_site());
-
-                let source_stmt = match source {
-                    HfPlusSource::Stream(expr) => {
-                        parse_quote! {
-                            #source_ident = source_stream(#expr);
-                        }
-                    }
-
-                    HfPlusSource::Iter(expr) => {
-                        parse_quote! {
-                            #source_ident = source_iter(#expr);
-                        }
-                    }
-
-                    HfPlusSource::Interval(expr) => {
-                        parse_quote! {
-                            #source_ident = source_interval(#expr);
-                        }
-                    }
-
-                    HfPlusSource::Spin() => {
-                        parse_quote! {
-                            #source_ident = spin();
-                        }
-                    }
-                };
-
                 let location_id = match location_kind {
                     LocationId::Process(id) => id,
                     LocationId::Cluster(id) => id,
+                    LocationId::ExternalProcess(id) => id,
                 };
 
-                graph_builders
-                    .entry(*location_id)
-                    .or_default()
-                    .add_statement(source_stmt);
+                if let HfPlusSource::ExternalNetwork() = source {
+                    (syn::Ident::new("DUMMY", Span::call_site()), *location_id)
+                } else {
+                    let source_id = *next_stmt_id;
+                    *next_stmt_id += 1;
 
-                (source_ident, *location_id)
+                    let source_ident =
+                        syn::Ident::new(&format!("stream_{}", source_id), Span::call_site());
+
+                    let source_stmt = match source {
+                        HfPlusSource::Stream(expr) => {
+                            parse_quote! {
+                                #source_ident = source_stream(#expr);
+                            }
+                        }
+
+                        HfPlusSource::ExternalNetwork() => {
+                            unreachable!()
+                        }
+
+                        HfPlusSource::Iter(expr) => {
+                            parse_quote! {
+                                #source_ident = source_iter(#expr);
+                            }
+                        }
+
+                        HfPlusSource::Interval(expr) => {
+                            parse_quote! {
+                                #source_ident = source_interval(#expr);
+                            }
+                        }
+
+                        HfPlusSource::Spin() => {
+                            parse_quote! {
+                                #source_ident = spin();
+                            }
+                        }
+                    };
+
+                    graph_builders
+                        .entry(*location_id)
+                        .or_default()
+                        .add_statement(source_stmt);
+
+                    (source_ident, *location_id)
+                }
             }
 
             HfPlusNode::CycleSource {
@@ -714,6 +591,7 @@ impl<'a> HfPlusNode<'a> {
                 let location_id = match location_kind {
                     LocationId::Process(id) => id,
                     LocationId::Cluster(id) => id,
+                    LocationId::ExternalProcess(_) => panic!(),
                 };
 
                 (ident.clone(), *location_id)
@@ -1198,7 +1076,9 @@ impl<'a> HfPlusNode<'a> {
 
             HfPlusNode::Network {
                 from_location: _,
+                from_key: _,
                 to_location,
+                to_key: _,
                 serialize_pipeline,
                 instantiate_fn,
                 deserialize_pipeline,
@@ -1232,6 +1112,7 @@ impl<'a> HfPlusNode<'a> {
                 let to_id = match to_location {
                     LocationId::Process(id) => id,
                     LocationId::Cluster(id) => id,
+                    LocationId::ExternalProcess(_) => panic!(),
                 };
 
                 let receiver_builder = graph_builders.entry(*to_id).or_default();
@@ -1255,4 +1136,156 @@ impl<'a> HfPlusNode<'a> {
             }
         }
     }
+}
+
+#[expect(clippy::too_many_arguments, reason = "networking internals")]
+fn instantiate_network<'a, D: Deploy<'a> + 'a>(
+    from_location: &mut LocationId,
+    from_key: Option<usize>,
+    to_location: &mut LocationId,
+    _to_key: Option<usize>,
+    nodes: &HashMap<usize, D::Process>,
+    clusters: &HashMap<usize, D::Cluster>,
+    externals: &HashMap<usize, D::ExternalProcess>,
+    compile_env: &D::CompileEnv,
+) -> (syn::Expr, syn::Expr, Box<dyn Fn() + 'a>) {
+    let ((sink, source), connect_fn) = match (from_location, to_location) {
+        (LocationId::Process(from), LocationId::Process(to)) => {
+            let from_node = nodes
+                .get(from)
+                .unwrap_or_else(|| {
+                    panic!("A process used in the graph was not instantiated: {}", from)
+                })
+                .clone();
+            let to_node = nodes
+                .get(to)
+                .unwrap_or_else(|| {
+                    panic!("A process used in the graph was not instantiated: {}", to)
+                })
+                .clone();
+
+            let sink_port = D::allocate_process_port(&from_node);
+            let source_port = D::allocate_process_port(&to_node);
+
+            (
+                D::o2o_sink_source(compile_env, &from_node, &sink_port, &to_node, &source_port),
+                Box::new(move || D::o2o_connect(&from_node, &sink_port, &to_node, &source_port))
+                    as Box<dyn Fn() + 'a>,
+            )
+        }
+        (LocationId::Process(from), LocationId::Cluster(to)) => {
+            let from_node = nodes
+                .get(from)
+                .unwrap_or_else(|| {
+                    panic!("A process used in the graph was not instantiated: {}", from)
+                })
+                .clone();
+            let to_node = clusters
+                .get(to)
+                .unwrap_or_else(|| {
+                    panic!("A cluster used in the graph was not instantiated: {}", to)
+                })
+                .clone();
+
+            let sink_port = D::allocate_process_port(&from_node);
+            let source_port = D::allocate_cluster_port(&to_node);
+
+            (
+                D::o2m_sink_source(compile_env, &from_node, &sink_port, &to_node, &source_port),
+                Box::new(move || D::o2m_connect(&from_node, &sink_port, &to_node, &source_port))
+                    as Box<dyn Fn() + 'a>,
+            )
+        }
+        (LocationId::Cluster(from), LocationId::Process(to)) => {
+            let from_node = clusters
+                .get(from)
+                .unwrap_or_else(|| {
+                    panic!("A cluster used in the graph was not instantiated: {}", from)
+                })
+                .clone();
+            let to_node = nodes
+                .get(to)
+                .unwrap_or_else(|| {
+                    panic!("A process used in the graph was not instantiated: {}", to)
+                })
+                .clone();
+
+            let sink_port = D::allocate_cluster_port(&from_node);
+            let source_port = D::allocate_process_port(&to_node);
+
+            (
+                D::m2o_sink_source(compile_env, &from_node, &sink_port, &to_node, &source_port),
+                Box::new(move || D::m2o_connect(&from_node, &sink_port, &to_node, &source_port))
+                    as Box<dyn Fn() + 'a>,
+            )
+        }
+        (LocationId::Cluster(from), LocationId::Cluster(to)) => {
+            let from_node = clusters
+                .get(from)
+                .unwrap_or_else(|| {
+                    panic!("A cluster used in the graph was not instantiated: {}", from)
+                })
+                .clone();
+            let to_node = clusters
+                .get(to)
+                .unwrap_or_else(|| {
+                    panic!("A cluster used in the graph was not instantiated: {}", to)
+                })
+                .clone();
+
+            let sink_port = D::allocate_cluster_port(&from_node);
+            let source_port = D::allocate_cluster_port(&to_node);
+
+            (
+                D::m2m_sink_source(compile_env, &from_node, &sink_port, &to_node, &source_port),
+                Box::new(move || D::m2m_connect(&from_node, &sink_port, &to_node, &source_port))
+                    as Box<dyn Fn() + 'a>,
+            )
+        }
+        (LocationId::ExternalProcess(from), LocationId::Process(to)) => {
+            let from_node = externals
+                .get(from)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "A external used in the graph was not instantiated: {}",
+                        from
+                    )
+                })
+                .clone();
+
+            let to_node = nodes
+                .get(to)
+                .unwrap_or_else(|| {
+                    panic!("A process used in the graph was not instantiated: {}", to)
+                })
+                .clone();
+
+            let sink_port = D::allocate_external_port(&from_node);
+            let source_port = D::allocate_process_port(&to_node);
+
+            from_node.register(from_key.unwrap(), sink_port.clone());
+
+            (
+                (
+                    parse_quote!(DUMMY),
+                    D::e2o_source(compile_env, &from_node, &sink_port, &to_node, &source_port),
+                ),
+                Box::new(move || D::e2o_connect(&from_node, &sink_port, &to_node, &source_port))
+                    as Box<dyn Fn() + 'a>,
+            )
+        }
+        (LocationId::ExternalProcess(_from), LocationId::Cluster(_to)) => {
+            todo!("NYI")
+        }
+        (LocationId::ExternalProcess(_), LocationId::ExternalProcess(_)) => {
+            panic!("Cannot send from external to external")
+        }
+        (LocationId::Process(_from), LocationId::ExternalProcess(_to)) => {
+            todo!("NYI")
+        }
+        (LocationId::Cluster(_from), LocationId::ExternalProcess(_to)) => {
+            todo!("NYI")
+        }
+    };
+    (sink, source, connect_fn)
 }

--- a/hydroflow_plus/src/location.rs
+++ b/hydroflow_plus/src/location.rs
@@ -1,13 +1,42 @@
 use std::marker::PhantomData;
 
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum LocationId {
     Process(usize),
     Cluster(usize),
+    ExternalProcess(usize),
 }
 
 pub trait Location {
     fn id(&self) -> LocationId;
+}
+
+pub struct ExternalBytesPort {
+    pub(crate) process_id: usize,
+    pub(crate) port_id: usize,
+}
+
+pub struct ExternalBincodePort<T: Serialize + DeserializeOwned> {
+    pub(crate) process_id: usize,
+    pub(crate) port_id: usize,
+    pub(crate) _phantom: PhantomData<T>,
+}
+
+pub struct ExternalProcess<P> {
+    pub(crate) id: usize,
+    pub(crate) _phantom: PhantomData<P>,
+}
+
+impl<P> Clone for ExternalProcess<P> {
+    fn clone(&self) -> Self {
+        ExternalProcess {
+            id: self.id,
+            _phantom: PhantomData,
+        }
+    }
 }
 
 pub struct Process<P> {

--- a/hydroflow_plus/src/persist_pullup.rs
+++ b/hydroflow_plus/src/persist_pullup.rs
@@ -114,7 +114,9 @@ fn persist_pullup_node<'a>(
         } => {
             if let HfPlusNode::Network {
                 from_location,
+                from_key,
                 to_location,
+                to_key,
                 serialize_pipeline,
                 instantiate_fn,
                 deserialize_pipeline,
@@ -123,7 +125,9 @@ fn persist_pullup_node<'a>(
             {
                 *node = HfPlusNode::Persist(Box::new(HfPlusNode::Network {
                     from_location,
+                    from_key,
                     to_location,
+                    to_key,
                     serialize_pipeline,
                     instantiate_fn,
                     deserialize_pipeline,

--- a/hydroflow_plus/src/stream.rs
+++ b/hydroflow_plus/src/stream.rs
@@ -675,7 +675,7 @@ fn serialize_bincode<T: Serialize>(is_demux: bool) -> Pipeline {
     }
 }
 
-fn deserialize_bincode<T: DeserializeOwned>(tagged: bool) -> Pipeline {
+pub(super) fn deserialize_bincode<T: DeserializeOwned>(tagged: bool) -> Pipeline {
     let root = get_this_crate();
 
     let t_type: syn::Type = stageleft::quote_type::<T>();
@@ -714,7 +714,9 @@ impl<'a, T, W, N: Location> Stream<'a, T, W, NoTick, N> {
             self.ir_leaves,
             HfPlusNode::Network {
                 from_location: self.location_kind,
+                from_key: None,
                 to_location: other.id(),
+                to_key: None,
                 serialize_pipeline,
                 instantiate_fn: DebugInstantiate::Building(),
                 deserialize_pipeline,
@@ -735,7 +737,9 @@ impl<'a, T, W, N: Location> Stream<'a, T, W, NoTick, N> {
             self.ir_leaves,
             HfPlusNode::Network {
                 from_location: self.location_kind,
+                from_key: None,
                 to_location: other.id(),
+                to_key: None,
                 serialize_pipeline: None,
                 instantiate_fn: DebugInstantiate::Building(),
                 deserialize_pipeline: if N::is_tagged() {

--- a/hydroflow_plus_test/src/cluster/snapshots/hydroflow_plus_test__cluster__compute_pi__tests__compute_pi_ir.snap
+++ b/hydroflow_plus_test/src/cluster/snapshots/hydroflow_plus_test__cluster__compute_pi__tests__compute_pi_ir.snap
@@ -17,9 +17,11 @@ expression: built.ir()
                                 from_location: Cluster(
                                     0,
                                 ),
+                                from_key: None,
                                 to_location: Process(
                                     1,
                                 ),
+                                to_key: None,
                                 serialize_pipeline: Some(
                                     Operator(
                                         Operator {

--- a/hydroflow_plus_test/src/cluster/snapshots/hydroflow_plus_test__cluster__many_to_many__tests__many_to_many.snap
+++ b/hydroflow_plus_test/src/cluster/snapshots/hydroflow_plus_test__cluster__many_to_many__tests__many_to_many.snap
@@ -9,9 +9,11 @@ expression: built.ir()
             from_location: Cluster(
                 0,
             ),
+            from_key: None,
             to_location: Cluster(
                 0,
             ),
+            to_key: None,
             serialize_pipeline: Some(
                 Operator(
                     Operator {

--- a/hydroflow_plus_test/src/cluster/snapshots/hydroflow_plus_test__cluster__map_reduce__tests__map_reduce_ir.snap
+++ b/hydroflow_plus_test/src/cluster/snapshots/hydroflow_plus_test__cluster__map_reduce__tests__map_reduce_ir.snap
@@ -14,9 +14,11 @@ expression: built.ir()
                         from_location: Cluster(
                             1,
                         ),
+                        from_key: None,
                         to_location: Process(
                             0,
                         ),
+                        to_key: None,
                         serialize_pipeline: Some(
                             Operator(
                                 Operator {
@@ -49,9 +51,11 @@ expression: built.ir()
                                         from_location: Process(
                                             0,
                                         ),
+                                        from_key: None,
                                         to_location: Cluster(
                                             1,
                                         ),
+                                        to_key: None,
                                         serialize_pipeline: Some(
                                             Operator(
                                                 Operator {

--- a/hydroflow_plus_test/src/cluster/snapshots/hydroflow_plus_test__cluster__paxos_bench__tests__paxos_ir.snap
+++ b/hydroflow_plus_test/src/cluster/snapshots/hydroflow_plus_test__cluster__paxos_bench__tests__paxos_ir.snap
@@ -366,9 +366,11 @@ expression: built.ir()
                 from_location: Cluster(
                     2,
                 ),
+                from_key: None,
                 to_location: Cluster(
                     2,
                 ),
+                to_key: None,
                 serialize_pipeline: Some(
                     Operator(
                         Operator {
@@ -779,9 +781,11 @@ expression: built.ir()
                                                                                             from_location: Cluster(
                                                                                                 0,
                                                                                             ),
+                                                                                            from_key: None,
                                                                                             to_location: Cluster(
                                                                                                 2,
                                                                                             ),
+                                                                                            to_key: None,
                                                                                             serialize_pipeline: Some(
                                                                                                 Operator(
                                                                                                     Operator {
@@ -837,9 +841,11 @@ expression: built.ir()
                                                                                                             from_location: Cluster(
                                                                                                                 0,
                                                                                                             ),
+                                                                                                            from_key: None,
                                                                                                             to_location: Cluster(
                                                                                                                 2,
                                                                                                             ),
+                                                                                                            to_key: None,
                                                                                                             serialize_pipeline: Some(
                                                                                                                 Operator(
                                                                                                                     Operator {
@@ -938,9 +944,11 @@ expression: built.ir()
                                                                                                 from_location: Cluster(
                                                                                                     0,
                                                                                                 ),
+                                                                                                from_key: None,
                                                                                                 to_location: Cluster(
                                                                                                     2,
                                                                                                 ),
+                                                                                                to_key: None,
                                                                                                 serialize_pipeline: Some(
                                                                                                     Operator(
                                                                                                         Operator {
@@ -1506,9 +1514,11 @@ expression: built.ir()
                                                                                                                     from_location: Cluster(
                                                                                                                         0,
                                                                                                                     ),
+                                                                                                                    from_key: None,
                                                                                                                     to_location: Cluster(
                                                                                                                         2,
                                                                                                                     ),
+                                                                                                                    to_key: None,
                                                                                                                     serialize_pipeline: Some(
                                                                                                                         Operator(
                                                                                                                             Operator {
@@ -1564,9 +1574,11 @@ expression: built.ir()
                                                                                                                                     from_location: Cluster(
                                                                                                                                         0,
                                                                                                                                     ),
+                                                                                                                                    from_key: None,
                                                                                                                                     to_location: Cluster(
                                                                                                                                         2,
                                                                                                                                     ),
+                                                                                                                                    to_key: None,
                                                                                                                                     serialize_pipeline: Some(
                                                                                                                                         Operator(
                                                                                                                                             Operator {
@@ -1665,9 +1677,11 @@ expression: built.ir()
                                                                                                                         from_location: Cluster(
                                                                                                                             0,
                                                                                                                         ),
+                                                                                                                        from_key: None,
                                                                                                                         to_location: Cluster(
                                                                                                                             2,
                                                                                                                         ),
+                                                                                                                        to_key: None,
                                                                                                                         serialize_pipeline: Some(
                                                                                                                             Operator(
                                                                                                                                 Operator {
@@ -2120,9 +2134,11 @@ expression: built.ir()
             from_location: Cluster(
                 3,
             ),
+            from_key: None,
             to_location: Cluster(
                 2,
             ),
+            to_key: None,
             serialize_pipeline: Some(
                 Operator(
                     Operator {
@@ -2158,9 +2174,11 @@ expression: built.ir()
                                             from_location: Cluster(
                                                 2,
                                             ),
+                                            from_key: None,
                                             to_location: Cluster(
                                                 3,
                                             ),
+                                            to_key: None,
                                             serialize_pipeline: Some(
                                                 Operator(
                                                     Operator {
@@ -2475,9 +2493,11 @@ expression: built.ir()
                                                                     from_location: Cluster(
                                                                         2,
                                                                     ),
+                                                                    from_key: None,
                                                                     to_location: Cluster(
                                                                         3,
                                                                     ),
+                                                                    to_key: None,
                                                                     serialize_pipeline: Some(
                                                                         Operator(
                                                                             Operator {
@@ -2807,9 +2827,11 @@ expression: built.ir()
                                                         from_location: Cluster(
                                                             2,
                                                         ),
+                                                        from_key: None,
                                                         to_location: Cluster(
                                                             3,
                                                         ),
+                                                        to_key: None,
                                                         serialize_pipeline: Some(
                                                             Operator(
                                                                 Operator {
@@ -3150,9 +3172,11 @@ expression: built.ir()
                                                                                                         from_location: Cluster(
                                                                                                             0,
                                                                                                         ),
+                                                                                                        from_key: None,
                                                                                                         to_location: Cluster(
                                                                                                             2,
                                                                                                         ),
+                                                                                                        to_key: None,
                                                                                                         serialize_pipeline: Some(
                                                                                                             Operator(
                                                                                                                 Operator {
@@ -3433,9 +3457,11 @@ expression: built.ir()
                                                                                     from_location: Cluster(
                                                                                         2,
                                                                                     ),
+                                                                                    from_key: None,
                                                                                     to_location: Cluster(
                                                                                         3,
                                                                                     ),
+                                                                                    to_key: None,
                                                                                     serialize_pipeline: Some(
                                                                                         Operator(
                                                                                             Operator {
@@ -3770,9 +3796,11 @@ expression: built.ir()
                                                                                 from_location: Cluster(
                                                                                     1,
                                                                                 ),
+                                                                                from_key: None,
                                                                                 to_location: Cluster(
                                                                                     3,
                                                                                 ),
+                                                                                to_key: None,
                                                                                 serialize_pipeline: Some(
                                                                                     Operator(
                                                                                         Operator {
@@ -3826,9 +3854,11 @@ expression: built.ir()
                                                                                             from_location: Cluster(
                                                                                                 1,
                                                                                             ),
+                                                                                            from_key: None,
                                                                                             to_location: Cluster(
                                                                                                 3,
                                                                                             ),
+                                                                                            to_key: None,
                                                                                             serialize_pipeline: Some(
                                                                                                 Operator(
                                                                                                     Operator {
@@ -3904,9 +3934,11 @@ expression: built.ir()
             from_location: Cluster(
                 3,
             ),
+            from_key: None,
             to_location: Cluster(
                 2,
             ),
+            to_key: None,
             serialize_pipeline: Some(
                 Operator(
                     Operator {
@@ -3939,9 +3971,11 @@ expression: built.ir()
                                     from_location: Cluster(
                                         2,
                                     ),
+                                    from_key: None,
                                     to_location: Cluster(
                                         3,
                                     ),
+                                    to_key: None,
                                     serialize_pipeline: Some(
                                         Operator(
                                             Operator {
@@ -4282,9 +4316,11 @@ expression: built.ir()
                                                                                     from_location: Cluster(
                                                                                         0,
                                                                                     ),
+                                                                                    from_key: None,
                                                                                     to_location: Cluster(
                                                                                         2,
                                                                                     ),
+                                                                                    to_key: None,
                                                                                     serialize_pipeline: Some(
                                                                                         Operator(
                                                                                             Operator {
@@ -4565,9 +4601,11 @@ expression: built.ir()
                                                                 from_location: Cluster(
                                                                     2,
                                                                 ),
+                                                                from_key: None,
                                                                 to_location: Cluster(
                                                                     3,
                                                                 ),
+                                                                to_key: None,
                                                                 serialize_pipeline: Some(
                                                                     Operator(
                                                                         Operator {
@@ -4909,9 +4947,11 @@ expression: built.ir()
                                                         from_location: Cluster(
                                                             2,
                                                         ),
+                                                        from_key: None,
                                                         to_location: Cluster(
                                                             1,
                                                         ),
+                                                        to_key: None,
                                                         serialize_pipeline: Some(
                                                             Operator(
                                                                 Operator {
@@ -5030,9 +5070,11 @@ expression: built.ir()
                                                                         from_location: Cluster(
                                                                             2,
                                                                         ),
+                                                                        from_key: None,
                                                                         to_location: Cluster(
                                                                             1,
                                                                         ),
+                                                                        to_key: None,
                                                                         serialize_pipeline: Some(
                                                                             Operator(
                                                                                 Operator {
@@ -5195,9 +5237,11 @@ expression: built.ir()
                                                                                     from_location: Cluster(
                                                                                         2,
                                                                                     ),
+                                                                                    from_key: None,
                                                                                     to_location: Cluster(
                                                                                         1,
                                                                                     ),
+                                                                                    to_key: None,
                                                                                     serialize_pipeline: Some(
                                                                                         Operator(
                                                                                             Operator {
@@ -5316,9 +5360,11 @@ expression: built.ir()
                                                                                                     from_location: Cluster(
                                                                                                         2,
                                                                                                     ),
+                                                                                                    from_key: None,
                                                                                                     to_location: Cluster(
                                                                                                         1,
                                                                                                     ),
+                                                                                                    to_key: None,
                                                                                                     serialize_pipeline: Some(
                                                                                                         Operator(
                                                                                                             Operator {
@@ -5518,9 +5564,11 @@ expression: built.ir()
                                                                                                     from_location: Cluster(
                                                                                                         2,
                                                                                                     ),
+                                                                                                    from_key: None,
                                                                                                     to_location: Cluster(
                                                                                                         1,
                                                                                                     ),
+                                                                                                    to_key: None,
                                                                                                     serialize_pipeline: Some(
                                                                                                         Operator(
                                                                                                             Operator {
@@ -5639,9 +5687,11 @@ expression: built.ir()
                                                                                                                     from_location: Cluster(
                                                                                                                         2,
                                                                                                                     ),
+                                                                                                                    from_key: None,
                                                                                                                     to_location: Cluster(
                                                                                                                         1,
                                                                                                                     ),
+                                                                                                                    to_key: None,
                                                                                                                     serialize_pipeline: Some(
                                                                                                                         Operator(
                                                                                                                             Operator {
@@ -5844,9 +5894,11 @@ expression: built.ir()
                                                                                                 from_location: Cluster(
                                                                                                     2,
                                                                                                 ),
+                                                                                                from_key: None,
                                                                                                 to_location: Cluster(
                                                                                                     1,
                                                                                                 ),
+                                                                                                to_key: None,
                                                                                                 serialize_pipeline: Some(
                                                                                                     Operator(
                                                                                                         Operator {
@@ -5965,9 +6017,11 @@ expression: built.ir()
                                                                                                                 from_location: Cluster(
                                                                                                                     2,
                                                                                                                 ),
+                                                                                                                from_key: None,
                                                                                                                 to_location: Cluster(
                                                                                                                     1,
                                                                                                                 ),
+                                                                                                                to_key: None,
                                                                                                                 serialize_pipeline: Some(
                                                                                                                     Operator(
                                                                                                                         Operator {
@@ -6123,9 +6177,11 @@ expression: built.ir()
                                     from_location: Cluster(
                                         1,
                                     ),
+                                    from_key: None,
                                     to_location: Cluster(
                                         0,
                                     ),
+                                    to_key: None,
                                     serialize_pipeline: Some(
                                         Operator(
                                             Operator {
@@ -6157,9 +6213,11 @@ expression: built.ir()
                                                         from_location: Cluster(
                                                             2,
                                                         ),
+                                                        from_key: None,
                                                         to_location: Cluster(
                                                             1,
                                                         ),
+                                                        to_key: None,
                                                         serialize_pipeline: Some(
                                                             Operator(
                                                                 Operator {
@@ -6278,9 +6336,11 @@ expression: built.ir()
                                                     from_location: Cluster(
                                                         1,
                                                     ),
+                                                    from_key: None,
                                                     to_location: Cluster(
                                                         0,
                                                     ),
+                                                    to_key: None,
                                                     serialize_pipeline: Some(
                                                         Operator(
                                                             Operator {
@@ -6312,9 +6372,11 @@ expression: built.ir()
                                                                         from_location: Cluster(
                                                                             2,
                                                                         ),
+                                                                        from_key: None,
                                                                         to_location: Cluster(
                                                                             1,
                                                                         ),
+                                                                        to_key: None,
                                                                         serialize_pipeline: Some(
                                                                             Operator(
                                                                                 Operator {
@@ -6468,9 +6530,11 @@ expression: built.ir()
                                                                         from_location: Cluster(
                                                                             2,
                                                                         ),
+                                                                        from_key: None,
                                                                         to_location: Cluster(
                                                                             0,
                                                                         ),
+                                                                        to_key: None,
                                                                         serialize_pipeline: Some(
                                                                             Operator(
                                                                                 Operator {
@@ -6762,9 +6826,11 @@ expression: built.ir()
                                                                     from_location: Cluster(
                                                                         1,
                                                                     ),
+                                                                    from_key: None,
                                                                     to_location: Cluster(
                                                                         0,
                                                                     ),
+                                                                    to_key: None,
                                                                     serialize_pipeline: Some(
                                                                         Operator(
                                                                             Operator {
@@ -6796,9 +6862,11 @@ expression: built.ir()
                                                                                         from_location: Cluster(
                                                                                             2,
                                                                                         ),
+                                                                                        from_key: None,
                                                                                         to_location: Cluster(
                                                                                             1,
                                                                                         ),
+                                                                                        to_key: None,
                                                                                         serialize_pipeline: Some(
                                                                                             Operator(
                                                                                                 Operator {
@@ -6968,9 +7036,11 @@ expression: built.ir()
                                                                                     from_location: Cluster(
                                                                                         1,
                                                                                     ),
+                                                                                    from_key: None,
                                                                                     to_location: Cluster(
                                                                                         0,
                                                                                     ),
+                                                                                    to_key: None,
                                                                                     serialize_pipeline: Some(
                                                                                         Operator(
                                                                                             Operator {
@@ -7002,9 +7072,11 @@ expression: built.ir()
                                                                                                         from_location: Cluster(
                                                                                                             2,
                                                                                                         ),
+                                                                                                        from_key: None,
                                                                                                         to_location: Cluster(
                                                                                                             1,
                                                                                                         ),
+                                                                                                        to_key: None,
                                                                                                         serialize_pipeline: Some(
                                                                                                             Operator(
                                                                                                                 Operator {
@@ -7166,9 +7238,11 @@ expression: built.ir()
                                                                             from_location: Cluster(
                                                                                 1,
                                                                             ),
+                                                                            from_key: None,
                                                                             to_location: Cluster(
                                                                                 0,
                                                                             ),
+                                                                            to_key: None,
                                                                             serialize_pipeline: Some(
                                                                                 Operator(
                                                                                     Operator {
@@ -7200,9 +7274,11 @@ expression: built.ir()
                                                                                                 from_location: Cluster(
                                                                                                     2,
                                                                                                 ),
+                                                                                                from_key: None,
                                                                                                 to_location: Cluster(
                                                                                                     1,
                                                                                                 ),
+                                                                                                to_key: None,
                                                                                                 serialize_pipeline: Some(
                                                                                                     Operator(
                                                                                                         Operator {
@@ -7383,9 +7459,11 @@ expression: built.ir()
                                                         from_location: Cluster(
                                                             2,
                                                         ),
+                                                        from_key: None,
                                                         to_location: Cluster(
                                                             0,
                                                         ),
+                                                        to_key: None,
                                                         serialize_pipeline: Some(
                                                             Operator(
                                                                 Operator {
@@ -7674,9 +7752,11 @@ expression: built.ir()
                                                         from_location: Cluster(
                                                             1,
                                                         ),
+                                                        from_key: None,
                                                         to_location: Cluster(
                                                             0,
                                                         ),
+                                                        to_key: None,
                                                         serialize_pipeline: Some(
                                                             Operator(
                                                                 Operator {
@@ -7708,9 +7788,11 @@ expression: built.ir()
                                                                             from_location: Cluster(
                                                                                 2,
                                                                             ),
+                                                                            from_key: None,
                                                                             to_location: Cluster(
                                                                                 1,
                                                                             ),
+                                                                            to_key: None,
                                                                             serialize_pipeline: Some(
                                                                                 Operator(
                                                                                     Operator {
@@ -7830,9 +7912,11 @@ expression: built.ir()
                                                 from_location: Cluster(
                                                     2,
                                                 ),
+                                                from_key: None,
                                                 to_location: Cluster(
                                                     0,
                                                 ),
+                                                to_key: None,
                                                 serialize_pipeline: Some(
                                                     Operator(
                                                         Operator {

--- a/hydroflow_plus_test/src/cluster/snapshots/hydroflow_plus_test__cluster__simple_cluster__tests__simple_cluster.snap
+++ b/hydroflow_plus_test/src/cluster/snapshots/hydroflow_plus_test__cluster__simple_cluster__tests__simple_cluster.snap
@@ -9,9 +9,11 @@ expression: built.ir()
             from_location: Cluster(
                 1,
             ),
+            from_key: None,
             to_location: Process(
                 0,
             ),
+            to_key: None,
             serialize_pipeline: Some(
                 Operator(
                     Operator {
@@ -39,9 +41,11 @@ expression: built.ir()
                     from_location: Process(
                         0,
                     ),
+                    from_key: None,
                     to_location: Cluster(
                         1,
                     ),
+                    to_key: None,
                     serialize_pipeline: Some(
                         Operator(
                             Operator {

--- a/hydroflow_plus_test/src/distributed/first_ten.rs
+++ b/hydroflow_plus_test/src/distributed/first_ten.rs
@@ -1,4 +1,5 @@
 use hydroflow_plus::*;
+use location::{ExternalBincodePort, ExternalProcess};
 use serde::{Deserialize, Serialize};
 use stageleft::*;
 
@@ -10,9 +11,21 @@ struct SendOverNetwork {
 pub struct P1 {}
 pub struct P2 {}
 
-pub fn first_ten_distributed(flow: &FlowBuilder) -> (Process<P1>, Process<P2>) {
+pub fn first_ten_distributed(
+    flow: &FlowBuilder,
+) -> (
+    ExternalProcess<()>,
+    ExternalBincodePort<String>,
+    Process<P1>,
+    Process<P2>,
+) {
+    let external_process = flow.external_process::<()>();
     let process = flow.process::<P1>();
     let second_process = flow.process::<P2>();
+
+    let (numbers_external_port, numbers_external) =
+        flow.source_external_bincode(&external_process, &process);
+    numbers_external.for_each(q!(|n| println!("hi: {:?}", n)));
 
     let numbers = flow.source_iter(&process, q!(0..10));
     numbers
@@ -20,12 +33,20 @@ pub fn first_ten_distributed(flow: &FlowBuilder) -> (Process<P1>, Process<P2>) {
         .send_bincode(&second_process)
         .for_each(q!(|n: SendOverNetwork| println!("{}", n.n))); // TODO(shadaj): why is the explicit type required here?
 
-    (process, second_process)
+    (
+        external_process,
+        numbers_external_port,
+        process,
+        second_process,
+    )
 }
 
 #[cfg(test)]
 mod tests {
-    use hydro_deploy::Deployment;
+    use std::sync::Arc;
+
+    use futures::SinkExt;
+    use hydro_deploy::{Deployment, Host};
     use hydroflow_plus_deploy::{DeployCrateWrapper, TrybuildHost};
 
     #[tokio::test]
@@ -33,7 +54,8 @@ mod tests {
         let mut deployment = Deployment::new();
 
         let builder = hydroflow_plus::FlowBuilder::new();
-        let (first_node, second_node) = super::first_ten_distributed(&builder);
+        let (external_process, external_port, first_node, second_node) =
+            super::first_ten_distributed(&builder);
 
         let built = builder.with_default_optimize();
 
@@ -43,13 +65,26 @@ mod tests {
         let nodes = built
             .with_process(&first_node, TrybuildHost::new(deployment.Localhost()))
             .with_process(&second_node, TrybuildHost::new(deployment.Localhost()))
+            .with_external(&external_process, deployment.Localhost() as Arc<dyn Host>)
             .deploy(&mut deployment);
 
         deployment.deploy().await.unwrap();
 
+        let mut external_port = nodes.connect_sink_bincode(external_port).await;
+
+        let mut first_node_stdout = nodes.get_process(&first_node).stdout().await;
         let mut second_node_stdout = nodes.get_process(&second_node).stdout().await;
 
         deployment.start().await.unwrap();
+
+        external_port
+            .send("this is some string".to_string())
+            .await
+            .unwrap();
+        assert_eq!(
+            first_node_stdout.recv().await.unwrap(),
+            "hi: \"this is some string\""
+        );
 
         for i in 0..10 {
             assert_eq!(second_node_stdout.recv().await.unwrap(), i.to_string());

--- a/hydroflow_plus_test/src/distributed/snapshots/hydroflow_plus_test__distributed__first_ten__tests__first_ten_distributed.snap
+++ b/hydroflow_plus_test/src/distributed/snapshots/hydroflow_plus_test__distributed__first_ten__tests__first_ten_distributed.snap
@@ -4,14 +4,49 @@ expression: built.ir()
 ---
 [
     ForEach {
-        f: stageleft :: runtime_support :: fn1_type_hint :: < hydroflow_plus_test :: distributed :: first_ten :: SendOverNetwork , () > ({ use crate :: __staged :: distributed :: first_ten :: * ; | n : SendOverNetwork | println ! ("{}" , n . n) }),
+        f: stageleft :: runtime_support :: fn1_type_hint :: < std :: string :: String , () > ({ use crate :: __staged :: distributed :: first_ten :: * ; | n | println ! ("hi: {:?}" , n) }),
         input: Network {
-            from_location: Process(
+            from_location: ExternalProcess(
+                0,
+            ),
+            from_key: Some(
                 0,
             ),
             to_location: Process(
                 1,
             ),
+            to_key: None,
+            serialize_pipeline: None,
+            instantiate_fn: <network instantiate>,
+            deserialize_pipeline: Some(
+                Operator(
+                    Operator {
+                        path: "map",
+                        args: [
+                            "| res | { hydroflow_plus :: runtime_support :: bincode :: deserialize :: < std :: string :: String > (& res . unwrap ()) . unwrap () }",
+                        ],
+                    },
+                ),
+            ),
+            input: Source {
+                source: ExternalNetwork,
+                location_kind: ExternalProcess(
+                    0,
+                ),
+            },
+        },
+    },
+    ForEach {
+        f: stageleft :: runtime_support :: fn1_type_hint :: < hydroflow_plus_test :: distributed :: first_ten :: SendOverNetwork , () > ({ use crate :: __staged :: distributed :: first_ten :: * ; | n : SendOverNetwork | println ! ("{}" , n . n) }),
+        input: Network {
+            from_location: Process(
+                1,
+            ),
+            from_key: None,
+            to_location: Process(
+                2,
+            ),
+            to_key: None,
             serialize_pipeline: Some(
                 Operator(
                     Operator {
@@ -40,7 +75,7 @@ expression: built.ir()
                         { use crate :: __staged :: distributed :: first_ten :: * ; 0 .. 10 },
                     ),
                     location_kind: Process(
-                        0,
+                        1,
                     ),
                 },
             },

--- a/stageleft/src/type_name.rs
+++ b/stageleft/src/type_name.rs
@@ -111,6 +111,23 @@ impl VisitMut for RewriteAlloc {
                     .chain(i.segments.iter().skip(3).cloned()),
                 ),
             };
+        } else if i.segments.iter().take(2).collect::<Vec<_>>()
+            == vec![
+                &syn::PathSegment::from(syn::Ident::new("bytes", Span::call_site())),
+                &syn::PathSegment::from(syn::Ident::new("bytes", Span::call_site())),
+            ]
+        {
+            *i = syn::Path {
+                leading_colon: i.leading_colon,
+                segments: syn::punctuated::Punctuated::from_iter(
+                    vec![syn::PathSegment::from(syn::Ident::new(
+                        "bytes",
+                        Span::call_site(),
+                    ))]
+                    .into_iter()
+                    .chain(i.segments.iter().skip(2).cloned()),
+                ),
+            };
         } else if let Some((macro_name, final_name)) = &self.mapping {
             if i.segments.first().unwrap().ident == macro_name {
                 *i.segments.first_mut().unwrap() =


### PR DESCRIPTION

This is a key step towards being able to unit-test HF+ graphs, by being able to have controlled inputs. Outputs next.
