### PR TITLE
fix(docs): use async API required by Mermaid v10

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -28,10 +28,11 @@
         "@docusaurus/module-type-aliases": "^3.6.1"
       },
       "engines": {
-        "node": ">=16.14"
+        "node": ">=18.0"
       }
     },
     "../website_playground/pkg": {
+      "name": "website_playground",
       "version": "0.0.0"
     },
     "node_modules/@algolia/autocomplete-core": {

--- a/docs/src/pages/playground.js
+++ b/docs/src/pages/playground.js
@@ -39,7 +39,7 @@ import styles from "./playground.module.css";
 function MermaidGraph({ id, source }) {
   const [svg, setSvg] = useState({ __html: 'Loading Mermaid graph...' });
   useEffect(() => {
-    mermaid.render(id, source, svg => {
+    mermaid.render(id, source).then(({ svg }) => {
       setSvg({
         __html: svg,
       });


### PR DESCRIPTION

Docusaurus v3 broke Mermaid in the playground due to an API change.
