### PR TITLE
refactor(hydroflow_plus)!: move `self_id` and `members` to be APIs on cluster instead of builder

### DIFF
--- a/docs/docs/hydroflow_plus/clusters.mdx
+++ b/docs/docs/hydroflow_plus/clusters.mdx
@@ -36,7 +36,7 @@ Elements in a cluster are identified by a **cluster ID** (a `u32`). To get the I
 
 This can then be passed into `source_iter` to load the IDs into the graph.
 ```rust
-let stream = flow.source_iter(&process, flow.cluster_members(&cluster)).cloned();
+let stream = flow.source_iter(&process, cluster.members()).cloned();
 ```
 
 ### One-to-Many
@@ -44,7 +44,7 @@ When sending data from a process to a cluster, the source must be a stream of tu
 
 This is useful for partitioning data across instances. For example, we can partition a stream of elements in a round-robin fashion by using `enumerate` to add a sequence number to each element, then using `send_bincode` to send each element to the instance with the matching sequence number:
 ```rust
-let cluster_ids = flow.cluster_members(&cluster);
+let cluster_ids = cluster.members();
 let stream = flow.source_iter(&process, q!(vec![123, 456, 789]))
     .enumerate()
     .map(q!(|(i, x)| (

--- a/hydroflow_plus/src/builder/mod.rs
+++ b/hydroflow_plus/src/builder/mod.rs
@@ -58,9 +58,9 @@ impl<'a> FreeVariable<&'a Vec<u32>> for ClusterIds<'a> {
 impl<'a> Quoted<'a, &'a Vec<u32>> for ClusterIds<'a> {}
 
 #[derive(Copy, Clone)]
-struct ClusterSelfId<'a> {
-    id: usize,
-    _phantom: PhantomData<&'a mut &'a u32>,
+pub(crate) struct ClusterSelfId<'a> {
+    pub(crate) id: usize,
+    pub(crate) _phantom: PhantomData<&'a mut &'a u32>,
 }
 
 impl<'a> FreeVariable<u32> for ClusterSelfId<'a> {
@@ -196,23 +196,6 @@ impl<'a> FlowBuilder<'a> {
 
     pub fn runtime_context(&self) -> RuntimeContext<'a> {
         RuntimeContext {
-            _phantom: PhantomData,
-        }
-    }
-
-    pub fn cluster_members<C>(
-        &self,
-        cluster: &Cluster<C>,
-    ) -> impl Quoted<'a, &'a Vec<u32>> + Copy + 'a {
-        ClusterIds {
-            id: cluster.id,
-            _phantom: PhantomData,
-        }
-    }
-
-    pub fn cluster_self_id<C>(&self, cluster: &Cluster<C>) -> impl Quoted<'a, u32> + Copy + 'a {
-        ClusterSelfId {
-            id: cluster.id,
             _phantom: PhantomData,
         }
     }

--- a/hydroflow_plus/src/location.rs
+++ b/hydroflow_plus/src/location.rs
@@ -2,6 +2,9 @@ use std::marker::PhantomData;
 
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use stageleft::Quoted;
+
+use super::builder::{ClusterIds, ClusterSelfId};
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum LocationId {
@@ -74,6 +77,22 @@ impl<P> Location for Process<P> {
 pub struct Cluster<C> {
     pub(crate) id: usize,
     pub(crate) _phantom: PhantomData<C>,
+}
+
+impl<C> Cluster<C> {
+    pub fn self_id<'a>(&self) -> impl Quoted<'a, u32> + Copy + 'a {
+        ClusterSelfId {
+            id: self.id,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn members<'a>(&self) -> impl Quoted<'a, &'a Vec<u32>> + Copy + 'a {
+        ClusterIds {
+            id: self.id,
+            _phantom: PhantomData,
+        }
+    }
 }
 
 impl<C> Clone for Cluster<C> {

--- a/hydroflow_plus/src/stream.rs
+++ b/hydroflow_plus/src/stream.rs
@@ -14,7 +14,7 @@ use serde::Serialize;
 use stageleft::{q, IntoQuotedMut, Quoted};
 use syn::parse_quote;
 
-use crate::builder::{ClusterIds, FlowLeaves};
+use crate::builder::FlowLeaves;
 use crate::cycle::{CycleCollection, CycleComplete};
 use crate::ir::{DebugInstantiate, HfPlusLeaf, HfPlusNode, HfPlusSource};
 use crate::location::{
@@ -856,10 +856,7 @@ impl<'a, T, W, N: Location> Stream<'a, T, W, NoTick, N> {
         N: CanSend<Cluster<C2>, In<T> = (u32, T)>,
         T: Clone + Serialize + DeserializeOwned,
     {
-        let ids = ClusterIds::<'a> {
-            id: other.id,
-            _phantom: PhantomData,
-        };
+        let ids = other.members();
 
         self.flat_map(q!(|b| ids.iter().map(move |id| (
             ::std::clone::Clone::clone(id),
@@ -887,10 +884,7 @@ impl<'a, T, W, N: Location> Stream<'a, T, W, NoTick, N> {
         N: CanSend<Cluster<C2>, In<Bytes> = (u32, T)> + 'a,
         T: Clone,
     {
-        let ids = ClusterIds::<'a> {
-            id: other.id,
-            _phantom: PhantomData,
-        };
+        let ids = other.members();
 
         self.flat_map(q!(|b| ids.iter().map(move |id| (
             ::std::clone::Clone::clone(id),

--- a/hydroflow_plus_test/src/cluster/map_reduce.rs
+++ b/hydroflow_plus_test/src/cluster/map_reduce.rs
@@ -12,7 +12,7 @@ pub fn map_reduce(flow: &FlowBuilder) -> (Process<Leader>, Cluster<Worker>) {
         .source_iter(&process, q!(vec!["abc", "abc", "xyz", "abc"]))
         .map(q!(|s| s.to_string()));
 
-    let all_ids_vec = flow.cluster_members(&cluster);
+    let all_ids_vec = cluster.members();
     let words_partitioned = words
         .tick_batch()
         .enumerate()

--- a/hydroflow_plus_test/src/cluster/paxos_bench.rs
+++ b/hydroflow_plus_test/src/cluster/paxos_bench.rs
@@ -264,7 +264,7 @@ fn bench_client<'a, B: LeaderElected + std::fmt::Debug>(
     median_latency_window_size: usize,
     f: usize,
 ) -> Stream<'a, (u32, ClientPayload), Unbounded, NoTick, Cluster<Client>> {
-    let c_id = flow.cluster_self_id(clients);
+    let c_id = clients.self_id();
     // r_to_clients_payload_applied.clone().inspect(q!(|payload: &(u32, ReplicaPayload)| println!("Client received payload: {:?}", payload)));
     // Only keep the latest leader
     let c_max_leader_ballot = p_to_clients_leader_elected

--- a/hydroflow_plus_test/src/cluster/simple_cluster.rs
+++ b/hydroflow_plus_test/src/cluster/simple_cluster.rs
@@ -7,10 +7,10 @@ pub fn simple_cluster(flow: &FlowBuilder) -> (Process<()>, Cluster<()>) {
 
     let numbers = flow.source_iter(&process, q!(0..5));
     let ids = flow
-        .source_iter(&process, flow.cluster_members(&cluster))
+        .source_iter(&process, cluster.members())
         .map(q!(|&id| id));
 
-    let cluster_self_id = flow.cluster_self_id(&cluster);
+    let cluster_self_id = cluster.self_id();
 
     ids.cross_product(numbers)
         .map(q!(|(id, n)| (id, (id, n))))


### PR DESCRIPTION
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydroflow/pull/1468).
* #1471
* __->__ #1468