### PR TITLE
fix(hydroflow_lang): `cross_singleton()` forgot value if multiple runs in a tick, fix #1518

### DIFF
--- a/hydroflow/tests/snapshots/surface_cross_singleton__union_defer_tick@graphvis_dot.snap
+++ b/hydroflow/tests/snapshots/surface_cross_singleton__union_defer_tick@graphvis_dot.snap
@@ -1,0 +1,158 @@
+---
+source: hydroflow/tests/surface_cross_singleton.rs
+expression: "df.meta_graph().unwrap().to_dot(& Default :: default())"
+---
+digraph {
+    node [fontname="Monaco,Menlo,Consolas,&quot;Droid Sans Mono&quot;,Inconsolata,&quot;Courier New&quot;,monospace", style=filled];
+    edge [fontname="Monaco,Menlo,Consolas,&quot;Droid Sans Mono&quot;,Inconsolata,&quot;Courier New&quot;,monospace"];
+    n1v1 [label="(n1v1) source_stream(cross_rx)", shape=invhouse, fillcolor="#88aaff"]
+    n2v1 [label="(n2v1) sort()", shape=invhouse, fillcolor="#88aaff"]
+    n3v1 [label="(n3v1) tee()", shape=house, fillcolor="#ffff88"]
+    n4v1 [label="(n4v1) defer_tick_lazy()", shape=invhouse, fillcolor="#88aaff"]
+    n5v1 [label="(n5v1) source_iter([0])", shape=invhouse, fillcolor="#88aaff"]
+    n6v1 [label="(n6v1) persist::<'static>()", shape=invhouse, fillcolor="#88aaff"]
+    n7v1 [label="(n7v1) union()", shape=invhouse, fillcolor="#88aaff"]
+    n8v1 [label="(n8v1) cross_singleton()", shape=invhouse, fillcolor="#88aaff"]
+    n9v1 [label="(n9v1) tee()", shape=house, fillcolor="#ffff88"]
+    n10v1 [label="(n10v1) for_each(|x| egress_tx.send(x).unwrap())", shape=house, fillcolor="#ffff88"]
+    n11v1 [label="(n11v1) fold(|| 0, |_, _| {})", shape=invhouse, fillcolor="#88aaff"]
+    n12v1 [label="(n12v1) cross_singleton()", shape=invhouse, fillcolor="#88aaff"]
+    n13v1 [label="(n13v1) fold(|| 0, |_, _| {})", shape=invhouse, fillcolor="#88aaff"]
+    n14v1 [label="(n14v1) flat_map(|_| [])", shape=invhouse, fillcolor="#88aaff"]
+    n15v1 [label="(n15v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n16v1 [label="(n16v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n17v1 [label="(n17v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n18v1 [label="(n18v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n19v1 [label="(n19v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n20v1 [label="(n20v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n21v1 [label="(n21v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n22v1 [label="(n22v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n23v1 [label="(n23v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n24v1 [label="(n24v1) identity()", shape=invhouse, fillcolor="#88aaff"]
+    n25v1 [label="(n25v1) handoff", shape=parallelogram, fillcolor="#ddddff"]
+    n2v1 -> n3v1
+    n1v1 -> n15v1
+    n3v1 -> n16v1
+    n4v1 -> n7v1 [label="0"]
+    n14v1 -> n17v1
+    n5v1 -> n6v1
+    n6v1 -> n7v1 [label="1"]
+    n7v1 -> n18v1
+    n8v1 -> n9v1
+    n9v1 -> n10v1
+    n9v1 -> n19v1
+    n3v1 -> n20v1
+    n11v1 -> n21v1
+    n13v1 -> n22v1
+    n12v1 -> n23v1
+    n15v1 -> n2v1 [color=red]
+    n16v1 -> n8v1 [label="input"]
+    n17v1 -> n24v1
+    n18v1 -> n8v1 [label="single", color=red]
+    n19v1 -> n11v1 [color=red]
+    n20v1 -> n12v1 [label="input"]
+    n21v1 -> n12v1 [label="single", color=red]
+    n22v1 -> n14v1
+    n23v1 -> n13v1 [color=red]
+    n24v1 -> n25v1
+    n25v1 -> n4v1 [color=red]
+    subgraph "cluster n1v1" {
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_1v1\nstratum 0"
+        n1v1
+        subgraph "cluster_sg_1v1_var_teed_in" {
+            label="var teed_in"
+            n1v1
+        }
+    }
+    subgraph "cluster n2v1" {
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_2v1\nstratum 1"
+        n2v1
+        n3v1
+        subgraph "cluster_sg_2v1_var_teed_in" {
+            label="var teed_in"
+            n2v1
+            n3v1
+        }
+    }
+    subgraph "cluster n3v1" {
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_3v1\nstratum 0"
+        n4v1
+        n5v1
+        n6v1
+        n7v1
+        subgraph "cluster_sg_3v1_var_persisted_stream" {
+            label="var persisted_stream"
+            n5v1
+            n6v1
+        }
+        subgraph "cluster_sg_3v1_var_unioned_stream" {
+            label="var unioned_stream"
+            n7v1
+        }
+    }
+    subgraph "cluster n4v1" {
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_4v1\nstratum 1"
+        n8v1
+        n9v1
+        n10v1
+        subgraph "cluster_sg_4v1_var_join" {
+            label="var join"
+            n8v1
+            n9v1
+        }
+    }
+    subgraph "cluster n5v1" {
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_5v1\nstratum 2"
+        n11v1
+        subgraph "cluster_sg_5v1_var_folded_thing" {
+            label="var folded_thing"
+            n11v1
+        }
+    }
+    subgraph "cluster n6v1" {
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_6v1\nstratum 3"
+        n12v1
+        subgraph "cluster_sg_6v1_var_joined_folded" {
+            label="var joined_folded"
+            n12v1
+        }
+    }
+    subgraph "cluster n7v1" {
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_7v1\nstratum 4"
+        n13v1
+        subgraph "cluster_sg_7v1_var_deferred_stream" {
+            label="var deferred_stream"
+            n13v1
+        }
+    }
+    subgraph "cluster n8v1" {
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_8v1\nstratum 4"
+        n14v1
+        subgraph "cluster_sg_8v1_var_deferred_stream" {
+            label="var deferred_stream"
+            n14v1
+        }
+    }
+    subgraph "cluster n9v1" {
+        fillcolor="#dddddd"
+        style=filled
+        label = "sg_9v1\nstratum 5"
+        n24v1
+    }
+}

--- a/hydroflow/tests/snapshots/surface_cross_singleton__union_defer_tick@graphvis_mermaid.snap
+++ b/hydroflow/tests/snapshots/surface_cross_singleton__union_defer_tick@graphvis_mermaid.snap
@@ -1,0 +1,124 @@
+---
+source: hydroflow/tests/surface_cross_singleton.rs
+expression: "df.meta_graph().unwrap().to_mermaid(& Default :: default())"
+---
+%%{init:{'theme':'base','themeVariables':{'clusterBkg':'#ddd','clusterBorder':'#888'}}}%%
+flowchart TD
+classDef pullClass fill:#8af,stroke:#000,text-align:left,white-space:pre
+classDef pushClass fill:#ff8,stroke:#000,text-align:left,white-space:pre
+classDef otherClass fill:#fdc,stroke:#000,text-align:left,white-space:pre
+linkStyle default stroke:#aaa
+1v1[\"(1v1) <code>source_stream(cross_rx)</code>"/]:::pullClass
+2v1[\"(2v1) <code>sort()</code>"/]:::pullClass
+3v1[/"(3v1) <code>tee()</code>"\]:::pushClass
+4v1[\"(4v1) <code>defer_tick_lazy()</code>"/]:::pullClass
+5v1[\"(5v1) <code>source_iter([0])</code>"/]:::pullClass
+6v1[\"(6v1) <code>persist::&lt;'static&gt;()</code>"/]:::pullClass
+7v1[\"(7v1) <code>union()</code>"/]:::pullClass
+8v1[\"(8v1) <code>cross_singleton()</code>"/]:::pullClass
+9v1[/"(9v1) <code>tee()</code>"\]:::pushClass
+10v1[/"(10v1) <code>for_each(|x| egress_tx.send(x).unwrap())</code>"\]:::pushClass
+11v1[\"(11v1) <code>fold(|| 0, |_, _| {})</code>"/]:::pullClass
+12v1[\"(12v1) <code>cross_singleton()</code>"/]:::pullClass
+13v1[\"(13v1) <code>fold(|| 0, |_, _| {})</code>"/]:::pullClass
+14v1[\"(14v1) <code>flat_map(|_| [])</code>"/]:::pullClass
+15v1["(15v1) <code>handoff</code>"]:::otherClass
+16v1["(16v1) <code>handoff</code>"]:::otherClass
+17v1["(17v1) <code>handoff</code>"]:::otherClass
+18v1["(18v1) <code>handoff</code>"]:::otherClass
+19v1["(19v1) <code>handoff</code>"]:::otherClass
+20v1["(20v1) <code>handoff</code>"]:::otherClass
+21v1["(21v1) <code>handoff</code>"]:::otherClass
+22v1["(22v1) <code>handoff</code>"]:::otherClass
+23v1["(23v1) <code>handoff</code>"]:::otherClass
+24v1[\"(24v1) <code>identity()</code>"/]:::pullClass
+25v1["(25v1) <code>handoff</code>"]:::otherClass
+2v1-->3v1
+1v1-->15v1
+3v1-->16v1
+4v1-->|0|7v1
+14v1-->17v1
+5v1-->6v1
+6v1-->|1|7v1
+7v1-->18v1
+8v1-->9v1
+9v1-->10v1
+9v1-->19v1
+3v1-->20v1
+11v1-->21v1
+13v1-->22v1
+12v1-->23v1
+15v1--x2v1; linkStyle 15 stroke:red
+16v1-->|input|8v1
+17v1-->24v1
+18v1--x|single|8v1; linkStyle 18 stroke:red
+19v1--x11v1; linkStyle 19 stroke:red
+20v1-->|input|12v1
+21v1--x|single|12v1; linkStyle 21 stroke:red
+22v1-->14v1
+23v1--x13v1; linkStyle 23 stroke:red
+24v1-->25v1
+25v1--o4v1; linkStyle 25 stroke:red
+subgraph sg_1v1 ["sg_1v1 stratum 0"]
+    1v1
+    subgraph sg_1v1_var_teed_in ["var <tt>teed_in</tt>"]
+        1v1
+    end
+end
+subgraph sg_2v1 ["sg_2v1 stratum 1"]
+    2v1
+    3v1
+    subgraph sg_2v1_var_teed_in ["var <tt>teed_in</tt>"]
+        2v1
+        3v1
+    end
+end
+subgraph sg_3v1 ["sg_3v1 stratum 0"]
+    4v1
+    5v1
+    6v1
+    7v1
+    subgraph sg_3v1_var_persisted_stream ["var <tt>persisted_stream</tt>"]
+        5v1
+        6v1
+    end
+    subgraph sg_3v1_var_unioned_stream ["var <tt>unioned_stream</tt>"]
+        7v1
+    end
+end
+subgraph sg_4v1 ["sg_4v1 stratum 1"]
+    8v1
+    9v1
+    10v1
+    subgraph sg_4v1_var_join ["var <tt>join</tt>"]
+        8v1
+        9v1
+    end
+end
+subgraph sg_5v1 ["sg_5v1 stratum 2"]
+    11v1
+    subgraph sg_5v1_var_folded_thing ["var <tt>folded_thing</tt>"]
+        11v1
+    end
+end
+subgraph sg_6v1 ["sg_6v1 stratum 3"]
+    12v1
+    subgraph sg_6v1_var_joined_folded ["var <tt>joined_folded</tt>"]
+        12v1
+    end
+end
+subgraph sg_7v1 ["sg_7v1 stratum 4"]
+    13v1
+    subgraph sg_7v1_var_deferred_stream ["var <tt>deferred_stream</tt>"]
+        13v1
+    end
+end
+subgraph sg_8v1 ["sg_8v1 stratum 4"]
+    14v1
+    subgraph sg_8v1_var_deferred_stream ["var <tt>deferred_stream</tt>"]
+        14v1
+    end
+end
+subgraph sg_9v1 ["sg_9v1 stratum 5"]
+    24v1
+end

--- a/hydroflow/tests/surface_cross_singleton.rs
+++ b/hydroflow/tests/surface_cross_singleton.rs
@@ -2,7 +2,7 @@ use hydroflow::util::collect_ready;
 use hydroflow::{assert_graphvis_snapshots, hydroflow_syntax};
 use multiplatform_test::multiplatform_test;
 
-#[multiplatform_test]
+#[multiplatform_test(test, wasm, env_tracing)]
 pub fn test_basic() {
     let (single_tx, single_rx) = hydroflow::util::unbounded_channel::<()>();
     let (egress_tx, mut egress_rx) = hydroflow::util::unbounded_channel();
@@ -25,4 +25,47 @@ pub fn test_basic() {
 
     let out: Vec<_> = collect_ready(&mut egress_rx);
     assert_eq!(out, vec![(1, ()), (2, ()), (3, ())]);
+}
+
+#[multiplatform_test(test, wasm, env_tracing)]
+pub fn test_union_defer_tick() {
+    let (cross_tx, cross_rx) = hydroflow::util::unbounded_channel::<i32>();
+    let (egress_tx, mut egress_rx) = hydroflow::util::unbounded_channel();
+
+    let mut df = hydroflow_syntax! {
+        teed_in = source_stream(cross_rx) -> sort() -> tee();
+        teed_in -> [input]join;
+
+        deferred_stream -> defer_tick_lazy() -> [0]unioned_stream;
+
+        persisted_stream = source_iter([0]) -> persist::<'static>();
+        persisted_stream -> [1]unioned_stream;
+
+        unioned_stream = union();
+        unioned_stream -> [single]join;
+
+        join = cross_singleton() -> tee();
+
+        join -> for_each(|x| egress_tx.send(x).unwrap());
+
+        folded_thing = join -> fold(|| 0, |_, _| {});
+
+        teed_in -> [input]joined_folded;
+        folded_thing -> [single]joined_folded;
+        joined_folded = cross_singleton();
+        deferred_stream = joined_folded -> fold(|| 0, |_, _| {}) -> flat_map(|_| []);
+    };
+    assert_graphvis_snapshots!(df);
+
+    df.run_available();
+    let out: Vec<_> = collect_ready(&mut egress_rx);
+    assert_eq!(out, vec![]);
+
+    cross_tx.send(1).unwrap();
+    cross_tx.send(2).unwrap();
+    cross_tx.send(3).unwrap();
+    df.run_available();
+
+    let out: Vec<_> = collect_ready(&mut egress_rx);
+    assert_eq!(out, vec![(1, 0), (2, 0), (3, 0)]);
 }

--- a/hydroflow_lang/src/graph/ops/cross_singleton.rs
+++ b/hydroflow_lang/src/graph/ops/cross_singleton.rs
@@ -2,8 +2,8 @@ use quote::{quote_spanned, ToTokens};
 use syn::parse_quote;
 
 use super::{
-    DelayType, OperatorCategory, OperatorConstraints,
-    OperatorWriteOutput, WriteContextArgs, RANGE_0, RANGE_1,
+    DelayType, OperatorCategory, OperatorConstraints, OperatorWriteOutput, WriteContextArgs,
+    RANGE_0, RANGE_1,
 };
 use crate::graph::PortIndexValue;
 
@@ -48,6 +48,8 @@ pub const CROSS_SINGLETON: OperatorConstraints = OperatorConstraints {
         _else => None,
     },
     write_fn: |wc @ &WriteContextArgs {
+                   context,
+                   hydroflow,
                    ident,
                    op_span,
                    inputs,
@@ -59,18 +61,29 @@ pub const CROSS_SINGLETON: OperatorConstraints = OperatorConstraints {
 
         let input = &inputs[0];
         let singleton = &inputs[1];
-        let s_taken_ident = wc.make_ident("singleton_taken");
-        let singleton_value_ident = wc.make_ident("singleton_value");
+        let singleton_handle_ident = wc.make_ident("singleton_handle");
+
+        let write_prologue = quote_spanned! {op_span=>
+            let #singleton_handle_ident = #hydroflow.add_state(
+                ::std::cell::RefCell::new(::std::option::Option::None)
+            );
+            // Reset the value if it is a new tick.
+            #hydroflow.set_state_tick_hook(#singleton_handle_ident, |rcell| { rcell.take(); });
+        };
 
         let write_iterator = quote_spanned! {op_span=>
-            let mut #s_taken_ident = #singleton;
-            let #ident = #s_taken_ident.next().map(|#singleton_value_ident| {
-                #input.map(move |x| (x, ::std::clone::Clone::clone(&#singleton_value_ident)))
-            }).into_iter().flatten();
+            let #ident = {
+                let mut singleton_state_mut = #context.state_ref(#singleton_handle_ident).borrow_mut();
+                let first = { #singleton }.next();
+                *singleton_state_mut = singleton_state_mut.take().or(first);
+                singleton_state_mut.as_ref().cloned().map(|singleton_value| {
+                    #input.map(move |item| (item, ::std::clone::Clone::clone(&singleton_value)))
+                }).into_iter().flatten()
+            };
         };
 
         Ok(OperatorWriteOutput {
-            write_prologue: Default::default(),
+            write_prologue,
             write_iterator,
             ..Default::default()
         })

--- a/hydroflow_lang/src/graph/ops/cross_singleton.rs
+++ b/hydroflow_lang/src/graph/ops/cross_singleton.rs
@@ -59,8 +59,8 @@ pub const CROSS_SINGLETON: OperatorConstraints = OperatorConstraints {
                _diagnostics| {
         assert!(is_pull);
 
-        let input = &inputs[0];
-        let singleton = &inputs[1];
+        let stream_input = &inputs[0];
+        let singleton_input = &inputs[1];
         let singleton_handle_ident = wc.make_ident("singleton_handle");
 
         let write_prologue = quote_spanned! {op_span=>
@@ -73,12 +73,35 @@ pub const CROSS_SINGLETON: OperatorConstraints = OperatorConstraints {
 
         let write_iterator = quote_spanned! {op_span=>
             let #ident = {
-                let mut singleton_state_mut = #context.state_ref(#singleton_handle_ident).borrow_mut();
-                let first = { #singleton }.next();
-                *singleton_state_mut = singleton_state_mut.take().or(first);
-                singleton_state_mut.as_ref().cloned().map(|singleton_value| {
-                    #input.map(move |item| (item, ::std::clone::Clone::clone(&singleton_value)))
-                }).into_iter().flatten()
+                #[inline(always)]
+                fn cross_singleton_guard<Singleton, Item>(
+                    mut singleton_state_mut: std::cell::RefMut<'_, Option<Singleton>>,
+                    mut singleton_input: impl Iterator<Item = Singleton>,
+                    stream_input: impl Iterator<Item = Item>,
+                ) -> impl Iterator<Item = (Item, Singleton)>
+                where
+                    Singleton: ::std::clone::Clone,
+                {
+                    let singleton_value_opt = match &*singleton_state_mut {
+                        ::std::option::Option::Some(singleton_value) => Some(singleton_value.clone()),
+                        ::std::option::Option::None => {
+                            let singleton_value_opt = singleton_input.next();
+                            *singleton_state_mut = singleton_value_opt.clone();
+                            singleton_value_opt
+                        }
+                    };
+                    singleton_value_opt
+                        .map(|singleton_value| {
+                            stream_input.map(move |item| (item, ::std::clone::Clone::clone(&singleton_value)))
+                        })
+                        .into_iter()
+                        .flatten()
+                }
+                cross_singleton_guard(
+                    #context.state_ref(#singleton_handle_ident).borrow_mut(),
+                    #singleton_input,
+                    #stream_input,
+                )
             };
         };
 


### PR DESCRIPTION
Adds the minimal reproducer test from @shadaj

Note this may have negative performance implications, as the singleton value now is stored in the state API (heap) instead of locally