### PR TITLE
ci: push templates to auxilary repos

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -154,13 +154,13 @@ jobs:
           args: --manifest-path "${{ runner.temp }}/generated/Cargo.toml"  --all-targets
 
   push_dfir:
-    name: Push dfir repo
+    name: Push to dfir template repo
     needs: test_dfir
     if: ${{ needs.test_dfir.result == 'success' && github.event_name != 'pull_request' }}
-    runs-on: ubuntu-latest
     env:
       DIR: template/dfir
       REPO: dfir-template
+    runs-on: ubuntu-latest
 
     steps:
       - name: Generate token
@@ -179,7 +179,50 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Push to dfir repo
+      - name: Push to template repo
+        shell: bash
+        run: |
+          git -C "$DIR" init -q
+          git -C "$DIR" remote add origin "https://github.com/${{ github.repository_owner }}/${{ env.REPO }}.git"
+          git -C "$DIR" config credential.helper "$(git config credential.helper)"
+          git -C "$DIR" config 'http.https://github.com/.extraheader' "$(git config 'http.https://github.com/.extraheader')"
+          git -C "$DIR" config core.autocrlf input
+          git -C "$DIR" config core.safecrlf false
+          git -C "$DIR" config user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git -C "$DIR" config user.email "$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)[bot]@users.noreply.github.com"
+          git -C "$DIR" add -A
+          git -C "$DIR" commit -m "Update template $(date -I) $(git rev-parse HEAD)"
+          git -C "$DIR" push -f -u origin HEAD:main --quiet
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+  push_hydro_lang:
+    name: Push to hydro template repo
+    needs: test_hydro_lang
+    if: ${{ needs.test_hydro_lang.result == 'success' && github.event_name != 'pull_request' }}
+    env:
+      DIR: template/hydro
+      REPO: hydro-template
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+            ${{ env.REPO }}
+
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Push to template repo
         shell: bash
         run: |
           git -C "$DIR" init -q

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -18,11 +18,11 @@ jobs:
         with:
           cancel_others: "true"
 
-  test_hydroflow:
-    name: Test hydroflow
+  test_dfir:
+    name: Test dfir
+    needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.event_name != 'pull_request' }}
     timeout-minutes: 10
-    needs: pre_job
     runs-on: ubuntu-latest
 
     steps:
@@ -41,7 +41,7 @@ jobs:
         with:
           name: generated
           template: template/dfir
-          arguments: "-d hydroflow_git=${{ github.event.pull_request.head.repo.clone_url }} -d hydroflow_branch=${{ github.event.pull_request.head.ref }}"
+          arguments: "-d hydro_git=${{ github.event.pull_request.head.repo.clone_url }} -d hydro_branch=${{ github.event.pull_request.head.ref }}"
       - name: Move generated project
         run: |
           mv generated ${{ runner.temp }}/
@@ -95,11 +95,11 @@ jobs:
               exit -1
           fi
 
-  test_hydroflow_plus:
+  test_hydro_lang:
     name: Test hydro_lang
+    needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.event_name != 'pull_request' }}
     timeout-minutes: 10
-    needs: pre_job
     runs-on: ubuntu-latest
 
     steps:
@@ -118,7 +118,7 @@ jobs:
         with:
           name: generated
           template: template/hydro
-          arguments: "-d hydroflow_git=${{ github.event.pull_request.head.repo.clone_url }} -d hydroflow_branch=${{ github.event.pull_request.head.ref }}"
+          arguments: "-d hydro_git=${{ github.event.pull_request.head.repo.clone_url }} -d hydro_branch=${{ github.event.pull_request.head.ref }}"
       - name: Move generated project
         run: |
           mv generated ${{ runner.temp }}/
@@ -152,3 +152,46 @@ jobs:
         with:
           command: build
           args: --manifest-path "${{ runner.temp }}/generated/Cargo.toml"  --all-targets
+
+  push_dfir:
+    name: Push dfir repo
+    needs: test_dfir
+    if: ${{ needs.test_dfir.result == 'success' && github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    env:
+      DIR: template/dfir
+      REPO: dfir-template
+
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+            ${{ env.REPO }}
+
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Push to dfir repo
+        shell: bash
+        run: |
+          git -C "$DIR" init -q
+          git -C "$DIR" remote add origin "https://github.com/${{ github.repository_owner }}/${{ env.REPO }}.git"
+          git -C "$DIR" config credential.helper "$(git config credential.helper)"
+          git -C "$DIR" config 'http.https://github.com/.extraheader' "$(git config 'http.https://github.com/.extraheader')"
+          git -C "$DIR" config core.autocrlf input
+          git -C "$DIR" config core.safecrlf false
+          git -C "$DIR" config user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git -C "$DIR" config user.email "$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)[bot]@users.noreply.github.com"
+          git -C "$DIR" add -A
+          git -C "$DIR" commit -m "Update template $(date -I) $(git rev-parse HEAD)"
+          git -C "$DIR" push -f -u origin HEAD:main --quiet
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/template/dfir/Cargo.toml
+++ b/template/dfir/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 [dependencies]
 chrono = { version = "0.4.20", features = [ "serde" ], default-features = true }
 clap = { version = "4.5.4", features = [ "derive" ] }
-dfir_rs = { git = "{{ hydroflow_git | default: 'https://github.com/hydro-project/hydroflow.git' }}", branch = "{{ hydroflow_branch | default: 'main' }}" }
+dfir_rs = { git = "{{ hydro_git | default: 'https://github.com/hydro-project/hydroflow.git' }}", branch = "{{ hydro_branch | default: 'main' }}" }
 serde = { version = "1.0.197", features = [ "derive" ] }

--- a/template/hydro/Cargo.toml
+++ b/template/hydro/Cargo.toml
@@ -9,18 +9,18 @@ default = ["stageleft_devel"]
 stageleft_devel = []
 
 [dependencies]
-hydro_lang = { git = "{{ hydroflow_git | default: 'https://github.com/hydro-project/hydroflow.git' }}", branch = "{{ hydroflow_branch | default: 'main' }}" }
-hydro_std = { git = "{{ hydroflow_git | default: 'https://github.com/hydro-project/hydroflow.git' }}", branch = "{{ hydroflow_branch | default: 'main' }}" }
-stageleft = { git = "{{ hydroflow_git | default: 'https://github.com/hydro-project/hydroflow.git' }}", branch = "{{ hydroflow_branch | default: 'main' }}" }
+hydro_lang = { git = "{{ hydro_git | default: 'https://github.com/hydro-project/hydroflow.git' }}", branch = "{{ hydro_branch | default: 'main' }}" }
+hydro_std = { git = "{{ hydro_git | default: 'https://github.com/hydro-project/hydroflow.git' }}", branch = "{{ hydro_branch | default: 'main' }}" }
+stageleft = { git = "{{ hydro_git | default: 'https://github.com/hydro-project/hydroflow.git' }}", branch = "{{ hydro_branch | default: 'main' }}" }
 tokio = { version = "1.29.0", features = [ "full" ] }
 
 [build-dependencies]
-stageleft_tool = { git = "{{ hydroflow_git | default: 'https://github.com/hydro-project/hydroflow.git' }}", branch = "{{ hydroflow_branch | default: 'main' }}" }
+stageleft_tool = { git = "{{ hydro_git | default: 'https://github.com/hydro-project/hydroflow.git' }}", branch = "{{ hydro_branch | default: 'main' }}" }
 
 [dev-dependencies]
 async-ssh2-lite = { version = "0.5.0", features = ["vendored-openssl"] }
-hydro_deploy = { git = "{{ hydroflow_git | default: 'https://github.com/hydro-project/hydroflow.git' }}", branch = "{{ hydroflow_branch | default: 'main' }}" }
-hydro_lang = { git = "{{ hydroflow_git | default: 'https://github.com/hydro-project/hydroflow.git' }}", branch = "{{ hydroflow_branch | default: 'main' }}", features = [
+hydro_deploy = { git = "{{ hydro_git | default: 'https://github.com/hydro-project/hydroflow.git' }}", branch = "{{ hydro_branch | default: 'main' }}" }
+hydro_lang = { git = "{{ hydro_git | default: 'https://github.com/hydro-project/hydroflow.git' }}", branch = "{{ hydro_branch | default: 'main' }}", features = [
     "deploy",
 ] }
 tokio-stream = { version = "0.1.3", default-features = false }


### PR DESCRIPTION
Sorta undoes #1314, except the different now is the template repos have no active code in them, they're entirely tied to the `template/*` folder in this repo by this CI job. Testing is still done in this repo.

Actually updating the docs to the new repo URLs is still TODO