### PR TITLE
refactor!: use `cfg(nightly)` instead of feature, remove `-Z` flag, use `Diagnostic::try_emit`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,12 +1,8 @@
 [build]
 rustflags = [
-    "-Zproc-macro-backtrace",
     # Flag to make build.rs scripts generate docs. Should only be used in this repository
     # internally, not by dependants.
     '--cfg=HYDROFLOW_GENERATE_DOCS',
-    # https://github.com/rust-lang/rust-clippy/issues/10087
-    ## TODO(mingwei): Need rust-analyzer support:
-    # "-Aclippy::uninlined-format-args",
 ]
 
 [target.x86_64-apple-darwin]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        rust_release: [pinned-nightly, latest-nightly]
+        rust_release: [pinned-nightly, latest-stable]
         exclude:
           # For non-pull requests, event_name != 'pull_request' will be true, and 'nothing' is
           # truthy, so the entire && operator will resolve to 'nothing'. Then the || operator will
           # resolve to 'nothing' so we will exclude 'nothing'. https://stackoverflow.com/a/73822998
           - rust_release: ${{ (needs.pre_job.outputs.should_skip != 'true' && 'nothing') || 'pinned-nightly' }}
-          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-nightly' }}
+          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-stable' }}
 
     env:
       CARGO_TERM_COLOR: always
@@ -55,12 +55,17 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install nightly toolchain
+      - name: Override RUSTFLAGS
+        run: echo "RUSTFLAGS=--cfg noop" >> $GITHUB_ENV
+        shell: bash
+        if: matrix.rust_release == 'latest-stable'
+
+      - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
-          override: ${{ matrix.rust_release == 'latest-nightly' }}
+          toolchain: stable
+          override: ${{ matrix.rust_release == 'latest-stable' }}
           components: rustfmt, clippy
 
       - name: Run sccache-cache
@@ -96,25 +101,30 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_release: [pinned-nightly, latest-nightly]
+        rust_release: [pinned-nightly, latest-stable]
         exclude:
           # For non-pull requests, event_name != 'pull_request' will be true, and 'nothing' is
           # truthy, so the entire && operator will resolve to 'nothing'. Then the || operator will
           # resolve to 'nothing' so we will exclude 'nothing'. https://stackoverflow.com/a/73822998
           - rust_release: ${{ (needs.pre_job.outputs.should_skip != 'true' && 'nothing') || 'pinned-nightly' }}
-          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-nightly' }}
+          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-stable' }}
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install nightly toolchain
+      - name: Override RUSTFLAGS
+        run: echo "RUSTFLAGS=--cfg noop" >> $GITHUB_ENV
+        shell: bash
+        if: matrix.rust_release == 'latest-stable'
+
+      - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           target: wasm32-unknown-unknown
-          override: ${{ matrix.rust_release == 'latest-nightly' }}
+          override: ${{ matrix.rust_release == 'latest-stable' }}
 
       - name: Check hydroflow_lang
         uses: actions-rs/cargo@v1
@@ -132,13 +142,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        rust_release: [pinned-nightly, latest-nightly]
+        rust_release: [pinned-nightly, latest-stable]
         exclude:
           # For non-pull requests, event_name != 'pull_request' will be true, and 'nothing' is
           # truthy, so the entire && operator will resolve to 'nothing'. Then the || operator will
           # resolve to 'nothing' so we will exclude 'nothing'. https://stackoverflow.com/a/73822998
           - rust_release: ${{ (needs.pre_job.outputs.should_skip != 'true' && 'nothing') || 'pinned-nightly' }}
-          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-nightly' }}
+          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-stable' }}
           - os: ${{ (github.event_name != 'pull_request' && 'nothing') || 'windows-latest' }}
 
     env:
@@ -152,12 +162,17 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install nightly toolchain
+      - name: Override RUSTFLAGS
+        run: echo "RUSTFLAGS=--cfg noop" >> $GITHUB_ENV
+        shell: bash
+        if: matrix.rust_release == 'latest-stable'
+
+      - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
-          override: ${{ matrix.rust_release == 'latest-nightly' }}
+          toolchain: stable
+          override: ${{ matrix.rust_release == 'latest-stable' }}
 
       - name: Run sccache-cache
         if: matrix.rust_release == 'pinned-nightly'
@@ -235,25 +250,30 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_release: [pinned-nightly, latest-nightly]
+        rust_release: [pinned-nightly, latest-stable]
         exclude:
           # For non-pull requests, event_name != 'pull_request' will be true, and 'nothing' is
           # truthy, so the entire && operator will resolve to 'nothing'. Then the || operator will
           # resolve to 'nothing' so we will exclude 'nothing'. https://stackoverflow.com/a/73822998
           - rust_release: ${{ (needs.pre_job.outputs.should_skip != 'true' && 'nothing') || 'pinned-nightly' }}
-          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-nightly' }}
+          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-stable' }}
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install nightly toolchain
+      - name: Override RUSTFLAGS
+        run: echo "RUSTFLAGS=--cfg noop" >> $GITHUB_ENV
+        shell: bash
+        if: matrix.rust_release == 'latest-stable'
+
+      - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           target: wasm32-unknown-unknown
-          override: ${{ matrix.rust_release == 'latest-nightly' }}
+          override: ${{ matrix.rust_release == 'latest-stable' }}
 
       - name: Get wasm-bindgen version
         id: wasm-bindgen-version
@@ -299,7 +319,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install nightly toolchain
+      - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -366,7 +386,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install nightly toolchain
+      - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Override RUSTFLAGS
-        run: echo "RUSTFLAGS=--cfg noop" >> $GITHUB_ENV
-        shell: bash
-        if: matrix.rust_release == 'latest-stable'
-
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -113,11 +108,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Override RUSTFLAGS
-        run: echo "RUSTFLAGS=--cfg noop" >> $GITHUB_ENV
-        shell: bash
-        if: matrix.rust_release == 'latest-stable'
-
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -161,11 +151,6 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-
-      - name: Override RUSTFLAGS
-        run: echo "RUSTFLAGS=--cfg noop" >> $GITHUB_ENV
-        shell: bash
-        if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
@@ -261,11 +246,6 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-
-      - name: Override RUSTFLAGS
-        run: echo "RUSTFLAGS=--cfg noop" >> $GITHUB_ENV
-        shell: bash
-        if: matrix.rust_release == 'latest-stable'
 
       - name: Install toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        rust_release: [pinned-nightly, latest-stable]
+        rust_release: [pinned-nightly, latest-nightly]
         exclude:
           # For non-pull requests, event_name != 'pull_request' will be true, and 'nothing' is
           # truthy, so the entire && operator will resolve to 'nothing'. Then the || operator will
           # resolve to 'nothing' so we will exclude 'nothing'. https://stackoverflow.com/a/73822998
           - rust_release: ${{ (needs.pre_job.outputs.should_skip != 'true' && 'nothing') || 'pinned-nightly' }}
-          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-stable' }}
+          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-nightly' }}
 
     env:
       CARGO_TERM_COLOR: always
@@ -55,12 +55,12 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install toolchain
+      - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
-          override: ${{ matrix.rust_release == 'latest-stable' }}
+          toolchain: nightly
+          override: ${{ matrix.rust_release == 'latest-nightly' }}
           components: rustfmt, clippy
 
       - name: Run sccache-cache
@@ -96,25 +96,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_release: [pinned-nightly, latest-stable]
+        rust_release: [pinned-nightly, latest-nightly]
         exclude:
           # For non-pull requests, event_name != 'pull_request' will be true, and 'nothing' is
           # truthy, so the entire && operator will resolve to 'nothing'. Then the || operator will
           # resolve to 'nothing' so we will exclude 'nothing'. https://stackoverflow.com/a/73822998
           - rust_release: ${{ (needs.pre_job.outputs.should_skip != 'true' && 'nothing') || 'pinned-nightly' }}
-          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-stable' }}
+          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-nightly' }}
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install toolchain
+      - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           target: wasm32-unknown-unknown
-          override: ${{ matrix.rust_release == 'latest-stable' }}
+          override: ${{ matrix.rust_release == 'latest-nightly' }}
 
       - name: Check hydroflow_lang
         uses: actions-rs/cargo@v1
@@ -132,13 +132,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        rust_release: [pinned-nightly, latest-stable]
+        rust_release: [pinned-nightly, latest-nightly]
         exclude:
           # For non-pull requests, event_name != 'pull_request' will be true, and 'nothing' is
           # truthy, so the entire && operator will resolve to 'nothing'. Then the || operator will
           # resolve to 'nothing' so we will exclude 'nothing'. https://stackoverflow.com/a/73822998
           - rust_release: ${{ (needs.pre_job.outputs.should_skip != 'true' && 'nothing') || 'pinned-nightly' }}
-          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-stable' }}
+          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-nightly' }}
           - os: ${{ (github.event_name != 'pull_request' && 'nothing') || 'windows-latest' }}
 
     env:
@@ -152,12 +152,12 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install toolchain
+      - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
-          override: ${{ matrix.rust_release == 'latest-stable' }}
+          toolchain: nightly
+          override: ${{ matrix.rust_release == 'latest-nightly' }}
 
       - name: Run sccache-cache
         if: matrix.rust_release == 'pinned-nightly'
@@ -235,25 +235,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_release: [pinned-nightly, latest-stable]
+        rust_release: [pinned-nightly, latest-nightly]
         exclude:
           # For non-pull requests, event_name != 'pull_request' will be true, and 'nothing' is
           # truthy, so the entire && operator will resolve to 'nothing'. Then the || operator will
           # resolve to 'nothing' so we will exclude 'nothing'. https://stackoverflow.com/a/73822998
           - rust_release: ${{ (needs.pre_job.outputs.should_skip != 'true' && 'nothing') || 'pinned-nightly' }}
-          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-stable' }}
+          - rust_release: ${{ (github.event_name != 'pull_request' && 'nothing') || 'latest-nightly' }}
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install toolchain
+      - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           target: wasm32-unknown-unknown
-          override: ${{ matrix.rust_release == 'latest-stable' }}
+          override: ${{ matrix.rust_release == 'latest-nightly' }}
 
       - name: Get wasm-bindgen version
         id: wasm-bindgen-version
@@ -299,7 +299,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install toolchain
+      - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -366,7 +366,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install toolchain
+      - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,6 +1560,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
+ "rustc_version 0.4.1",
  "serde",
  "serde_json",
  "slotmap",
@@ -2633,7 +2634,7 @@ dependencies = [
  "byteorder",
  "libc",
  "nom 2.2.1",
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -3065,6 +3066,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver 1.0.23",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,6 +1577,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
+ "rustc_version 0.4.1",
  "syn 2.0.75",
 ]
 

--- a/hydroflow/Cargo.toml
+++ b/hydroflow/Cargo.toml
@@ -11,9 +11,8 @@ description = "Hydro's low-level dataflow runtime and IR"
 workspace = true
 
 [features]
-default = [ "macros", "nightly", "debugging" ]
+default = [ "macros", "debugging" ]
 
-nightly = []
 macros = [ "hydroflow_macro", "hydroflow_datalog" ]
 hydroflow_macro = [ "dep:hydroflow_macro" ]
 hydroflow_datalog = [ "dep:hydroflow_datalog" ]

--- a/hydroflow/Cargo.toml
+++ b/hydroflow/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [features]
 default = [ "macros", "nightly", "debugging" ]
 
-nightly = [ "hydroflow_macro", "hydroflow_macro/diagnostics" ]
+nightly = []
 macros = [ "hydroflow_macro", "hydroflow_datalog" ]
 hydroflow_macro = [ "dep:hydroflow_macro" ]
 hydroflow_datalog = [ "dep:hydroflow_datalog" ]

--- a/hydroflow/src/lib.rs
+++ b/hydroflow/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(feature = "nightly", feature(never_type))]
 #![warn(missing_docs)]
 
 //! Hydroflow is a low-level dataflow-based runtime system for the [Hydro Project](https://hydro.run/).
@@ -39,12 +38,9 @@ pub use hydroflow_macro::{
     hydroflow_test as test, monotonic_fn, morphism, DemuxEnum,
 };
 
+// TODO(mingwei): Use the [nightly "never" type `!`](https://doc.rust-lang.org/std/primitive.never.html)
 /// Stand-in for the [nightly "never" type `!`](https://doc.rust-lang.org/std/primitive.never.html)
-#[cfg(not(feature = "nightly"))]
 pub type Never = std::convert::Infallible;
-/// The [nightly "never" type `!`](https://doc.rust-lang.org/std/primitive.never.html)
-#[cfg(feature = "nightly")]
-pub type Never = !;
 
 #[cfg(doctest)]
 mod booktest {

--- a/hydroflow_datalog/Cargo.toml
+++ b/hydroflow_datalog/Cargo.toml
@@ -14,9 +14,6 @@ workspace = true
 proc-macro = true
 path = "src/lib.rs"
 
-[features]
-diagnostics = [ "hydroflow_datalog_core/diagnostics" ]
-
 [dependencies]
 quote = "1.0.35"
 syn = { version = "2.0.46", features = [ "parsing", "extra-traits" ] }

--- a/hydroflow_datalog/src/lib.rs
+++ b/hydroflow_datalog/src/lib.rs
@@ -1,3 +1,4 @@
+use hydroflow_datalog_core::diagnostic::Diagnostic;
 use hydroflow_datalog_core::{gen_hydroflow_graph, hydroflow_graph_to_program};
 use proc_macro2::Span;
 use quote::{quote, ToTokens};
@@ -31,10 +32,15 @@ pub fn datalog(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
             program.to_token_stream().into()
         }
         Err(diagnostics) => {
-            for diagnostic in diagnostics {
-                diagnostic.emit();
-            }
-            proc_macro::TokenStream::from(quote!(hydroflow::scheduled::graph::Hydroflow::new()))
+            let diagnostic_tokens = Diagnostic::try_emit_all(diagnostics.iter())
+                .err()
+                .unwrap_or_default();
+            proc_macro::TokenStream::from(quote! {
+                {
+                    #diagnostic_tokens
+                    hydroflow::scheduled::graph::Hydroflow::new()
+                }
+            })
         }
     }
 }

--- a/hydroflow_datalog_core/Cargo.toml
+++ b/hydroflow_datalog_core/Cargo.toml
@@ -13,10 +13,6 @@ workspace = true
 [lib]
 path = "src/lib.rs"
 
-[features]
-default = []
-diagnostics = [ "hydroflow_lang/diagnostics" ]
-
 [dependencies]
 quote = "1.0.35"
 slotmap = "1.0.0"

--- a/hydroflow_datalog_core/src/lib.rs
+++ b/hydroflow_datalog_core/src/lib.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 
+pub use hydroflow_lang::diagnostic;
 use hydroflow_lang::diagnostic::{Diagnostic, Level};
 use hydroflow_lang::graph::{
     eliminate_extra_unions_tees, partition_graph, FlatGraphBuilder, HydroflowGraph,

--- a/hydroflow_lang/Cargo.toml
+++ b/hydroflow_lang/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 
 [features]
 default = []
-diagnostics = []
 debugging = [ "dep:data-encoding", "dep:webbrowser", "clap-derive" ]
 clap-derive = [ "dep:clap" ]
 
@@ -34,3 +33,4 @@ webbrowser = { version = "1.0.0", optional = true }
 
 [build-dependencies]
 syn = { version = "2.0.46", features = [ "extra-traits", "full", "parsing" ] }
+rustc_version = "0.4.0"

--- a/hydroflow_lang/build.rs
+++ b/hydroflow_lang/build.rs
@@ -4,6 +4,7 @@ use std::fs::File;
 use std::io::{BufWriter, Error, ErrorKind, Result, Write};
 use std::path::PathBuf;
 
+use rustc_version::{version_meta, Channel};
 use syn::{
     parse_quote, AttrStyle, Expr, ExprLit, Ident, Item, Lit, Member, Meta, MetaNameValue, Path,
 };
@@ -12,6 +13,15 @@ const OPS_PATH: &str = "src/graph/ops";
 
 fn main() {
     println!("cargo::rerun-if-changed={}", OPS_PATH);
+
+    println!("cargo::rustc-check-cfg=cfg(nightly)");
+    if matches!(
+        version_meta().map(|meta| meta.channel),
+        Ok(Channel::Nightly)
+    ) {
+        println!("cargo:rustc-cfg=nightly");
+    }
+
     if Err(VarError::NotPresent) != var("CARGO_CFG_HYDROFLOW_GENERATE_DOCS") {
         if let Err(err) = generate_op_docs() {
             eprintln!("hydroflow_lang/build.rs error: {:?}", err);

--- a/hydroflow_lang/src/diagnostic.rs
+++ b/hydroflow_lang/src/diagnostic.rs
@@ -194,19 +194,15 @@ pub struct SerdeSpan {
 impl From<Span> for SerdeSpan {
     fn from(span: Span) -> Self {
         #[cfg(nightly)]
-        let path = span
-            .unwrap()
-            .source_file()
-            .path()
-            .display()
-            .to_string()
-            .into();
+        let path = std::panic::catch_unwind(|| span.unwrap())
+            .map(|span| span.source_file().path().display().to_string())
+            .ok();
 
         #[cfg(not(nightly))]
-        let path = "unknown".into();
+        let path = None::<String>;
 
         Self {
-            path,
+            path: path.map_or(Cow::Borrowed("unknown"), Cow::Owned),
             line: span.start().line,
             column: span.start().column,
         }

--- a/hydroflow_lang/src/graph/hydroflow_graph.rs
+++ b/hydroflow_lang/src/graph/hydroflow_graph.rs
@@ -1006,10 +1006,10 @@ impl HydroflowGraph {
                             subgraph_op_iter_code.push(write_iterator);
 
                             if include_type_guards {
-                                #[cfg(not(feature = "diagnostics"))]
+                                #[cfg(not(nightly))]
                                 let source_info = Option::<String>::None;
 
-                                #[cfg(feature = "diagnostics")]
+                                #[cfg(nightly)]
                                 let source_info = std::panic::catch_unwind(|| op_span.unwrap())
                                     .map(|op_span| {
                                         format!(
@@ -1029,7 +1029,7 @@ impl HydroflowGraph {
                                     .ok();
 
                                 #[cfg_attr(
-                                    not(feature = "diagnostics"),
+                                    not(nightly),
                                     expect(
                                         clippy::unnecessary_literal_unwrap,
                                         reason = "conditional compilation"

--- a/hydroflow_lang/src/graph/hydroflow_graph.rs
+++ b/hydroflow_lang/src/graph/hydroflow_graph.rs
@@ -1,5 +1,7 @@
 #![warn(missing_docs)]
 
+extern crate proc_macro;
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
 use std::iter::FusedIterator;
@@ -1007,10 +1009,9 @@ impl HydroflowGraph {
 
                             if include_type_guards {
                                 let source_info = 'a: {
-                                    #[cfg(all(nightly, panic = "unwind"))]
-                                    if let Ok(op_span) =
-                                        std::panic::catch_unwind(|| op_span.unwrap())
-                                    {
+                                    #[cfg(nightly)]
+                                    if proc_macro::is_available() {
+                                        let op_span = op_span.unwrap();
                                         break 'a format!(
                                             "loc_{}_{}_{}_{}_{}",
                                             op_span

--- a/hydroflow_lang/src/lib.rs
+++ b/hydroflow_lang/src/lib.rs
@@ -1,10 +1,7 @@
 //! Hydroflow surface syntax
 
 #![warn(missing_docs)]
-#![cfg_attr(
-    feature = "diagnostics",
-    feature(proc_macro_diagnostic, proc_macro_span)
-)]
+#![cfg_attr(nightly, feature(proc_macro_diagnostic, proc_macro_span))]
 pub mod diagnostic;
 pub mod graph;
 pub mod parse;

--- a/hydroflow_lang/src/pretty_span.rs
+++ b/hydroflow_lang/src/pretty_span.rs
@@ -5,7 +5,7 @@
 pub struct PrettySpan(pub proc_macro2::Span);
 impl std::fmt::Display for PrettySpan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        #[cfg(feature = "diagnostics")]
+        #[cfg(nightly)]
         {
             if let Ok(span) = std::panic::catch_unwind(|| self.0.unwrap()) {
                 write!(
@@ -21,7 +21,7 @@ impl std::fmt::Display for PrettySpan {
 
         write!(
             f,
-            "nopath:{}:{}",
+            "unknown:{}:{}",
             self.0.start().line,
             self.0.start().column
         )

--- a/hydroflow_lang/src/pretty_span.rs
+++ b/hydroflow_lang/src/pretty_span.rs
@@ -7,7 +7,7 @@ extern crate proc_macro;
 pub struct PrettySpan(pub proc_macro2::Span);
 impl std::fmt::Display for PrettySpan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        #[cfg(all(nightly, panic = "unwind"))]
+        #[cfg(nightly)]
         if proc_macro::is_available() {
             let span = self.0.unwrap();
             write!(

--- a/hydroflow_lang/src/pretty_span.rs
+++ b/hydroflow_lang/src/pretty_span.rs
@@ -1,22 +1,23 @@
 //! Pretty, human-readable printing of [`proc_macro2::Span`]s.
 
+extern crate proc_macro;
+
 /// Helper struct which displays the span as `path:row:col` for human reading/IDE linking.
 /// Example: `hydroflow\tests\surface_syntax.rs:42:18`.
 pub struct PrettySpan(pub proc_macro2::Span);
 impl std::fmt::Display for PrettySpan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[cfg(all(nightly, panic = "unwind"))]
-        {
-            if let Ok(span) = std::panic::catch_unwind(|| self.0.unwrap()) {
-                write!(
-                    f,
-                    "{}:{}:{}",
-                    span.source_file().path().display(),
-                    span.start().line(),
-                    span.start().column(),
-                )?;
-                return Ok(());
-            }
+        if proc_macro::is_available() {
+            let span = self.0.unwrap();
+            write!(
+                f,
+                "{}:{}:{}",
+                span.source_file().path().display(),
+                span.start().line(),
+                span.start().column(),
+            )?;
+            return Ok(());
         }
 
         write!(

--- a/hydroflow_lang/src/pretty_span.rs
+++ b/hydroflow_lang/src/pretty_span.rs
@@ -5,7 +5,7 @@
 pub struct PrettySpan(pub proc_macro2::Span);
 impl std::fmt::Display for PrettySpan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        #[cfg(nightly)]
+        #[cfg(all(nightly, panic = "unwind"))]
         {
             if let Ok(span) = std::panic::catch_unwind(|| self.0.unwrap()) {
                 write!(

--- a/hydroflow_macro/Cargo.toml
+++ b/hydroflow_macro/Cargo.toml
@@ -13,9 +13,6 @@ workspace = true
 [lib]
 proc-macro = true
 
-[features]
-diagnostics = [ "hydroflow_lang/diagnostics" ]
-
 [dependencies]
 # Note: If we ever compile this proc macro crate to WASM (e.g., if we are
 # building on a WASM host), we may need to turn diagnostics off for WASM if

--- a/hydroflow_macro/Cargo.toml
+++ b/hydroflow_macro/Cargo.toml
@@ -27,3 +27,4 @@ syn = { version = "2.0.46", features = [ "parsing", "extra-traits" ] }
 hydroflow_lang = { path = "../hydroflow_lang", version = "^0.10.0" }
 itertools = "0.10.0"
 quote = "1.0.35"
+rustc_version = "0.4.0"

--- a/hydroflow_macro/build.rs
+++ b/hydroflow_macro/build.rs
@@ -10,6 +10,7 @@ use hydroflow_lang::graph::ops::{PortListSpec, OPERATORS};
 use hydroflow_lang::graph::PortIndexValue;
 use itertools::Itertools;
 use quote::ToTokens;
+use rustc_version::{version_meta, Channel};
 
 const FILENAME: &str = "surface_ops_gen.md";
 
@@ -207,6 +208,14 @@ fn update_book() -> Result<()> {
 }
 
 fn main() {
+    println!("cargo::rustc-check-cfg=cfg(nightly)");
+    if matches!(
+        version_meta().map(|meta| meta.channel),
+        Ok(Channel::Nightly)
+    ) {
+        println!("cargo:rustc-cfg=nightly");
+    }
+
     if Err(VarError::NotPresent) != std::env::var("CARGO_CFG_HYDROFLOW_GENERATE_DOCS") {
         if let Err(err) = update_book() {
             eprintln!("hydroflow_macro/build.rs error: {:?}", err);

--- a/hydroflow_macro/src/lib.rs
+++ b/hydroflow_macro/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(
-    feature = "diagnostics",
+    nightly,
     feature(proc_macro_diagnostic, proc_macro_span, proc_macro_def_site)
 )]
 
@@ -72,25 +72,16 @@ fn hydroflow_syntax_internal(
         .iter()
         .filter(|diag: &&Diagnostic| Some(diag.level) <= min_diagnostic_level);
 
-    #[cfg(feature = "diagnostics")]
-    {
-        diagnostics.for_each(Diagnostic::emit);
-        tokens.into()
-    }
-
-    #[cfg(not(feature = "diagnostics"))]
-    {
-        let diagnostics = diagnostics.map(Diagnostic::to_tokens);
-        quote! {
-            {
-                #(
-                    #diagnostics
-                )*
-                #tokens
-            }
+    let diagnostic_tokens = Diagnostic::try_emit_all(diagnostics)
+        .err()
+        .unwrap_or_default();
+    quote! {
+        {
+            #diagnostic_tokens
+            #tokens
         }
-        .into()
     }
+    .into()
 }
 
 /// Parse Hydroflow "surface syntax" without emitting code.
@@ -123,8 +114,10 @@ pub fn hydroflow_parser(input: proc_macro::TokenStream) -> proc_macro::TokenStre
         }
     }
 
-    diagnostics.iter().for_each(Diagnostic::emit);
-    quote! {}.into()
+    Diagnostic::try_emit_all(diagnostics.iter())
+        .err()
+        .unwrap_or_default()
+        .into()
 }
 
 #[doc(hidden)]

--- a/hydroflow_plus/Cargo.toml
+++ b/hydroflow_plus/Cargo.toml
@@ -15,7 +15,6 @@ path = "src/lib.rs"
 
 [features]
 default = ["deploy_runtime"]
-diagnostics = [ "hydroflow_lang/diagnostics" ]
 stageleft_devel = []
 deploy_runtime = [ "hydroflow/deploy_integration" ]
 deploy = [ "deploy_runtime", "dep:hydro_deploy", "dep:trybuild-internals-api", "dep:toml", "dep:prettyplease" ]


### PR DESCRIPTION
Previous PR (#1587) website build did not work because `panic = "abort"` is set on wasm, leading to aborts for `proc_macro2::Span::unwrap()` calls.

All tests except trybuild seem to pass on stable, WIP #1587 next

BREAKING CHANGE: replaces `hydroflow_lang::diagnostic::Diagnostic::emit` with `try_emit`
BREAKING CHANGE: removes features: `hydroflow/nightly`, `hydroflow_datalog/diagnostics`, `hydroflow_datalog_core/diagnostics`, `hydroflow_lang/diagnostics`, `hydroflow_macro/diagnostics`, `hydroflow_plus/diagnostics`.