### PR TITLE
refactor(hydroflow_plus): deduplicate some error messages and drop unused `Interval` IR node

### DIFF
--- a/hydroflow_plus/src/builder/mod.rs
+++ b/hydroflow_plus/src/builder/mod.rs
@@ -27,6 +27,8 @@ pub struct FlowStateInner {
 
 pub type FlowState = Rc<RefCell<FlowStateInner>>;
 
+pub const FLOW_USED_MESSAGE: &str = "Attempted to add a leaf to a flow that has already been finalized. No leaves can be added after the flow has been compiled.";
+
 pub struct FlowBuilder<'a> {
     flow_state: FlowState,
     nodes: RefCell<Vec<usize>>,

--- a/hydroflow_plus/src/ir.rs
+++ b/hydroflow_plus/src/ir.rs
@@ -69,7 +69,6 @@ pub enum HfPlusSource {
     Stream(DebugExpr),
     ExternalNetwork(),
     Iter(DebugExpr),
-    Interval(DebugExpr),
     Spin(),
 }
 
@@ -613,12 +612,6 @@ impl<'a> HfPlusNode {
                         HfPlusSource::Iter(expr) => {
                             parse_quote! {
                                 #source_ident = source_iter(#expr);
-                            }
-                        }
-
-                        HfPlusSource::Interval(expr) => {
-                            parse_quote! {
-                                #source_ident = source_interval(#expr);
                             }
                         }
 

--- a/hydroflow_plus/src/optional.rs
+++ b/hydroflow_plus/src/optional.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use stageleft::{q, IntoQuotedMut, Quoted};
 use syn::parse_quote;
 
-use crate::builder::FlowState;
+use crate::builder::{FlowState, FLOW_USED_MESSAGE};
 use crate::cycle::{CycleCollection, CycleComplete, DeferTick, ForwardRef, TickCycle};
 use crate::ir::{HfPlusLeaf, HfPlusNode, HfPlusSource, TeeNode};
 use crate::location::{check_matching_location, LocationId, NoTick};
@@ -64,11 +64,17 @@ impl<'a, T, N: Location<'a>> CycleCollection<'a, TickCycle> for Optional<T, Boun
 
 impl<'a, T, N: Location<'a>> CycleComplete<'a, TickCycle> for Optional<T, Bounded, Tick<N>> {
     fn complete(self, ident: syn::Ident) {
-        self.flow_state().clone().borrow_mut().leaves.as_mut().expect("Attempted to add a leaf to a flow that has already been finalized. No leaves can be added after the flow has been compiled.").push(HfPlusLeaf::CycleSink {
-            ident,
-            location_kind: self.location_kind(),
-            input: Box::new(self.ir_node.into_inner()),
-        });
+        self.flow_state()
+            .clone()
+            .borrow_mut()
+            .leaves
+            .as_mut()
+            .expect(FLOW_USED_MESSAGE)
+            .push(HfPlusLeaf::CycleSink {
+                ident,
+                location_kind: self.location_kind(),
+                input: Box::new(self.ir_node.into_inner()),
+            });
     }
 }
 
@@ -89,11 +95,17 @@ impl<'a, T, N: Location<'a>> CycleCollection<'a, ForwardRef> for Optional<T, Bou
 
 impl<'a, T, N: Location<'a>> CycleComplete<'a, ForwardRef> for Optional<T, Bounded, Tick<N>> {
     fn complete(self, ident: syn::Ident) {
-        self.flow_state().clone().borrow_mut().leaves.as_mut().expect("Attempted to add a leaf to a flow that has already been finalized. No leaves can be added after the flow has been compiled.").push(HfPlusLeaf::CycleSink {
-            ident,
-            location_kind: self.location_kind(),
-            input: Box::new(self.ir_node.into_inner()),
-        });
+        self.flow_state()
+            .clone()
+            .borrow_mut()
+            .leaves
+            .as_mut()
+            .expect(FLOW_USED_MESSAGE)
+            .push(HfPlusLeaf::CycleSink {
+                ident,
+                location_kind: self.location_kind(),
+                input: Box::new(self.ir_node.into_inner()),
+            });
     }
 }
 
@@ -114,11 +126,17 @@ impl<'a, T, W, N: Location<'a> + NoTick> CycleCollection<'a, ForwardRef> for Opt
 
 impl<'a, T, W, N: Location<'a> + NoTick> CycleComplete<'a, ForwardRef> for Optional<T, W, N> {
     fn complete(self, ident: syn::Ident) {
-        self.flow_state().clone().borrow_mut().leaves.as_mut().expect("Attempted to add a leaf to a flow that has already been finalized. No leaves can be added after the flow has been compiled.").push(HfPlusLeaf::CycleSink {
-            ident,
-            location_kind: self.location_kind(),
-            input: Box::new(HfPlusNode::Unpersist(Box::new(self.ir_node.into_inner()))),
-        });
+        self.flow_state()
+            .clone()
+            .borrow_mut()
+            .leaves
+            .as_mut()
+            .expect(FLOW_USED_MESSAGE)
+            .push(HfPlusLeaf::CycleSink {
+                ident,
+                location_kind: self.location_kind(),
+                input: Box::new(HfPlusNode::Unpersist(Box::new(self.ir_node.into_inner()))),
+            });
     }
 }
 

--- a/hydroflow_plus/src/singleton.rs
+++ b/hydroflow_plus/src/singleton.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 
 use stageleft::{q, IntoQuotedMut, Quoted};
 
-use crate::builder::FlowState;
+use crate::builder::{FlowState, FLOW_USED_MESSAGE};
 use crate::cycle::{
     CycleCollection, CycleCollectionWithInitial, CycleComplete, DeferTick, ForwardRef, TickCycle,
 };
@@ -73,11 +73,17 @@ impl<'a, T, N: Location<'a>> CycleCollectionWithInitial<'a, TickCycle>
 
 impl<'a, T, N: Location<'a>> CycleComplete<'a, TickCycle> for Singleton<T, Bounded, Tick<N>> {
     fn complete(self, ident: syn::Ident) {
-        self.flow_state().clone().borrow_mut().leaves.as_mut().expect("Attempted to add a leaf to a flow that has already been finalized. No leaves can be added after the flow has been compiled.").push(HfPlusLeaf::CycleSink {
-            ident,
-            location_kind: self.location_kind(),
-            input: Box::new(self.ir_node.into_inner()),
-        });
+        self.flow_state()
+            .clone()
+            .borrow_mut()
+            .leaves
+            .as_mut()
+            .expect(FLOW_USED_MESSAGE)
+            .push(HfPlusLeaf::CycleSink {
+                ident,
+                location_kind: self.location_kind(),
+                input: Box::new(self.ir_node.into_inner()),
+            });
     }
 }
 
@@ -98,11 +104,17 @@ impl<'a, T, N: Location<'a>> CycleCollection<'a, ForwardRef> for Singleton<T, Bo
 
 impl<'a, T, N: Location<'a>> CycleComplete<'a, ForwardRef> for Singleton<T, Bounded, Tick<N>> {
     fn complete(self, ident: syn::Ident) {
-        self.flow_state().clone().borrow_mut().leaves.as_mut().expect("Attempted to add a leaf to a flow that has already been finalized. No leaves can be added after the flow has been compiled.").push(HfPlusLeaf::CycleSink {
-            ident,
-            location_kind: self.location_kind(),
-            input: Box::new(self.ir_node.into_inner()),
-        });
+        self.flow_state()
+            .clone()
+            .borrow_mut()
+            .leaves
+            .as_mut()
+            .expect(FLOW_USED_MESSAGE)
+            .push(HfPlusLeaf::CycleSink {
+                ident,
+                location_kind: self.location_kind(),
+                input: Box::new(self.ir_node.into_inner()),
+            });
     }
 }
 


### PR DESCRIPTION
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydroflow/pull/1540).
* #1543
* #1542
* #1541
* __->__ #1540