### PR TITLE
refactor(hydroflow_plus)!: don't re-export all of `hydroflow`

### DIFF
--- a/hydroflow_plus/src/builder/compiled.rs
+++ b/hydroflow_plus/src/builder/compiled.rs
@@ -31,10 +31,10 @@ impl<'a> CompiledFlow<'a, usize> {
         let hydroflow_crate = proc_macro_crate::crate_name("hydroflow_plus")
             .expect("hydroflow_plus should be present in `Cargo.toml`");
         let root = match hydroflow_crate {
-            proc_macro_crate::FoundCrate::Itself => quote! { hydroflow_plus },
+            proc_macro_crate::FoundCrate::Itself => quote! { hydroflow_plus::hydroflow },
             proc_macro_crate::FoundCrate::Name(name) => {
                 let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
-                quote! { #ident }
+                quote! { #ident::hydroflow }
             }
         };
 
@@ -89,10 +89,10 @@ impl<'a> FreeVariable<Hydroflow<'a>> for CompiledFlow<'a, ()> {
         let hydroflow_crate = proc_macro_crate::crate_name("hydroflow_plus")
             .expect("hydroflow_plus should be present in `Cargo.toml`");
         let root = match hydroflow_crate {
-            proc_macro_crate::FoundCrate::Itself => quote! { hydroflow_plus },
+            proc_macro_crate::FoundCrate::Itself => quote! { hydroflow_plus::hydroflow },
             proc_macro_crate::FoundCrate::Name(name) => {
                 let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
-                quote! { #ident }
+                quote! { #ident::hydroflow }
             }
         };
 

--- a/hydroflow_plus/src/builder/deploy.rs
+++ b/hydroflow_plus/src/builder/deploy.rs
@@ -12,14 +12,16 @@ use stageleft::Quoted;
 
 use super::built::build_inner;
 use super::compiled::CompiledFlow;
-use crate::deploy::{ExternalSpec, IntoProcessSpec, LocalDeploy, Node, RegisterPort};
+use crate::deploy::{
+    ClusterSpec, Deploy, ExternalSpec, IntoProcessSpec, LocalDeploy, Node, ProcessSpec,
+    RegisterPort,
+};
 use crate::ir::HfPlusLeaf;
 use crate::location::external_process::{
     ExternalBincodeSink, ExternalBincodeStream, ExternalBytesPort,
 };
-use crate::location::{ExternalProcess, Location, LocationId};
+use crate::location::{Cluster, ExternalProcess, Location, LocationId, Process};
 use crate::staging_util::Invariant;
-use crate::{Cluster, ClusterSpec, Deploy, Process, ProcessSpec};
 
 pub struct DeployFlow<'a, D: LocalDeploy<'a>> {
     pub(super) ir: Vec<HfPlusLeaf>,

--- a/hydroflow_plus/src/builder/mod.rs
+++ b/hydroflow_plus/src/builder/mod.rs
@@ -7,11 +7,11 @@ use compiled::CompiledFlow;
 use deploy::{DeployFlow, DeployResult};
 use stageleft::*;
 
-use crate::deploy::{ExternalSpec, IntoProcessSpec, LocalDeploy};
+use crate::deploy::{ClusterSpec, Deploy, ExternalSpec, IntoProcessSpec, LocalDeploy};
 use crate::ir::HfPlusLeaf;
 use crate::location::{Cluster, ExternalProcess, Process};
 use crate::staging_util::Invariant;
-use crate::{ClusterSpec, Deploy, RuntimeContext};
+use crate::RuntimeContext;
 
 pub mod built;
 pub mod compiled;

--- a/hydroflow_plus/src/deploy/macro_runtime.rs
+++ b/hydroflow_plus/src/deploy/macro_runtime.rs
@@ -1,13 +1,16 @@
 use std::cell::RefCell;
+use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
 
+use hydroflow::bytes::Bytes;
+use hydroflow::futures::{Sink, Stream};
 use hydroflow::util::deploy::DeployPorts;
+use hydroflow_lang::graph::HydroflowGraph;
 use stageleft::{Quoted, RuntimeData};
 
 use super::HydroflowPlusMeta;
 use crate::deploy::{ClusterSpec, Deploy, ExternalSpec, Node, ProcessSpec, RegisterPort};
-use crate::lang::graph::HydroflowGraph;
 
 pub struct DeployRuntime {}
 
@@ -197,9 +200,7 @@ impl<'a> RegisterPort<'a, DeployRuntime> for DeployRuntimeNode {
     fn as_bytes_sink(
         &self,
         _key: usize,
-    ) -> impl std::future::Future<
-        Output = Pin<Box<dyn crate::futures::Sink<crate::bytes::Bytes, Error = std::io::Error>>>,
-    > + 'a {
+    ) -> impl Future<Output = Pin<Box<dyn Sink<Bytes, Error = std::io::Error>>>> + 'a {
         async { panic!() }
     }
 
@@ -210,9 +211,7 @@ impl<'a> RegisterPort<'a, DeployRuntime> for DeployRuntimeNode {
     fn as_bincode_sink<T: serde::Serialize + 'static>(
         &self,
         _key: usize,
-    ) -> impl std::future::Future<
-        Output = Pin<Box<dyn crate::futures::Sink<T, Error = std::io::Error>>>,
-    > + 'a {
+    ) -> impl Future<Output = Pin<Box<dyn Sink<T, Error = std::io::Error>>>> + 'a {
         async { panic!() }
     }
 
@@ -223,9 +222,7 @@ impl<'a> RegisterPort<'a, DeployRuntime> for DeployRuntimeNode {
     fn as_bytes_source(
         &self,
         _key: usize,
-    ) -> impl std::future::Future<
-        Output = Pin<Box<dyn hydroflow::futures::Stream<Item = hydroflow::bytes::Bytes>>>,
-    > + 'a {
+    ) -> impl Future<Output = Pin<Box<dyn Stream<Item = Bytes>>>> + 'a {
         async { panic!() }
     }
 
@@ -236,8 +233,7 @@ impl<'a> RegisterPort<'a, DeployRuntime> for DeployRuntimeNode {
     fn as_bincode_source<T: serde::de::DeserializeOwned + 'static>(
         &self,
         _key: usize,
-    ) -> impl std::future::Future<Output = Pin<Box<dyn hydroflow::futures::Stream<Item = T>>>> + 'a
-    {
+    ) -> impl Future<Output = Pin<Box<dyn Stream<Item = T>>>> + 'a {
         async { panic!() }
     }
 }

--- a/hydroflow_plus/src/lib.rs
+++ b/hydroflow_plus/src/lib.rs
@@ -2,8 +2,8 @@
 
 stageleft::stageleft_no_entry_crate!();
 
+pub use hydroflow;
 pub use hydroflow::scheduled::graph::Hydroflow;
-pub use hydroflow::*;
 pub use stageleft::*;
 
 pub mod runtime_support {
@@ -26,7 +26,6 @@ pub mod location;
 pub use location::{Cluster, ClusterId, Location, Process, Tick};
 
 pub mod deploy;
-pub use deploy::{ClusterSpec, Deploy, ProcessSpec};
 
 pub mod cycle;
 

--- a/hydroflow_plus_test_local/src/local/chat_app.rs
+++ b/hydroflow_plus_test_local/src/local/chat_app.rs
@@ -1,8 +1,7 @@
+use hydroflow::tokio::sync::mpsc::UnboundedSender;
+use hydroflow::tokio_stream::wrappers::UnboundedReceiverStream;
 use hydroflow_plus::deploy::SingleProcessGraph;
-use hydroflow_plus::tokio::sync::mpsc::UnboundedSender;
-use hydroflow_plus::tokio_stream::wrappers::UnboundedReceiverStream;
 use hydroflow_plus::*;
-use stageleft::{q, Quoted, RuntimeData};
 
 #[stageleft::entry]
 pub fn chat_app<'a>(
@@ -44,14 +43,14 @@ pub fn chat_app<'a>(
 #[stageleft::runtime]
 #[cfg(test)]
 mod tests {
-    use hydroflow_plus::assert_graphvis_snapshots;
-    use hydroflow_plus::util::collect_ready;
+    use hydroflow::assert_graphvis_snapshots;
+    use hydroflow::util::collect_ready;
 
     #[test]
     fn test_chat_app_no_replay() {
-        let (users_send, users) = hydroflow_plus::util::unbounded_channel();
-        let (messages_send, messages) = hydroflow_plus::util::unbounded_channel();
-        let (out, mut out_recv) = hydroflow_plus::util::unbounded_channel();
+        let (users_send, users) = hydroflow::util::unbounded_channel();
+        let (messages_send, messages) = hydroflow::util::unbounded_channel();
+        let (out, mut out_recv) = hydroflow::util::unbounded_channel();
 
         let mut chat_server = super::chat_app!(users, messages, &out, false);
         assert_graphvis_snapshots!(chat_server);
@@ -92,9 +91,9 @@ mod tests {
 
     #[test]
     fn test_chat_app_replay() {
-        let (users_send, users) = hydroflow_plus::util::unbounded_channel();
-        let (messages_send, messages) = hydroflow_plus::util::unbounded_channel();
-        let (out, mut out_recv) = hydroflow_plus::util::unbounded_channel();
+        let (users_send, users) = hydroflow::util::unbounded_channel();
+        let (messages_send, messages) = hydroflow::util::unbounded_channel();
+        let (out, mut out_recv) = hydroflow::util::unbounded_channel();
 
         let mut chat_server = super::chat_app!(users, messages, &out, true);
         assert_graphvis_snapshots!(chat_server);

--- a/hydroflow_plus_test_local/src/local/count_elems.rs
+++ b/hydroflow_plus_test_local/src/local/count_elems.rs
@@ -1,8 +1,7 @@
+use hydroflow::tokio::sync::mpsc::UnboundedSender;
+use hydroflow::tokio_stream::wrappers::UnboundedReceiverStream;
 use hydroflow_plus::deploy::SingleProcessGraph;
-use hydroflow_plus::tokio::sync::mpsc::UnboundedSender;
-use hydroflow_plus::tokio_stream::wrappers::UnboundedReceiverStream;
 use hydroflow_plus::*;
-use stageleft::{q, Quoted, RuntimeData};
 
 pub fn count_elems_generic<'a, T: 'a>(
     flow: FlowBuilder<'a>,
@@ -38,13 +37,13 @@ pub fn count_elems<'a>(
 #[stageleft::runtime]
 #[cfg(test)]
 mod tests {
-    use hydroflow_plus::assert_graphvis_snapshots;
-    use hydroflow_plus::util::collect_ready;
+    use hydroflow::assert_graphvis_snapshots;
+    use hydroflow::util::collect_ready;
 
     #[test]
     pub fn test_count() {
-        let (in_send, input) = hydroflow_plus::util::unbounded_channel();
-        let (out, mut out_recv) = hydroflow_plus::util::unbounded_channel();
+        let (in_send, input) = hydroflow::util::unbounded_channel();
+        let (out, mut out_recv) = hydroflow::util::unbounded_channel();
 
         let mut count = super::count_elems!(input, &out);
         assert_graphvis_snapshots!(count);

--- a/hydroflow_plus_test_local/src/local/graph_reachability.rs
+++ b/hydroflow_plus_test_local/src/local/graph_reachability.rs
@@ -1,6 +1,6 @@
+use hydroflow::tokio::sync::mpsc::UnboundedSender;
+use hydroflow::tokio_stream::wrappers::UnboundedReceiverStream;
 use hydroflow_plus::deploy::SingleProcessGraph;
-use hydroflow_plus::tokio::sync::mpsc::UnboundedSender;
-use hydroflow_plus::tokio_stream::wrappers::UnboundedReceiverStream;
 use hydroflow_plus::*;
 
 #[stageleft::entry]
@@ -35,14 +35,14 @@ pub fn graph_reachability<'a>(
 #[stageleft::runtime]
 #[cfg(test)]
 mod tests {
-    use hydroflow_plus::assert_graphvis_snapshots;
-    use hydroflow_plus::util::collect_ready;
+    use hydroflow::assert_graphvis_snapshots;
+    use hydroflow::util::collect_ready;
 
     #[test]
     pub fn test_reachability() {
-        let (roots_send, roots) = hydroflow_plus::util::unbounded_channel();
-        let (edges_send, edges) = hydroflow_plus::util::unbounded_channel();
-        let (out, mut out_recv) = hydroflow_plus::util::unbounded_channel();
+        let (roots_send, roots) = hydroflow::util::unbounded_channel();
+        let (edges_send, edges) = hydroflow::util::unbounded_channel();
+        let (out, mut out_recv) = hydroflow::util::unbounded_channel();
 
         let mut reachability = super::graph_reachability!(roots, edges, &out);
         assert_graphvis_snapshots!(reachability);

--- a/hydroflow_plus_test_local/src/local/negation.rs
+++ b/hydroflow_plus_test_local/src/local/negation.rs
@@ -1,7 +1,6 @@
+use hydroflow::tokio::sync::mpsc::UnboundedSender;
 use hydroflow_plus::deploy::SingleProcessGraph;
-use hydroflow_plus::tokio::sync::mpsc::UnboundedSender;
 use hydroflow_plus::*;
-use stageleft::{q, Quoted, RuntimeData};
 
 #[stageleft::entry]
 pub fn test_difference<'a>(
@@ -63,12 +62,12 @@ pub fn test_anti_join<'a>(
 #[stageleft::runtime]
 #[cfg(test)]
 mod tests {
-    use hydroflow_plus::assert_graphvis_snapshots;
-    use hydroflow_plus::util::collect_ready;
+    use hydroflow::assert_graphvis_snapshots;
+    use hydroflow::util::collect_ready;
 
     #[test]
     fn test_difference_tick_tick() {
-        let (out, mut out_recv) = hydroflow_plus::util::unbounded_channel();
+        let (out, mut out_recv) = hydroflow::util::unbounded_channel();
 
         let mut flow = super::test_difference!(&out, false, false);
         assert_graphvis_snapshots!(flow);
@@ -84,7 +83,7 @@ mod tests {
 
     #[test]
     fn test_difference_tick_static() {
-        let (out, mut out_recv) = hydroflow_plus::util::unbounded_channel();
+        let (out, mut out_recv) = hydroflow::util::unbounded_channel();
 
         let mut flow = super::test_difference!(&out, false, true);
         assert_graphvis_snapshots!(flow);
@@ -100,7 +99,7 @@ mod tests {
 
     #[test]
     fn test_difference_static_tick() {
-        let (out, mut out_recv) = hydroflow_plus::util::unbounded_channel();
+        let (out, mut out_recv) = hydroflow::util::unbounded_channel();
 
         let mut flow = super::test_difference!(&out, true, false);
         assert_graphvis_snapshots!(flow);
@@ -119,7 +118,7 @@ mod tests {
 
     #[test]
     fn test_difference_static_static() {
-        let (out, mut out_recv) = hydroflow_plus::util::unbounded_channel();
+        let (out, mut out_recv) = hydroflow::util::unbounded_channel();
 
         let mut flow = super::test_difference!(&out, true, true);
         assert_graphvis_snapshots!(flow);
@@ -135,7 +134,7 @@ mod tests {
 
     #[test]
     fn test_anti_join_tick_tick() {
-        let (out, mut out_recv) = hydroflow_plus::util::unbounded_channel();
+        let (out, mut out_recv) = hydroflow::util::unbounded_channel();
 
         let mut flow = super::test_anti_join!(&out, false, false);
         assert_graphvis_snapshots!(flow);
@@ -151,7 +150,7 @@ mod tests {
 
     #[test]
     fn test_anti_join_tick_static() {
-        let (out, mut out_recv) = hydroflow_plus::util::unbounded_channel();
+        let (out, mut out_recv) = hydroflow::util::unbounded_channel();
 
         let mut flow = super::test_anti_join!(&out, false, true);
         assert_graphvis_snapshots!(flow);
@@ -167,7 +166,7 @@ mod tests {
 
     #[test]
     fn test_anti_join_static_tick() {
-        let (out, mut out_recv) = hydroflow_plus::util::unbounded_channel();
+        let (out, mut out_recv) = hydroflow::util::unbounded_channel();
 
         let mut flow = super::test_anti_join!(&out, true, false);
         assert_graphvis_snapshots!(flow);
@@ -186,7 +185,7 @@ mod tests {
 
     #[test]
     fn test_anti_join_static_static() {
-        let (out, mut out_recv) = hydroflow_plus::util::unbounded_channel();
+        let (out, mut out_recv) = hydroflow::util::unbounded_channel();
 
         let mut flow = super::test_anti_join!(&out, true, true);
         assert_graphvis_snapshots!(flow);

--- a/hydroflow_plus_test_local/src/local/teed_join.rs
+++ b/hydroflow_plus_test_local/src/local/teed_join.rs
@@ -1,9 +1,8 @@
+use hydroflow::futures::stream::Stream;
+use hydroflow::tokio::sync::mpsc::UnboundedSender;
+use hydroflow::tokio_stream::wrappers::UnboundedReceiverStream;
 use hydroflow_plus::deploy::MultiGraph;
-use hydroflow_plus::futures::stream::Stream;
-use hydroflow_plus::tokio::sync::mpsc::UnboundedSender;
-use hydroflow_plus::tokio_stream::wrappers::UnboundedReceiverStream;
 use hydroflow_plus::*;
-use stageleft::{q, Quoted, RuntimeData};
 
 struct N0 {}
 struct N1 {}
@@ -48,13 +47,13 @@ pub fn teed_join<'a, S: Stream<Item = u32> + Unpin + 'a>(
 #[stageleft::runtime]
 #[cfg(test)]
 mod tests {
-    use hydroflow_plus::assert_graphvis_snapshots;
-    use hydroflow_plus::util::collect_ready;
+    use hydroflow::assert_graphvis_snapshots;
+    use hydroflow::util::collect_ready;
 
     #[test]
     fn test_teed_join() {
-        let (in_send, input) = hydroflow_plus::util::unbounded_channel();
-        let (out, mut out_recv) = hydroflow_plus::util::unbounded_channel();
+        let (in_send, input) = hydroflow::util::unbounded_channel();
+        let (out, mut out_recv) = hydroflow::util::unbounded_channel();
 
         let mut joined = super::teed_join!(input, &out, false, 0);
         assert_graphvis_snapshots!(joined);
@@ -71,8 +70,8 @@ mod tests {
 
     #[test]
     fn test_teed_join_twice() {
-        let (in_send, input) = hydroflow_plus::util::unbounded_channel();
-        let (out, mut out_recv) = hydroflow_plus::util::unbounded_channel();
+        let (in_send, input) = hydroflow::util::unbounded_channel();
+        let (out, mut out_recv) = hydroflow::util::unbounded_channel();
 
         let mut joined = super::teed_join!(input, &out, true, 0);
         assert_graphvis_snapshots!(joined);
@@ -89,8 +88,8 @@ mod tests {
 
     #[test]
     fn test_teed_join_multi_node() {
-        let (_, input) = hydroflow_plus::util::unbounded_channel();
-        let (out, mut out_recv) = hydroflow_plus::util::unbounded_channel();
+        let (_, input) = hydroflow::util::unbounded_channel();
+        let (out, mut out_recv) = hydroflow::util::unbounded_channel();
 
         let mut joined = super::teed_join!(input, &out, true, 1);
         assert_graphvis_snapshots!(joined);

--- a/template/hydroflow_plus/src/first_ten_distributed.rs
+++ b/template/hydroflow_plus/src/first_ten_distributed.rs
@@ -12,7 +12,7 @@ pub fn first_ten_distributed<'a>(p1: &Process<'a, P1>, p2: &Process<'a, P2>) {
 mod tests {
     use hydro_deploy::Deployment;
     use hydroflow_plus::deploy::DeployCrateWrapper;
-    use hydroflow_plus::futures::StreamExt;
+    use hydroflow_plus::hydroflow::futures::StreamExt;
     use tokio_stream::wrappers::UnboundedReceiverStream;
 
     #[tokio::test]


### PR DESCRIPTION

Reduces namespace pollution when wildcard-importing `hydroflow_plus`.
