### PR TITLE
build: use different target dir for rust-analyzer to prevent thrashing with cargo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,10 +13,16 @@
             }
         }
     ],
+    "rust-analyzer.runnables.extraTestBinaryArgs": [
+        "--nocapture"
+    ],
+    "rust-analyzer.cargo.features": [
+        "python"
+    ],
+    "rust-analyzer.server.extraEnv": {
+        "CARGO_TARGET_DIR": "${workspaceFolder}/target/rust-analyzer",
+    },
     "files.watcherExclude": {
         "**/target": true
     },
-    "rust-analyzer.cargo.features": [
-        "python"
-    ]
 }


### PR DESCRIPTION
Might only be a problem on windows?

Edit: seems to only be windows