### PR TITLE
fix(hydroflow_plus): adjust default features to allow compilation to musl targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,10 +181,10 @@ jobs:
         run: curl -LsSf https://get.nexte.st/latest/windows-tar | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
       - name: Run cargo nextest on all targets
-        run: cargo nextest run --no-fail-fast --features python --all-targets
+        run: cargo nextest run --no-fail-fast --features python --features deploy --all-targets
 
       - name: Run doctests
-        run: cargo test --no-fail-fast --features python --doc
+        run: cargo test --no-fail-fast --features python --features deploy --doc
 
       - name: Install Python
         uses: actions/setup-python@v4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,4 @@
     "files.watcherExclude": {
         "**/target": true
     },
-    "rust-analyzer.cargo.features": [
-        "python"
-    ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,6 +1469,7 @@ dependencies = [
 name = "hydroflow_plus_test"
 version = "0.0.0"
 dependencies = [
+ "async-ssh2-lite",
  "futures",
  "hydro_deploy",
  "hydroflow_plus",

--- a/hydroflow_plus/Cargo.toml
+++ b/hydroflow_plus/Cargo.toml
@@ -14,10 +14,11 @@ workspace = true
 path = "src/lib.rs"
 
 [features]
-default = ["deploy"]
+default = ["deploy_runtime"]
 diagnostics = [ "hydroflow_lang/diagnostics" ]
 stageleft_devel = []
-deploy = [ "hydroflow/deploy_integration", "dep:hydro_deploy", "dep:trybuild-internals-api", "dep:toml", "dep:prettyplease" ]
+deploy_runtime = [ "hydroflow/deploy_integration" ]
+deploy = [ "deploy_runtime", "dep:hydro_deploy", "dep:trybuild-internals-api", "dep:toml", "dep:prettyplease" ]
 
 [dependencies]
 quote = "1.0.35"

--- a/hydroflow_plus/src/deploy/deploy_graph.rs
+++ b/hydroflow_plus/src/deploy/deploy_graph.rs
@@ -17,7 +17,7 @@ use hydroflow::futures::StreamExt;
 use hydroflow::util::deploy::ConnectedSource;
 use nameof::name_of;
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use sha2::{Digest, Sha256};
 use stageleft::{Quoted, RuntimeData};
 use syn::visit_mut::VisitMut;
@@ -30,13 +30,6 @@ use super::{ClusterSpec, Deploy, ExternalSpec, Node, ProcessSpec, RegisterPort};
 use crate::futures::SinkExt;
 use crate::lang::graph::HydroflowGraph;
 use crate::util::deploy::ConnectedSink;
-
-#[derive(Default, Serialize, Deserialize)]
-pub struct HydroflowPlusMeta {
-    pub clusters: HashMap<usize, Vec<u32>>,
-    pub cluster_id: Option<u32>,
-    pub subgraph_id: usize,
-}
 
 pub struct HydroDeploy {}
 

--- a/hydroflow_plus/src/deploy/deploy_runtime.rs
+++ b/hydroflow_plus/src/deploy/deploy_runtime.rs
@@ -1,9 +1,18 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
 use stageleft::{q, Quoted, RuntimeData};
 
-use super::HydroflowPlusMeta;
 use crate::util::deploy::{
     ConnectedDemux, ConnectedDirect, ConnectedSink, ConnectedSource, ConnectedTagged, DeployPorts,
 };
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct HydroflowPlusMeta {
+    pub clusters: HashMap<usize, Vec<u32>>,
+    pub cluster_id: Option<u32>,
+    pub subgraph_id: usize,
+}
 
 pub fn cluster_members(
     cli: RuntimeData<&DeployPorts<HydroflowPlusMeta>>,
@@ -123,7 +132,7 @@ pub fn deploy_m2m(
 
 pub fn deploy_e2o(
     env: RuntimeData<&DeployPorts<HydroflowPlusMeta>>,
-    e1_port: &str,
+    _e1_port: &str,
     p2_port: &str,
 ) -> syn::Expr {
     q!({
@@ -137,7 +146,7 @@ pub fn deploy_e2o(
 pub fn deploy_o2e(
     env: RuntimeData<&DeployPorts<HydroflowPlusMeta>>,
     p1_port: &str,
-    e2_port: &str,
+    _e2_port: &str,
 ) -> syn::Expr {
     q!({
         env.port(p1_port)

--- a/hydroflow_plus/src/deploy/mod.rs
+++ b/hydroflow_plus/src/deploy/mod.rs
@@ -9,6 +9,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use stageleft::Quoted;
 
+#[cfg(feature = "deploy_runtime")]
 pub mod macro_runtime;
 
 #[cfg(feature = "deploy")]
@@ -18,8 +19,10 @@ pub use macro_runtime::*;
 #[cfg(feature = "deploy")]
 pub use trybuild::init_test;
 
-#[allow(clippy::allow_attributes, unused, reason = "stageleft")]
-pub(crate) mod deploy_runtime;
+#[cfg(feature = "deploy_runtime")]
+pub mod deploy_runtime;
+#[cfg(feature = "deploy_runtime")]
+pub use deploy_runtime::HydroflowPlusMeta;
 
 #[cfg(feature = "deploy")]
 pub mod deploy_graph;

--- a/hydroflow_plus_test/Cargo.toml
+++ b/hydroflow_plus_test/Cargo.toml
@@ -26,3 +26,4 @@ insta = "1.39"
 hydro_deploy = { path = "../hydro_deploy/core", version = "^0.9.0" }
 hydroflow_plus = { path = "../hydroflow_plus", version = "^0.9.0", features = [ "deploy" ] }
 futures = "0.3.0"
+async-ssh2-lite = { version = "0.5.0", features = ["vendored-openssl"] }


### PR DESCRIPTION

Previously, the default `deploy` feature would pull in Hydro Deploy and its transitive native dependencies.

Also sets up `examples/paxos.rs` with CLI flags to deploy to GCP.
