### PR TITLE
ci: fix stable tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,8 @@ jobs:
       - name: Run cargo nextest on all targets
         run: cargo nextest run --no-fail-fast --features python --features deploy --all-targets
         env:
-          TRYBUILD: ${{ matrix.rust_release != 'pinned-nightly' && 'overwrite' || '' }}
+          # On stable the output messages will often not match pinned-nightly, so we set to 'overwrite'.
+          TRYBUILD: ${{ matrix.rust_release == 'pinned-nightly' && 'wip' || 'overwrite' }}
 
       - name: Run doctests
         run: cargo test --no-fail-fast --features python --features deploy --doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,8 @@ jobs:
 
       - name: Run cargo nextest on all targets
         run: cargo nextest run --no-fail-fast --features python --features deploy --all-targets
+        env:
+          TRYBUILD: ${{ matrix.rust_release != 'pinned-nightly' && 'overwrite' || '' }}
 
       - name: Run doctests
         run: cargo test --no-fail-fast --features python --features deploy --doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,7 @@ jobs:
         env:
           # On stable the output messages will often not match pinned-nightly, so we set to 'overwrite'.
           TRYBUILD: ${{ matrix.rust_release == 'pinned-nightly' && 'wip' || 'overwrite' }}
+          HYDROFLOW_EXPECT_WARNINGS: ${{ matrix.rust_release == 'pinned-nightly' && 'noop' || 'ignore' }}
 
       - name: Run doctests
         run: cargo test --no-fail-fast --features python --features deploy --doc

--- a/hydroflow/tests/surface_warnings.rs
+++ b/hydroflow/tests/surface_warnings.rs
@@ -1,7 +1,3 @@
-// TODO(mingwei): fix line numbers in tests
-// https://github.com/hydro-project/hydroflow/issues/729
-// https://github.com/rust-lang/rust/pull/111571
-
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/hydroflow_lang/src/diagnostic.rs
+++ b/hydroflow_lang/src/diagnostic.rs
@@ -204,6 +204,10 @@ impl From<Span> for SerdeSpan {
                     .into();
             }
 
+            #[cfg_attr(
+                not(nightly),
+                expect(clippy::diverging_sub_expression, reason = "conditional compilation")
+            )]
             break 'a "unknown".into();
         };
 

--- a/hydroflow_lang/src/diagnostic.rs
+++ b/hydroflow_lang/src/diagnostic.rs
@@ -192,6 +192,10 @@ pub struct SerdeSpan {
 }
 impl From<Span> for SerdeSpan {
     fn from(span: Span) -> Self {
+        #[cfg_attr(
+            not(nightly),
+            expect(unused_labels, reason = "conditional compilation")
+        )]
         let path = 'a: {
             #[cfg(nightly)]
             if proc_macro::is_available() {
@@ -204,11 +208,7 @@ impl From<Span> for SerdeSpan {
                     .into();
             }
 
-            #[cfg_attr(
-                not(nightly),
-                expect(clippy::diverging_sub_expression, reason = "conditional compilation")
-            )]
-            break 'a "unknown".into();
+            "unknown".into()
         };
 
         Self {

--- a/hydroflow_lang/src/graph/hydroflow_graph.rs
+++ b/hydroflow_lang/src/graph/hydroflow_graph.rs
@@ -1027,6 +1027,13 @@ impl HydroflowGraph {
                                         );
                                     }
 
+                                    #[cfg_attr(
+                                        not(nightly),
+                                        expect(
+                                            clippy::diverging_sub_expression,
+                                            reason = "conditional compilation"
+                                        )
+                                    )]
                                     break 'a format!(
                                         "loc_nopath_{}_{}_{}_{}",
                                         op_span.start().line,

--- a/hydroflow_lang/src/graph/hydroflow_graph.rs
+++ b/hydroflow_lang/src/graph/hydroflow_graph.rs
@@ -1008,6 +1008,10 @@ impl HydroflowGraph {
                             subgraph_op_iter_code.push(write_iterator);
 
                             if include_type_guards {
+                                #[cfg_attr(
+                                    not(nightly),
+                                    expect(unused_labels, reason = "conditional compilation")
+                                )]
                                 let source_info = 'a: {
                                     #[cfg(nightly)]
                                     if proc_macro::is_available() {
@@ -1027,20 +1031,13 @@ impl HydroflowGraph {
                                         );
                                     }
 
-                                    #[cfg_attr(
-                                        not(nightly),
-                                        expect(
-                                            clippy::diverging_sub_expression,
-                                            reason = "conditional compilation"
-                                        )
-                                    )]
-                                    break 'a format!(
+                                    format!(
                                         "loc_nopath_{}_{}_{}_{}",
                                         op_span.start().line,
                                         op_span.start().column,
                                         op_span.end().line,
                                         op_span.end().column
-                                    );
+                                    )
                                 };
 
                                 let fn_ident = format_ident!(


### PR DESCRIPTION
Sets `TRYBUILD=overwrite` on stable, as the output messages will often not match `pinned-nightly`

Adds env `HYDROFLOW_EXPECT_WARNINGS=ignore` to allow warning tests to pass