### PR TITLE
feat(hydro_deploy): use regular println when no tasks are active

### DIFF
--- a/hydro_deploy/core/src/progress.rs
+++ b/hydro_deploy/core/src/progress.rs
@@ -370,7 +370,9 @@ impl ProgressTracker {
             .lock()
             .unwrap();
 
-        if progress_bar.multi_progress.println(msg.as_ref()).is_err() {
+        if progress_bar.current_count == 0
+            || progress_bar.multi_progress.println(msg.as_ref()).is_err()
+        {
             println!("{}", msg.as_ref());
         }
     }


### PR DESCRIPTION

Significantly improves the appearance of Hydroflow+ logs when the terminal causes wrapping.
