### PR TITLE
feat(anna): Multi-server Anna Working Locally

### DIFF
--- a/datastores/gossip_kv/Makefile
+++ b/datastores/gossip_kv/Makefile
@@ -6,20 +6,20 @@ MINIKUBE_CPUS=16
 MINIKUBE_MEMORY=32768
 
 # Docker Image Tags
-BASE_IMAGE_TAG=hydroflow/gossip-kv-server-base-image:latest
+BASE_IMAGE_TAG=hydroflow/gossip-kv-base-image:latest
 SERVER_IMAGE_TAG=hydroflow/gossip-kv-server:latest
 CLI_IMAGE_TAG=hydroflow/gossip-kv-cli:latest
+DUMMY_IMAGE_TAG=hydroflow/gossip-kv-dummy:latest
 
 # Default target when you run 'make'
 
 # Target to start Minikube with specific options
 start_minikube:
 	minikube start --disk-size=$(MINIKUBE_DISK_SIZE) --cpus=$(MINIKUBE_CPUS) --memory=$(MINIKUBE_MEMORY)
-	eval $$(minikube docker-env)
+	@echo "Please run 'eval \$$(minikube docker-env)' to use the Minikube Docker daemon"
 
 # Target to build the Docker images
 build_docker_images: build_base_image build_server_image build_cli_image
-
 
 build_base_image:
 	docker build -t "$(BASE_IMAGE_TAG)" -f ../../datastores/gossip_kv/server/baseimage.Dockerfile ../..

--- a/datastores/gossip_kv/cli/Dockerfile
+++ b/datastores/gossip_kv/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM "hydroflow/gossip-kv-server-base-image:latest" AS builder
+FROM "hydroflow/gossip-kv-base-image:latest" AS builder
 WORKDIR /usr/src/gossip-kv-server
 COPY . .
 RUN find .
@@ -6,3 +6,7 @@ RUN cargo build --release --workspace -p gossip_kv
 
 FROM rustlang/rust:nightly-slim
 COPY --from=builder /usr/src/gossip-kv-server/target/release/gossip_cli /usr/local/bin/gossip_cli
+
+RUN apt-get update && apt-get install -y \
+    dnsutils \
+    && rm -rf /var/lib/apt/lists/*

--- a/datastores/gossip_kv/server/Dockerfile
+++ b/datastores/gossip_kv/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM "hydroflow/gossip-kv-server-base-image:latest" AS builder
+FROM "hydroflow/gossip-kv-base-image:latest" AS builder
 WORKDIR /usr/src/gossip-kv-server
 COPY . .
 RUN find .
@@ -11,4 +11,3 @@ RUN  mkdir -p /config/static
 # Don't skip the trailing slash in the destination directory
 COPY datastores/gossip_kv/server/config/static/*.toml /config/static/
 CMD ["gossip_server"]
-# ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/datastores/gossip_kv/server/README.md
+++ b/datastores/gossip_kv/server/README.md
@@ -40,5 +40,5 @@ minikube image ls --format tablemin
 
 ## Deploy to Minikube
 ```shell
-kubectl apply -f datastores/gossip_kv/server/deployment/local
+kubectl apply -f datastores/gossip_kv/server/deployment/local/objects.yaml
 ```

--- a/datastores/gossip_kv/server/config/static/default.toml
+++ b/datastores/gossip_kv/server/config/static/default.toml
@@ -2,4 +2,4 @@ seed_nodes = []
 
 #[[seed_nodes]]
 #id = "gossip-kv-seed-nodes-0"
-#address = "gossip-kv-seed-nodes-0.gossip-kv-seed-nodes.default.svc.cluster.local:3001"
+#address = "gossip-kv-seed-nodes-0.gossip-kv-seed-nodes.default.svc.cluster.local:3000"

--- a/datastores/gossip_kv/server/deployment/local/objects.yaml
+++ b/datastores/gossip_kv/server/deployment/local/objects.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: gossip-kv-seed-nodes
 spec:
-  replicas: 1
+  replicas: 3
   serviceName: gossip-kv-seed-nodes
   selector:
     matchLabels:
@@ -15,6 +15,7 @@ spec:
       labels:
         app: gossip-kv-seed-nodes
     spec:
+      terminationGracePeriodSeconds: 5 # Really aggressive, but makes teardown faster. Not recommended beyond benchmarking.
       containers:
         - name: gossip-kv-server
           image: docker.io/hydroflow/gossip-kv-server:latest
@@ -54,6 +55,7 @@ spec:
       labels:
         app: gossip-kv-cli
     spec:
+      terminationGracePeriodSeconds: 5 # Really aggressive, but makes teardown faster. Not recommended beyond benchmarking.
       containers:
         - name: gossip-kv-cli
           image: docker.io/hydroflow/gossip-kv-cli:latest

--- a/datastores/gossip_kv/server/deployment/local/updated_seed_node_config.yaml
+++ b/datastores/gossip_kv/server/deployment/local/updated_seed_node_config.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gossip-kv-dynamic-config
+data:
+  dynamic.toml: |
+    [[seed_nodes]]
+    id = "gossip-kv-seed-nodes-0"
+    address = "gossip-kv-seed-nodes-0.gossip-kv-seed-nodes.default.svc.cluster.local:3000"
+    
+    [[seed_nodes]]
+    id = "gossip-kv-seed-nodes-1"
+    address = "gossip-kv-seed-nodes-1.gossip-kv-seed-nodes.default.svc.cluster.local:3000"
+    
+    [[seed_nodes]]
+    id = "gossip-kv-seed-nodes-2"
+    address = "gossip-kv-seed-nodes-2.gossip-kv-seed-nodes.default.svc.cluster.local:3000"

--- a/datastores/gossip_kv/server/membership.rs
+++ b/datastores/gossip_kv/server/membership.rs
@@ -1,33 +1,37 @@
 use std::sync::OnceLock;
 
 use gossip_protocol::membership::MemberId;
-use rand::distributions::Distribution;
-use rand::{thread_rng, Rng};
+// use rand::distributions::Distribution;
+// use rand::{Rng};
 
 /// This is a simple distribution that generates a random lower-case alphanumeric
-struct LowercaseAlphanumeric;
-
-impl Distribution<char> for LowercaseAlphanumeric {
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> char {
-        let choices = b"abcdefghijklmnopqrstuvwxyz0123456789";
-        choices[rng.gen_range(0..choices.len())] as char
-    }
-}
+// struct LowercaseAlphanumeric;
+//
+// impl Distribution<char> for LowercaseAlphanumeric {
+//     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> char {
+//         let choices = b"abcdefghijklmnopqrstuvwxyz0123456789";
+//         choices[rng.gen_range(0..choices.len())] as char
+//     }
+// }
 
 /// Gets a name for the current process.
 pub fn member_name() -> &'static MemberId {
     static MEMBER_NAME: OnceLock<MemberId> = OnceLock::new();
     MEMBER_NAME.get_or_init(|| {
         // Generate a lower-case alphanumeric suffix of length 4
-        let suffix: String = thread_rng()
-            .sample_iter(&LowercaseAlphanumeric)
-            .take(4)
-            .map(char::from)
-            .collect();
+
+        // TODO: Random suffixes are good, but make benchmarking a pain. For now, we'll just use
+        // the hostname as-is.
+
+        // let suffix: String = thread_rng()
+        //     .sample_iter(&LowercaseAlphanumeric)
+        //     .take(4)
+        //     .map(char::from)
+        //     .collect();
 
         // Retrieve hostname
-        let hostname = hostname::get().unwrap().to_str().unwrap().to_string();
+        hostname::get().unwrap().to_str().unwrap().to_string()
 
-        format!("{}-{}", hostname, suffix)
+        // format!("{}-{}", hostname, suffix)
     })
 }


### PR DESCRIPTION
Summary of Changes:
1. Some cleanup/bug fixes with docker files.
2. Install `dig` on CLI to test DNS
3. Fixed gossip ports everywhere - using the wrong port was annoying.
4. Cluster tear-down is much faster - reduced pod termination wait from 30s (default) to 5s.
5. New static config for three servers - not planning to automate this now.
6. Gossip trigger timer wired in - this was earlier separated out for deterministic testing.
7. Not randomizing host-names at the moment - this was making testing difficult, although I think this does help in production with restarts and such.
8. Gossip assumed > 0 available peers - fixed that issue.