### PR TITLE
build!: compile and run CI on stable, fix #1587

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,12 +1,8 @@
 [build]
 rustflags = [
-    "-Zproc-macro-backtrace",
     # Flag to make build.rs scripts generate docs. Should only be used in this repository
     # internally, not by dependants.
     '--cfg=HYDROFLOW_GENERATE_DOCS',
-    # https://github.com/rust-lang/rust-clippy/issues/10087
-    ## TODO(mingwei): Need rust-analyzer support:
-    # "-Aclippy::uninlined-format-args",
 ]
 
 [target.x86_64-apple-darwin]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        rust_release: [pinned-nightly, latest-nightly]
+        rust_release: [pinned-nightly, latest-stable]
         exclude:
           # For non-pull requests, event_name != 'pull_request' will be true, and 'nothing' is
           # truthy, so the entire && operator will resolve to 'nothing'. Then the || operator will
           # resolve to 'nothing' so we will exclude 'nothing'. https://stackoverflow.com/a/73822998
           - rust_release: ${{ (needs.pre_job.outputs.should_skip != 'true' && 'nothing') || 'pinned-nightly' }}
-          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-nightly' }}
+          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-stable' }}
 
     env:
       CARGO_TERM_COLOR: always
@@ -55,12 +55,12 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install nightly toolchain
+      - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
-          override: ${{ matrix.rust_release == 'latest-nightly' }}
+          toolchain: stable
+          override: ${{ matrix.rust_release == 'latest-stable' }}
           components: rustfmt, clippy
 
       - name: Run sccache-cache
@@ -96,25 +96,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_release: [pinned-nightly, latest-nightly]
+        rust_release: [pinned-nightly, latest-stable]
         exclude:
           # For non-pull requests, event_name != 'pull_request' will be true, and 'nothing' is
           # truthy, so the entire && operator will resolve to 'nothing'. Then the || operator will
           # resolve to 'nothing' so we will exclude 'nothing'. https://stackoverflow.com/a/73822998
           - rust_release: ${{ (needs.pre_job.outputs.should_skip != 'true' && 'nothing') || 'pinned-nightly' }}
-          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-nightly' }}
+          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-stable' }}
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install nightly toolchain
+      - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           target: wasm32-unknown-unknown
-          override: ${{ matrix.rust_release == 'latest-nightly' }}
+          override: ${{ matrix.rust_release == 'latest-stable' }}
 
       - name: Check hydroflow_lang
         uses: actions-rs/cargo@v1
@@ -132,13 +132,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        rust_release: [pinned-nightly, latest-nightly]
+        rust_release: [pinned-nightly, latest-stable]
         exclude:
           # For non-pull requests, event_name != 'pull_request' will be true, and 'nothing' is
           # truthy, so the entire && operator will resolve to 'nothing'. Then the || operator will
           # resolve to 'nothing' so we will exclude 'nothing'. https://stackoverflow.com/a/73822998
           - rust_release: ${{ (needs.pre_job.outputs.should_skip != 'true' && 'nothing') || 'pinned-nightly' }}
-          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-nightly' }}
+          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-stable' }}
           - os: ${{ (github.event_name != 'pull_request' && 'nothing') || 'windows-latest' }}
 
     env:
@@ -152,12 +152,12 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install nightly toolchain
+      - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
-          override: ${{ matrix.rust_release == 'latest-nightly' }}
+          toolchain: stable
+          override: ${{ matrix.rust_release == 'latest-stable' }}
 
       - name: Run sccache-cache
         if: matrix.rust_release == 'pinned-nightly'
@@ -235,25 +235,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_release: [pinned-nightly, latest-nightly]
+        rust_release: [pinned-nightly, latest-stable]
         exclude:
           # For non-pull requests, event_name != 'pull_request' will be true, and 'nothing' is
           # truthy, so the entire && operator will resolve to 'nothing'. Then the || operator will
           # resolve to 'nothing' so we will exclude 'nothing'. https://stackoverflow.com/a/73822998
           - rust_release: ${{ (needs.pre_job.outputs.should_skip != 'true' && 'nothing') || 'pinned-nightly' }}
-          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-nightly' }}
+          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-stable' }}
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install nightly toolchain
+      - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           target: wasm32-unknown-unknown
-          override: ${{ matrix.rust_release == 'latest-nightly' }}
+          override: ${{ matrix.rust_release == 'latest-stable' }}
 
       - name: Get wasm-bindgen version
         id: wasm-bindgen-version
@@ -299,11 +299,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install nightly toolchain
+      - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
 
       - name: Run cargo doc
         uses: actions-rs/cargo@v1
@@ -366,11 +365,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install nightly toolchain
+      - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
 
       - name: Checkout gh-pages
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
 
       - name: Override RUSTFLAGS
         run: echo "RUSTFLAGS=--cfg noop" >> $GITHUB_ENV
+        shell: bash
         if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain
@@ -114,6 +115,7 @@ jobs:
 
       - name: Override RUSTFLAGS
         run: echo "RUSTFLAGS=--cfg noop" >> $GITHUB_ENV
+        shell: bash
         if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain
@@ -162,6 +164,7 @@ jobs:
 
       - name: Override RUSTFLAGS
         run: echo "RUSTFLAGS=--cfg noop" >> $GITHUB_ENV
+        shell: bash
         if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain
@@ -261,6 +264,7 @@ jobs:
 
       - name: Override RUSTFLAGS
         run: echo "RUSTFLAGS=--cfg noop" >> $GITHUB_ENV
+        shell: bash
         if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Override RUSTFLAGS
-        run: echo "RUSTFLAGS=''" >> $GITHUB_ENV
+        run: echo "RUSTFLAGS=" >> $GITHUB_ENV
         if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain
@@ -113,7 +113,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Override RUSTFLAGS
-        run: echo "RUSTFLAGS=''" >> $GITHUB_ENV
+        run: echo "RUSTFLAGS=" >> $GITHUB_ENV
         if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain
@@ -161,7 +161,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Override RUSTFLAGS
-        run: echo "RUSTFLAGS=''" >> $GITHUB_ENV
+        run: echo "RUSTFLAGS=" >> $GITHUB_ENV
         if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain
@@ -260,7 +260,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Override RUSTFLAGS
-        run: echo "RUSTFLAGS=''" >> $GITHUB_ENV
+        run: echo "RUSTFLAGS=" >> $GITHUB_ENV
         if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
+      - name: Override RUSTFLAGS
+        run: echo "BRANCH=''" >> $GITHUB_ENV
+        if: matrix.rust_release == 'latest-stable'
+
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -108,6 +112,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
+      - name: Override RUSTFLAGS
+        run: echo "BRANCH=''" >> $GITHUB_ENV
+        if: matrix.rust_release == 'latest-stable'
+
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -151,6 +159,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
+
+      - name: Override RUSTFLAGS
+        run: echo "BRANCH=''" >> $GITHUB_ENV
+        if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
@@ -246,6 +258,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
+
+      - name: Override RUSTFLAGS
+        run: echo "BRANCH=''" >> $GITHUB_ENV
+        if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Override RUSTFLAGS
-        run: echo "RUSTFLAGS=--cfg noop" >> $GITHUB_ENV
-        shell: bash
-        if: matrix.rust_release == 'latest-stable'
-
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -113,11 +108,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Override RUSTFLAGS
-        run: echo "RUSTFLAGS=--cfg noop" >> $GITHUB_ENV
-        shell: bash
-        if: matrix.rust_release == 'latest-stable'
-
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -161,11 +151,6 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-
-      - name: Override RUSTFLAGS
-        run: echo "RUSTFLAGS=--cfg noop" >> $GITHUB_ENV
-        shell: bash
-        if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
@@ -261,11 +246,6 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-
-      - name: Override RUSTFLAGS
-        run: echo "RUSTFLAGS=--cfg noop" >> $GITHUB_ENV
-        shell: bash
-        if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Override RUSTFLAGS
-        run: echo "RUSTFLAGS=" >> $GITHUB_ENV
+        run: echo "RUSTFLAGS=--cfg noop" >> $GITHUB_ENV
         if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain
@@ -113,7 +113,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Override RUSTFLAGS
-        run: echo "RUSTFLAGS=" >> $GITHUB_ENV
+        run: echo "RUSTFLAGS=--cfg noop" >> $GITHUB_ENV
         if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain
@@ -161,7 +161,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Override RUSTFLAGS
-        run: echo "RUSTFLAGS=" >> $GITHUB_ENV
+        run: echo "RUSTFLAGS=--cfg noop" >> $GITHUB_ENV
         if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain
@@ -260,7 +260,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Override RUSTFLAGS
-        run: echo "RUSTFLAGS=" >> $GITHUB_ENV
+        run: echo "RUSTFLAGS=--cfg noop" >> $GITHUB_ENV
         if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Override RUSTFLAGS
-        run: echo "BRANCH=''" >> $GITHUB_ENV
+        run: echo "RUSTFLAGS=''" >> $GITHUB_ENV
         if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain
@@ -113,7 +113,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Override RUSTFLAGS
-        run: echo "BRANCH=''" >> $GITHUB_ENV
+        run: echo "RUSTFLAGS=''" >> $GITHUB_ENV
         if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain
@@ -161,7 +161,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Override RUSTFLAGS
-        run: echo "BRANCH=''" >> $GITHUB_ENV
+        run: echo "RUSTFLAGS=''" >> $GITHUB_ENV
         if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain
@@ -260,7 +260,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Override RUSTFLAGS
-        run: echo "BRANCH=''" >> $GITHUB_ENV
+        run: echo "RUSTFLAGS=''" >> $GITHUB_ENV
         if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          toolchain: nightly
 
       - name: Run cargo doc
         uses: actions-rs/cargo@v1
@@ -369,6 +370,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          toolchain: nightly
 
       - name: Checkout gh-pages
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,6 +1487,7 @@ dependencies = [
  "ref-cast",
  "regex",
  "rustc-hash 1.1.0",
+ "rustc_version 0.4.1",
  "sealed 0.5.0",
  "serde",
  "serde_json",
@@ -1560,6 +1561,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
+ "rustc_version 0.4.1",
  "serde",
  "serde_json",
  "slotmap",
@@ -1576,6 +1578,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
+ "rustc_version 0.4.1",
  "syn 2.0.75",
 ]
 
@@ -2633,7 +2636,7 @@ dependencies = [
  "byteorder",
  "libc",
  "nom 2.2.1",
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -3065,6 +3068,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver 1.0.23",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,6 +1599,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
+ "rustc_version 0.4.1",
  "sealed 0.6.0",
  "serde",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1917,6 +1917,7 @@ dependencies = [
  "cc-traits",
  "lattices_macro",
  "ref-cast",
+ "rustc_version 0.4.1",
  "sealed 0.5.0",
  "serde",
  "trybuild",

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -10,7 +10,7 @@ const katex = require('rehype-katex');
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Hydro - Build for Every Scale',
-  tagline: 'Dinosaurs are cool',
+  tagline: 'Program the Cloud',
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here

--- a/hydroflow/Cargo.toml
+++ b/hydroflow/Cargo.toml
@@ -11,9 +11,8 @@ description = "Hydro's low-level dataflow runtime and IR"
 workspace = true
 
 [features]
-default = [ "macros", "nightly", "debugging" ]
+default = [ "macros", "debugging" ]
 
-nightly = [ "hydroflow_macro", "hydroflow_macro/diagnostics" ]
 macros = [ "hydroflow_macro", "hydroflow_datalog" ]
 hydroflow_macro = [ "dep:hydroflow_macro" ]
 hydroflow_datalog = [ "dep:hydroflow_datalog" ]
@@ -23,7 +22,6 @@ debugging = [ "hydroflow_lang/debugging" ]
 
 [[example]]
 name = "kvs_bench"
-required-features = [ "nightly" ]
 
 [[example]]
 name = "python_udf"
@@ -93,3 +91,6 @@ zipf = "7"
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 # Rayon (rust data-parallelism library) does not compile on WASM.
 criterion = { version = "0.5.0", features = [ "async_tokio", "html_reports" ] }
+
+[build-dependencies]
+rustc_version = "0.4.0"

--- a/hydroflow/build.rs
+++ b/hydroflow/build.rs
@@ -1,0 +1,11 @@
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(nightly)");
+    if matches!(
+        version_meta().map(|meta| meta.channel),
+        Ok(Channel::Nightly)
+    ) {
+        println!("cargo:rustc-cfg=nightly");
+    }
+}

--- a/hydroflow/src/lib.rs
+++ b/hydroflow/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "nightly", feature(never_type))]
+#![cfg_attr(nightly, feature(never_type))]
 #![warn(missing_docs)]
 
 //! Hydroflow is a low-level dataflow-based runtime system for the [Hydro Project](https://hydro.run/).
@@ -40,10 +40,10 @@ pub use hydroflow_macro::{
 };
 
 /// Stand-in for the [nightly "never" type `!`](https://doc.rust-lang.org/std/primitive.never.html)
-#[cfg(not(feature = "nightly"))]
+#[cfg(not(nightly))]
 pub type Never = std::convert::Infallible;
 /// The [nightly "never" type `!`](https://doc.rust-lang.org/std/primitive.never.html)
-#[cfg(feature = "nightly")]
+#[cfg(nightly)]
 pub type Never = !;
 
 #[cfg(doctest)]

--- a/hydroflow/tests/datalog_compile_fail.rs
+++ b/hydroflow/tests/datalog_compile_fail.rs
@@ -1,3 +1,5 @@
+#![cfg(nightly)]
+
 #[test]
 fn test_all() {
     let t = trybuild::TestCases::new();

--- a/hydroflow/tests/surface_compile_fail.rs
+++ b/hydroflow/tests/surface_compile_fail.rs
@@ -1,3 +1,5 @@
+#![cfg(nightly)]
+
 #[test]
 fn test_all() {
     let t = trybuild::TestCases::new();

--- a/hydroflow/tests/surface_warnings.rs
+++ b/hydroflow/tests/surface_warnings.rs
@@ -1,6 +1,4 @@
-// TODO(mingwei): fix line numbers in tests
-// https://github.com/hydro-project/hydroflow/issues/729
-// https://github.com/rust-lang/rust/pull/111571
+#![cfg(nightly)]
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/hydroflow_datalog/Cargo.toml
+++ b/hydroflow_datalog/Cargo.toml
@@ -14,9 +14,6 @@ workspace = true
 proc-macro = true
 path = "src/lib.rs"
 
-[features]
-diagnostics = [ "hydroflow_datalog_core/diagnostics" ]
-
 [dependencies]
 quote = "1.0.35"
 syn = { version = "2.0.46", features = [ "parsing", "extra-traits" ] }

--- a/hydroflow_datalog_core/Cargo.toml
+++ b/hydroflow_datalog_core/Cargo.toml
@@ -13,10 +13,6 @@ workspace = true
 [lib]
 path = "src/lib.rs"
 
-[features]
-default = []
-diagnostics = [ "hydroflow_lang/diagnostics" ]
-
 [dependencies]
 quote = "1.0.35"
 slotmap = "1.0.0"

--- a/hydroflow_datalog_core/src/lib.rs
+++ b/hydroflow_datalog_core/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 
-use hydroflow_lang::diagnostic::{Diagnostic, Level};
+pub use hydroflow_lang::diagnostic::{Diagnostic, Level};
 use hydroflow_lang::graph::{
     eliminate_extra_unions_tees, partition_graph, FlatGraphBuilder, HydroflowGraph,
 };

--- a/hydroflow_lang/Cargo.toml
+++ b/hydroflow_lang/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 
 [features]
 default = []
-diagnostics = []
 debugging = [ "dep:data-encoding", "dep:webbrowser", "clap-derive" ]
 clap-derive = [ "dep:clap" ]
 
@@ -34,3 +33,4 @@ webbrowser = { version = "1.0.0", optional = true }
 
 [build-dependencies]
 syn = { version = "2.0.46", features = [ "extra-traits", "full", "parsing" ] }
+rustc_version = "0.4.0"

--- a/hydroflow_lang/build.rs
+++ b/hydroflow_lang/build.rs
@@ -4,6 +4,7 @@ use std::fs::File;
 use std::io::{BufWriter, Error, ErrorKind, Result, Write};
 use std::path::PathBuf;
 
+use rustc_version::{version_meta, Channel};
 use syn::{
     parse_quote, AttrStyle, Expr, ExprLit, Ident, Item, Lit, Member, Meta, MetaNameValue, Path,
 };
@@ -12,6 +13,15 @@ const OPS_PATH: &str = "src/graph/ops";
 
 fn main() {
     println!("cargo::rerun-if-changed={}", OPS_PATH);
+
+    println!("cargo::rustc-check-cfg=cfg(nightly)");
+    if matches!(
+        version_meta().map(|meta| meta.channel),
+        Ok(Channel::Nightly)
+    ) {
+        println!("cargo:rustc-cfg=nightly");
+    }
+
     if Err(VarError::NotPresent) != var("CARGO_CFG_HYDROFLOW_GENERATE_DOCS") {
         if let Err(err) = generate_op_docs() {
             eprintln!("hydroflow_lang/build.rs error: {:?}", err);

--- a/hydroflow_lang/src/diagnostic.rs
+++ b/hydroflow_lang/src/diagnostic.rs
@@ -68,10 +68,10 @@ impl Diagnostic {
         }
     }
 
-    /// Emit the diagnostic. Only works from the `proc_macro` context. Does not work outside of
-    /// that e.g. in normal runtime execution or in tests.
+    /// Emit the diagnostic. Only works from the `proc_macro` context on nightly versions. Does
+    /// not work outside of that e.g. in normal runtime execution or in tests.
     pub fn emit(&self) {
-        #[cfg(feature = "diagnostics")]
+        #[cfg(nightly)]
         {
             let pm_diag = match self.level {
                 Level::Error => self.span.unwrap().error(&*self.message),
@@ -169,7 +169,7 @@ pub struct SerdeSpan {
 }
 impl From<Span> for SerdeSpan {
     fn from(span: Span) -> Self {
-        #[cfg(feature = "diagnostics")]
+        #[cfg(nightly)]
         let path = span
             .unwrap()
             .source_file()
@@ -178,7 +178,7 @@ impl From<Span> for SerdeSpan {
             .to_string()
             .into();
 
-        #[cfg(not(feature = "diagnostics"))]
+        #[cfg(not(nightly))]
         let path = "unknown".into();
 
         Self {

--- a/hydroflow_lang/src/diagnostic.rs
+++ b/hydroflow_lang/src/diagnostic.rs
@@ -40,8 +40,8 @@ impl Level {
 /// Diagnostic. A warning or error (or lower [`Level`]) with a message and span. Shown by IDEs
 /// usually as a squiggly red or yellow underline.
 ///
-/// Must call [`Diagnostic::emit`] or manually emit the output of [`Diagnostic::to_tokens`] for the
-/// diagnostic to show up.
+/// Diagnostics must be emitted via [`Diagnostic::try_emit`], [`Diagnostic::to_tokens`], or
+/// [`Diagnostic::try_emit_all`] for diagnostics to show up.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Diagnostic<S = Span> {
     /// Span (source code location).

--- a/hydroflow_lang/src/diagnostic.rs
+++ b/hydroflow_lang/src/diagnostic.rs
@@ -107,7 +107,7 @@ impl Diagnostic {
         }
     }
 
-    /// Used to emulate [`Diagnostic::emit`] by turning this diagnostic into a properly spanned [`TokenStream`]
+    /// Used to emulate `proc_macro::Diagnostic::emit` by turning this diagnostic into a properly spanned [`TokenStream`]
     /// that emits an error via `compile_error!(...)` with this diagnostic's message.
     pub fn to_tokens(&self) -> TokenStream {
         let msg_lit: Literal = Literal::string(&self.message);

--- a/hydroflow_lang/src/graph/hydroflow_graph.rs
+++ b/hydroflow_lang/src/graph/hydroflow_graph.rs
@@ -1006,10 +1006,10 @@ impl HydroflowGraph {
                             subgraph_op_iter_code.push(write_iterator);
 
                             if include_type_guards {
-                                #[cfg(not(feature = "diagnostics"))]
+                                #[cfg(not(nightly))]
                                 let source_info = Option::<String>::None;
 
-                                #[cfg(feature = "diagnostics")]
+                                #[cfg(nightly)]
                                 let source_info = std::panic::catch_unwind(|| op_span.unwrap())
                                     .map(|op_span| {
                                         format!(
@@ -1029,7 +1029,7 @@ impl HydroflowGraph {
                                     .ok();
 
                                 #[cfg_attr(
-                                    not(feature = "diagnostics"),
+                                    nightly,
                                     expect(
                                         clippy::unnecessary_literal_unwrap,
                                         reason = "conditional compilation"

--- a/hydroflow_lang/src/graph/hydroflow_graph.rs
+++ b/hydroflow_lang/src/graph/hydroflow_graph.rs
@@ -1029,7 +1029,7 @@ impl HydroflowGraph {
                                     .ok();
 
                                 #[cfg_attr(
-                                    nightly,
+                                    not(nightly),
                                     expect(
                                         clippy::unnecessary_literal_unwrap,
                                         reason = "conditional compilation"

--- a/hydroflow_lang/src/lib.rs
+++ b/hydroflow_lang/src/lib.rs
@@ -1,10 +1,7 @@
 //! Hydroflow surface syntax
 
 #![warn(missing_docs)]
-#![cfg_attr(
-    feature = "diagnostics",
-    feature(proc_macro_diagnostic, proc_macro_span)
-)]
+#![cfg_attr(nightly, feature(proc_macro_diagnostic, proc_macro_span))]
 pub mod diagnostic;
 pub mod graph;
 pub mod parse;

--- a/hydroflow_lang/src/pretty_span.rs
+++ b/hydroflow_lang/src/pretty_span.rs
@@ -5,7 +5,7 @@
 pub struct PrettySpan(pub proc_macro2::Span);
 impl std::fmt::Display for PrettySpan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        #[cfg(feature = "diagnostics")]
+        #[cfg(nightly)]
         {
             if let Ok(span) = std::panic::catch_unwind(|| self.0.unwrap()) {
                 write!(
@@ -21,7 +21,7 @@ impl std::fmt::Display for PrettySpan {
 
         write!(
             f,
-            "nopath:{}:{}",
+            "unknown:{}:{}",
             self.0.start().line,
             self.0.start().column
         )

--- a/hydroflow_macro/Cargo.toml
+++ b/hydroflow_macro/Cargo.toml
@@ -13,9 +13,6 @@ workspace = true
 [lib]
 proc-macro = true
 
-[features]
-diagnostics = [ "hydroflow_lang/diagnostics" ]
-
 [dependencies]
 # Note: If we ever compile this proc macro crate to WASM (e.g., if we are
 # building on a WASM host), we may need to turn diagnostics off for WASM if
@@ -30,3 +27,4 @@ syn = { version = "2.0.46", features = [ "parsing", "extra-traits" ] }
 hydroflow_lang = { path = "../hydroflow_lang", version = "^0.10.0" }
 itertools = "0.10.0"
 quote = "1.0.35"
+rustc_version = "0.4.0"

--- a/hydroflow_macro/build.rs
+++ b/hydroflow_macro/build.rs
@@ -10,6 +10,7 @@ use hydroflow_lang::graph::ops::{PortListSpec, OPERATORS};
 use hydroflow_lang::graph::PortIndexValue;
 use itertools::Itertools;
 use quote::ToTokens;
+use rustc_version::{version_meta, Channel};
 
 const FILENAME: &str = "surface_ops_gen.md";
 
@@ -207,6 +208,14 @@ fn update_book() -> Result<()> {
 }
 
 fn main() {
+    println!("cargo::rustc-check-cfg=cfg(nightly)");
+    if matches!(
+        version_meta().map(|meta| meta.channel),
+        Ok(Channel::Nightly)
+    ) {
+        println!("cargo:rustc-cfg=nightly");
+    }
+
     if Err(VarError::NotPresent) != std::env::var("CARGO_CFG_HYDROFLOW_GENERATE_DOCS") {
         if let Err(err) = update_book() {
             eprintln!("hydroflow_macro/build.rs error: {:?}", err);

--- a/hydroflow_macro/src/lib.rs
+++ b/hydroflow_macro/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(
-    feature = "diagnostics",
+    nightly,
     feature(proc_macro_diagnostic, proc_macro_span, proc_macro_def_site)
 )]
 
@@ -72,13 +72,13 @@ fn hydroflow_syntax_internal(
         .iter()
         .filter(|diag: &&Diagnostic| Some(diag.level) <= min_diagnostic_level);
 
-    #[cfg(feature = "diagnostics")]
+    #[cfg(nightly)]
     {
         diagnostics.for_each(Diagnostic::emit);
         tokens.into()
     }
 
-    #[cfg(not(feature = "diagnostics"))]
+    #[cfg(not(nightly))]
     {
         let diagnostics = diagnostics.map(Diagnostic::to_tokens);
         quote! {

--- a/hydroflow_plus/Cargo.toml
+++ b/hydroflow_plus/Cargo.toml
@@ -15,10 +15,15 @@ path = "src/lib.rs"
 
 [features]
 default = ["deploy_runtime"]
-diagnostics = [ "hydroflow_lang/diagnostics" ]
 stageleft_devel = []
-deploy_runtime = [ "hydroflow/deploy_integration" ]
-deploy = [ "deploy_runtime", "dep:hydro_deploy", "dep:trybuild-internals-api", "dep:toml", "dep:prettyplease" ]
+deploy_runtime = ["hydroflow/deploy_integration"]
+deploy = [
+    "deploy_runtime",
+    "dep:hydro_deploy",
+    "dep:trybuild-internals-api",
+    "dep:toml",
+    "dep:prettyplease",
+]
 
 [dependencies]
 bincode = "1.3.1"
@@ -27,17 +32,21 @@ hydroflow = { path = "../hydroflow", version = "^0.10.0", default-features = fal
 hydroflow_lang = { path = "../hydroflow_lang", version = "^0.10.0" }
 match_box = "0.0.2"
 nameof = "1.0.0"
-prettyplease = { version = "0.2.0", features = [ "verbatim" ], optional = true }
+prettyplease = { version = "0.2.0", features = ["verbatim"], optional = true }
 proc-macro-crate = "1.0.0"
 proc-macro2 = "1.0.74"
 quote = "1.0.35"
 sealed = "0.6.0"
-serde = { version = "1.0.197", features = [ "derive" ] }
+serde = { version = "1.0.197", features = ["derive"] }
 sha2 = "0.10.0"
 stageleft = { path = "../stageleft", version = "^0.5.0" }
 stageleft_tool = { path = "../stageleft_tool", version = "^0.4.0" }
-syn = { version = "2.0.46", features = [ "parsing", "extra-traits", "visit-mut" ] }
-tokio = { version = "1.29.0", features = [ "full" ] }
+syn = { version = "2.0.46", features = [
+    "parsing",
+    "extra-traits",
+    "visit-mut",
+] }
+tokio = { version = "1.29.0", features = ["full"] }
 toml = { version = "0.8.0", optional = true }
 trybuild-internals-api = { version = "1.0.99", optional = true }
 

--- a/hydroflow_plus/Cargo.toml
+++ b/hydroflow_plus/Cargo.toml
@@ -50,12 +50,13 @@ tokio = { version = "1.29.0", features = ["full"] }
 toml = { version = "0.8.0", optional = true }
 trybuild-internals-api = { version = "1.0.99", optional = true }
 
-[build-dependencies]
-stageleft_tool = { path = "../stageleft_tool", version = "^0.4.0" }
-
 [dev-dependencies]
 async-ssh2-lite = { version = "0.5.0", features = ["vendored-openssl"] }
 ctor = "0.2.8"
 hydro_deploy = { path = "../hydro_deploy/core", version = "^0.10.0" }
 insta = "1.39"
 trybuild = "1"
+
+[build-dependencies]
+rustc_version = "0.4.0"
+stageleft_tool = { path = "../stageleft_tool", version = "^0.4.0" }

--- a/hydroflow_plus/build.rs
+++ b/hydroflow_plus/build.rs
@@ -1,3 +1,13 @@
+use rustc_version::{version_meta, Channel};
+
 fn main() {
+    println!("cargo::rustc-check-cfg=cfg(nightly)");
+    if matches!(
+        version_meta().map(|meta| meta.channel),
+        Ok(Channel::Nightly)
+    ) {
+        println!("cargo:rustc-cfg=nightly");
+    }
+
     stageleft_tool::gen_final!();
 }

--- a/hydroflow_plus/tests/compile_fail.rs
+++ b/hydroflow_plus/tests/compile_fail.rs
@@ -1,3 +1,5 @@
+#![cfg(nightly)]
+
 #[test]
 fn test_all() {
     let t = trybuild::TestCases::new();

--- a/lattices/Cargo.toml
+++ b/lattices/Cargo.toml
@@ -25,3 +25,6 @@ variadics_macro = { path = "../variadics_macro", version = "^0.5.5" }
 
 [dev-dependencies]
 trybuild = "1.0.0"
+
+[build-dependencies]
+rustc_version = "0.4.0"

--- a/lattices/build.rs
+++ b/lattices/build.rs
@@ -1,0 +1,11 @@
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(nightly)");
+    if matches!(
+        version_meta().map(|meta| meta.channel),
+        Ok(Channel::Nightly)
+    ) {
+        println!("cargo:rustc-cfg=nightly");
+    }
+}

--- a/lattices/tests/compile_fail.rs
+++ b/lattices/tests/compile_fail.rs
@@ -1,3 +1,5 @@
+#[cfg(nightly)]
+
 #[test]
 fn test_all() {
     let t = trybuild::TestCases::new();

--- a/lattices/tests/compile_fail.rs
+++ b/lattices/tests/compile_fail.rs
@@ -1,4 +1,4 @@
-#[cfg(nightly)]
+#![cfg(nightly)]
 
 #[test]
 fn test_all() {


### PR DESCRIPTION
fix #1587

* use `nightly` cfg set in `build.rs`es instead of `feature = "nightly"` which could be incorrectly set
* run CI on stable rust instead of latest nightly

BREAKING CHANGE: `hydroflow_lang::Diagnostic::emit` replaced by `hydroflow_lang::Diagnostic::try_emit` to work on both stable and nightly, returning a result.