### PR TITLE
refactor(hydroflow_plus)!: further reduce namespace pollution

### DIFF
--- a/hydroflow_plus/src/deploy/trybuild.rs
+++ b/hydroflow_plus/src/deploy/trybuild.rs
@@ -107,7 +107,7 @@ pub fn compile_graph_trybuild(graph: HydroflowGraph, extra_stmts: Vec<syn::Stmt>
         use hydroflow_plus::*;
 
         #[allow(unused)]
-        fn __hfplus_runtime<'a>(__hydroflow_plus_trybuild_cli: &'a hydroflow_plus::hydroflow::util::deploy::DeployPorts<hydroflow_plus::deploy::HydroflowPlusMeta>) -> hydroflow_plus::Hydroflow<'a> {
+        fn __hfplus_runtime<'a>(__hydroflow_plus_trybuild_cli: &'a hydroflow_plus::hydroflow::util::deploy::DeployPorts<hydroflow_plus::deploy::HydroflowPlusMeta>) -> hydroflow_plus::hydroflow::scheduled::graph::Hydroflow<'a> {
             #(#extra_stmts)*
             #tokens
         }

--- a/hydroflow_plus/src/lib.rs
+++ b/hydroflow_plus/src/lib.rs
@@ -3,9 +3,9 @@
 stageleft::stageleft_no_entry_crate!();
 
 pub use hydroflow;
-pub use hydroflow::scheduled::graph::Hydroflow;
-pub use stageleft::*;
+pub use stageleft::q;
 
+#[doc(hidden)]
 pub mod runtime_support {
     pub use bincode;
 }
@@ -17,7 +17,7 @@ pub mod boundedness;
 pub use boundedness::{Bounded, Unbounded};
 
 pub mod stream;
-pub use stream::Stream;
+pub use stream::{NoOrder, Stream, TotalOrder};
 
 pub mod singleton;
 pub use singleton::Singleton;
@@ -27,7 +27,7 @@ pub use optional::Optional;
 
 pub mod location;
 pub use location::cluster::CLUSTER_SELF_ID;
-pub use location::{Cluster, ClusterId, Location, Process, Tick};
+pub use location::{Cluster, ClusterId, ExternalProcess, Location, Process, Tick, Timestamped};
 
 pub mod deploy;
 

--- a/hydroflow_plus/src/location/mod.rs
+++ b/hydroflow_plus/src/location/mod.rs
@@ -25,7 +25,7 @@ pub mod can_send;
 pub use can_send::CanSend;
 
 pub mod tick;
-pub use tick::{NoTick, Tick};
+pub use tick::{NoTick, Tick, Timestamped};
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum LocationId {

--- a/hydroflow_plus_test/src/cluster/paxos.rs
+++ b/hydroflow_plus_test/src/cluster/paxos.rs
@@ -4,10 +4,8 @@ use std::hash::Hash;
 use std::time::Duration;
 
 use hydroflow_plus::*;
-use location::tick::Timestamped;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use stream::NoOrder;
 
 use super::quorum::{collect_quorum, collect_quorum_with_response};
 use super::request_response::join_responses;

--- a/hydroflow_plus_test/src/cluster/paxos_bench.rs
+++ b/hydroflow_plus_test/src/cluster/paxos_bench.rs
@@ -3,7 +3,6 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use hydroflow_plus::*;
-use stream::{NoOrder, TotalOrder};
 use tokio::time::Instant;
 
 use super::paxos::{Acceptor, Ballot, Proposer};

--- a/hydroflow_plus_test/src/cluster/paxos_kv.rs
+++ b/hydroflow_plus_test/src/cluster/paxos_kv.rs
@@ -5,7 +5,6 @@ use std::hash::Hash;
 use hydroflow_plus::*;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use stream::NoOrder;
 
 use super::paxos::{paxos_core, Acceptor, Ballot, Proposer};
 

--- a/hydroflow_plus_test/src/cluster/quorum.rs
+++ b/hydroflow_plus_test/src/cluster/quorum.rs
@@ -1,7 +1,6 @@
 use std::hash::Hash;
 
 use hydroflow_plus::*;
-use location::tick::Timestamped;
 use location::NoTick;
 
 #[expect(clippy::type_complexity, reason = "internal paxos code // TODO")]

--- a/hydroflow_plus_test/src/cluster/request_response.rs
+++ b/hydroflow_plus_test/src/cluster/request_response.rs
@@ -1,9 +1,7 @@
 use std::hash::Hash;
 
 use hydroflow_plus::*;
-use location::tick::Timestamped;
 use location::NoTick;
-use stream::NoOrder;
 
 type JoinResponses<K, M, V, L> = Stream<(K, (M, V)), Timestamped<L>, Unbounded, NoOrder>;
 

--- a/hydroflow_plus_test/src/distributed/first_ten.rs
+++ b/hydroflow_plus_test/src/distributed/first_ten.rs
@@ -1,6 +1,5 @@
 use hydroflow_plus::*;
 use location::external_process::ExternalBincodeSink;
-use location::ExternalProcess;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]

--- a/hydroflow_plus_test_local/src/local/chat_app.rs
+++ b/hydroflow_plus_test_local/src/local/chat_app.rs
@@ -1,7 +1,9 @@
 use hydroflow::tokio::sync::mpsc::UnboundedSender;
 use hydroflow::tokio_stream::wrappers::UnboundedReceiverStream;
 use hydroflow_plus::deploy::SingleProcessGraph;
+use hydroflow_plus::hydroflow::scheduled::graph::Hydroflow;
 use hydroflow_plus::*;
+use stageleft::{Quoted, RuntimeData};
 
 #[stageleft::entry]
 pub fn chat_app<'a>(

--- a/hydroflow_plus_test_local/src/local/compute_pi.rs
+++ b/hydroflow_plus_test_local/src/local/compute_pi.rs
@@ -1,7 +1,9 @@
 use std::time::Duration;
 
 use hydroflow_plus::deploy::SingleProcessGraph;
+use hydroflow_plus::hydroflow::scheduled::graph::Hydroflow;
 use hydroflow_plus::*;
+use stageleft::{Quoted, RuntimeData};
 
 pub fn compute_pi<'a>(flow: &FlowBuilder<'a>, batch_size: RuntimeData<usize>) -> Process<'a, ()> {
     let process = flow.process();

--- a/hydroflow_plus_test_local/src/local/count_elems.rs
+++ b/hydroflow_plus_test_local/src/local/count_elems.rs
@@ -1,13 +1,15 @@
 use hydroflow::tokio::sync::mpsc::UnboundedSender;
 use hydroflow::tokio_stream::wrappers::UnboundedReceiverStream;
 use hydroflow_plus::deploy::SingleProcessGraph;
+use hydroflow_plus::hydroflow::scheduled::graph::Hydroflow;
 use hydroflow_plus::*;
+use stageleft::{Quoted, RuntimeData};
 
 pub fn count_elems_generic<'a, T: 'a>(
     flow: FlowBuilder<'a>,
     input_stream: RuntimeData<UnboundedReceiverStream<T>>,
     output: RuntimeData<&'a UnboundedSender<u32>>,
-) -> impl QuotedWithContext<'a, Hydroflow<'a>, ()> {
+) -> impl Quoted<'a, Hydroflow<'a>> {
     let process = flow.process::<()>();
     let tick = process.tick();
 

--- a/hydroflow_plus_test_local/src/local/first_ten.rs
+++ b/hydroflow_plus_test_local/src/local/first_ten.rs
@@ -1,5 +1,7 @@
 use hydroflow_plus::deploy::SingleProcessGraph;
+use hydroflow_plus::hydroflow::scheduled::graph::Hydroflow;
 use hydroflow_plus::*;
+use stageleft::Quoted;
 
 pub fn first_ten(flow: &FlowBuilder) {
     let process = flow.process::<()>();

--- a/hydroflow_plus_test_local/src/local/graph_reachability.rs
+++ b/hydroflow_plus_test_local/src/local/graph_reachability.rs
@@ -1,8 +1,9 @@
 use hydroflow::tokio::sync::mpsc::UnboundedSender;
 use hydroflow::tokio_stream::wrappers::UnboundedReceiverStream;
 use hydroflow_plus::deploy::SingleProcessGraph;
+use hydroflow_plus::hydroflow::scheduled::graph::Hydroflow;
 use hydroflow_plus::*;
-use stream::NoOrder;
+use stageleft::{Quoted, RuntimeData};
 
 #[stageleft::entry]
 pub fn graph_reachability<'a>(

--- a/hydroflow_plus_test_local/src/local/negation.rs
+++ b/hydroflow_plus_test_local/src/local/negation.rs
@@ -1,6 +1,8 @@
 use hydroflow::tokio::sync::mpsc::UnboundedSender;
 use hydroflow_plus::deploy::SingleProcessGraph;
+use hydroflow_plus::hydroflow::scheduled::graph::Hydroflow;
 use hydroflow_plus::*;
+use stageleft::{Quoted, RuntimeData};
 
 #[stageleft::entry]
 pub fn test_difference<'a>(

--- a/hydroflow_plus_test_local/src/local/teed_join.rs
+++ b/hydroflow_plus_test_local/src/local/teed_join.rs
@@ -2,7 +2,9 @@ use hydroflow::futures::stream::Stream;
 use hydroflow::tokio::sync::mpsc::UnboundedSender;
 use hydroflow::tokio_stream::wrappers::UnboundedReceiverStream;
 use hydroflow_plus::deploy::MultiGraph;
+use hydroflow_plus::hydroflow::scheduled::graph::Hydroflow;
 use hydroflow_plus::*;
+use stageleft::{Quoted, RuntimeData};
 
 struct N0 {}
 struct N1 {}


### PR DESCRIPTION

Some re-exports are only useful for the macro-based API, which is deprecated in favor of trybuild anyways.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/hydroflow/pull/1589).
* #1590
* __->__ #1589